### PR TITLE
feat: add hierarchy tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-docgen-typescript": "^2.2.2",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-window": "^1.8.9"
       },
       "devDependencies": {
         "@types/react": "^18.2.47",
@@ -374,6 +375,23 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redux": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "react-docgen-typescript": "^2.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-beautiful-dnd": "^13.1.1"
+    "react-beautiful-dnd": "^13.1.1",
+    "react-window": "^1.8.9"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/src/HierarchyTree.tsx
+++ b/src/HierarchyTree.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo, useState, useRef, useEffect } from 'react';
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import { useEditorState, useEditorActions, ComponentNode } from './store';
+
+interface FlatNode {
+  node: ComponentNode;
+  depth: number;
+  parentId: string | null;
+  index: number;
+}
+
+const ITEM_HEIGHT = 24;
+
+const HierarchyTree: React.FC = () => {
+  const { tree, selectedComponentId } = useEditorState();
+  const actions = useEditorActions();
+
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const [contextMenu, setContextMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const dragId = useRef<string | null>(null);
+
+  const flat = useMemo(() => {
+    const list: FlatNode[] = [];
+    const walk = (nodes: ComponentNode[], depth: number, parentId: string | null) => {
+      nodes.forEach((n, idx) => {
+        list.push({ node: n, depth, parentId, index: idx });
+        if (!collapsed[n.id] && n.children) {
+          walk(n.children, depth + 1, n.id);
+        }
+      });
+    };
+    walk(tree, 0, null);
+    return list;
+  }, [tree, collapsed]);
+
+  const useVirtual = flat.length > 200;
+
+  useEffect(() => {
+    const close = () => setContextMenu(null);
+    window.addEventListener('click', close);
+    return () => window.removeEventListener('click', close);
+  }, []);
+
+  const toggleCollapse = (id: string) => {
+    setCollapsed((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleContextMenu = (e: React.MouseEvent, id: string) => {
+    e.preventDefault();
+    setContextMenu({ id, x: e.clientX, y: e.clientY });
+  };
+
+  const handleDuplicate = () => {
+    if (contextMenu) {
+      actions.duplicateComponent(contextMenu.id);
+      setContextMenu(null);
+    }
+  };
+
+  const handleDelete = () => {
+    if (contextMenu) {
+      actions.deleteComponent(contextMenu.id);
+      setContextMenu(null);
+    }
+  };
+
+  const handleDragStart = (id: string) => (e: React.DragEvent) => {
+    dragId.current = id;
+    e.dataTransfer.setData('text/plain', id);
+  };
+
+  const handleDrop = (target: FlatNode) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const id = dragId.current;
+    if (!id) return;
+    const reparent = e.altKey || e.metaKey || e.ctrlKey;
+    const parentId = reparent ? target.node.id : target.parentId;
+    const index = reparent ? 0 : target.index;
+    actions.moveComponent(id, parentId, index);
+    dragId.current = null;
+  };
+
+  const renderNode = (item: FlatNode) => {
+    const { node, depth } = item;
+    const isSelected = selectedComponentId === node.id;
+    return (
+      <div
+        key={node.id}
+        className={`flex items-center h-6 select-none cursor-pointer ${isSelected ? 'bg-blue-100' : ''}`}
+        style={{ paddingLeft: depth * 16 }}
+        draggable
+        onDragStart={handleDragStart(node.id)}
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop(item)}
+        onClick={() => actions.selectComponent(node.id)}
+        onContextMenu={(e) => handleContextMenu(e, node.id)}
+      >
+        {node.children && node.children.length > 0 ? (
+          <button
+            className="mr-1 text-xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleCollapse(node.id);
+            }}
+          >
+            {collapsed[node.id] ? '▸' : '▾'}
+          </button>
+        ) : (
+          <span className="mr-3" />
+        )}
+        {node.isContainer && <span className="mr-1">📁</span>}
+        <span className="text-sm">{node.type}</span>
+      </div>
+    );
+  };
+
+  const Row: React.FC<ListChildComponentProps> = ({ index, style }) => (
+    <div style={style}>{renderNode(flat[index])}</div>
+  );
+
+  return (
+    <div className="relative h-full overflow-auto" onDragOver={(e) => e.preventDefault()}>
+      {useVirtual ? (
+        <List
+          height={Math.min(400, flat.length * ITEM_HEIGHT)}
+          itemCount={flat.length}
+          itemSize={ITEM_HEIGHT}
+          width={'100%'}
+        >
+          {Row}
+        </List>
+      ) : (
+        flat.map((item) => renderNode(item))
+      )}
+      {contextMenu && (
+        <div
+          className="absolute bg-white border shadow text-sm"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          <div className="px-2 py-1 hover:bg-gray-100 cursor-pointer" onClick={handleDuplicate}>
+            Duplicate
+          </div>
+          <div className="px-2 py-1 hover:bg-gray-100 cursor-pointer" onClick={handleDelete}>
+            Delete
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HierarchyTree;

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,0 +1,152 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface ComponentNode {
+  id: string;
+  type: string;
+  children?: ComponentNode[];
+  isContainer?: boolean;
+}
+
+interface EditorState {
+  tree: ComponentNode[];
+  selectedComponentId: string | null;
+}
+
+interface EditorActions {
+  selectComponent: (id: string | null) => void;
+  moveComponent: (dragId: string, parentId: string | null, index: number) => void;
+  duplicateComponent: (id: string) => void;
+  deleteComponent: (id: string) => void;
+}
+
+interface EditorContextValue {
+  state: EditorState;
+  actions: EditorActions;
+}
+
+const EditorContext = createContext<EditorContextValue | undefined>(undefined);
+
+export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children: ReactNode }>=({
+  initialTree = [],
+  children,
+}) => {
+  const [tree, setTree] = useState<ComponentNode[]>(initialTree);
+  const [selectedComponentId, setSelectedComponentId] = useState<string | null>(null);
+
+  const selectComponent = (id: string | null) => setSelectedComponentId(id);
+
+  const moveComponent = (dragId: string, parentId: string | null, index: number) => {
+    setTree((prev) => moveNode(prev, dragId, parentId, index));
+  };
+
+  const duplicateComponent = (id: string) => {
+    setTree((prev) => duplicateNode(prev, id));
+  };
+
+  const deleteComponent = (id: string) => {
+    setTree((prev) => deleteNode(prev, id));
+    setSelectedComponentId((prev) => (prev === id ? null : prev));
+  };
+
+  const value: EditorContextValue = {
+    state: { tree, selectedComponentId },
+    actions: { selectComponent, moveComponent, duplicateComponent, deleteComponent },
+  };
+
+  return <EditorContext.Provider value={value}>{children}</EditorContext.Provider>;
+};
+
+export const useEditorState = () => {
+  const ctx = useContext(EditorContext);
+  if (!ctx) throw new Error('useEditorState must be used within EditorProvider');
+  return ctx.state;
+};
+
+export const useEditorActions = () => {
+  const ctx = useContext(EditorContext);
+  if (!ctx) throw new Error('useEditorActions must be used within EditorProvider');
+  return ctx.actions;
+};
+
+// Helper functions for tree manipulation
+function cloneNode(node: ComponentNode): ComponentNode {
+  return {
+    ...node,
+    children: node.children ? node.children.map(cloneNode) : undefined,
+  };
+}
+
+function deleteNode(nodes: ComponentNode[], id: string): ComponentNode[] {
+  return nodes
+    .filter((n) => n.id !== id)
+    .map((n) =>
+      n.children
+        ? { ...n, children: deleteNode(n.children, id) }
+        : n
+    );
+}
+
+function duplicateNode(nodes: ComponentNode[], id: string): ComponentNode[] {
+  const result: ComponentNode[] = [];
+  for (const n of nodes) {
+    if (n.id === id) {
+      result.push(n);
+      const copy = cloneNode(n);
+      copy.id = `${n.id}_copy_${Math.random().toString(36).slice(2, 8)}`;
+      result.push(copy);
+    } else if (n.children) {
+      result.push({ ...n, children: duplicateNode(n.children, id) });
+    } else {
+      result.push(n);
+    }
+  }
+  return result;
+}
+
+function removeNode(nodes: ComponentNode[], id: string): { nodes: ComponentNode[]; removed?: ComponentNode } {
+  const result: ComponentNode[] = [];
+  let removed: ComponentNode | undefined;
+  for (const n of nodes) {
+    if (n.id === id) {
+      removed = n;
+      continue;
+    }
+    if (n.children) {
+      const res = removeNode(n.children, id);
+      if (res.removed) {
+        removed = res.removed;
+        result.push({ ...n, children: res.nodes });
+      } else {
+        result.push(n);
+      }
+    } else {
+      result.push(n);
+    }
+  }
+  return { nodes: result, removed };
+}
+
+function insertNode(nodes: ComponentNode[], parentId: string | null, index: number, node: ComponentNode): ComponentNode[] {
+  if (parentId === null) {
+    const arr = [...nodes];
+    arr.splice(index, 0, node);
+    return arr;
+  }
+  return nodes.map((n) => {
+    if (n.id === parentId) {
+      const children = n.children ? [...n.children] : [];
+      children.splice(index, 0, node);
+      return { ...n, children };
+    }
+    if (n.children) {
+      return { ...n, children: insertNode(n.children, parentId, index, node) };
+    }
+    return n;
+  });
+}
+
+function moveNode(nodes: ComponentNode[], dragId: string, parentId: string | null, index: number): ComponentNode[] {
+  const { nodes: without, removed } = removeNode(nodes, dragId);
+  if (!removed) return nodes;
+  return insertNode(without, parentId, index, removed);
+}


### PR DESCRIPTION
## Summary
- add global editor store to manage component tree and selection
- implement HierarchyTree with drag & drop, context actions, and virtualization for large trees
- add react-window dependency

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2e716d0c8832cb47461e360091830