### PR TITLE
feat: add EditorBridge utility and demo

### DIFF
--- a/src/EditorBridge.ts
+++ b/src/EditorBridge.ts
@@ -1,0 +1,118 @@
+export type Handler<T = any> = (payload: T) => void;
+
+interface Message<T = any> {
+  type: string;
+  payload?: T;
+}
+
+/**
+ * Bridge for communicating with a parent window. Supports both postMessage
+ * and MessageChannel for high frequency updates.
+ */
+export default class EditorBridge {
+  private handlers = new Map<string, Set<Handler>>();
+  private allowedOrigins: string[];
+  private port: MessagePort | null = null;
+  private heartbeatInterval: number;
+  private lastPong = Date.now();
+  private heartbeatTimer: number | undefined;
+
+  constructor(allowedOrigins: string[], heartbeatInterval = 5000) {
+    this.allowedOrigins = allowedOrigins;
+    this.heartbeatInterval = heartbeatInterval;
+    window.addEventListener('message', this.handleWindowMessage);
+    this.startHeartbeat();
+  }
+
+  private handleWindowMessage = (event: MessageEvent) => {
+    if (!this.allowedOrigins.includes(event.origin)) return;
+    const { data } = event;
+    if (!data || typeof (data as any).type !== 'string') return;
+
+    if ((data as any).type === 'init-channel' && event.ports && event.ports[0]) {
+      this.setupPort(event.ports[0]);
+      return;
+    }
+
+    if ((data as any).type === 'pong') {
+      this.lastPong = Date.now();
+      return;
+    }
+
+    this.emitToHandlers((data as any).type, (data as any).payload);
+  };
+
+  private setupPort(port: MessagePort) {
+    if (this.port) {
+      this.port.onmessage = null;
+      this.port.close();
+    }
+    this.port = port;
+    this.port.onmessage = this.handlePortMessage;
+    // @ts-ignore start may not exist in some environments
+    this.port.start && this.port.start();
+  }
+
+  private handlePortMessage = (event: MessageEvent) => {
+    const { data } = event;
+    if (!data || typeof (data as any).type !== 'string') return;
+
+    if ((data as any).type === 'pong') {
+      this.lastPong = Date.now();
+      return;
+    }
+
+    this.emitToHandlers((data as any).type, (data as any).payload);
+  };
+
+  private emitToHandlers(type: string, payload: any) {
+    const set = this.handlers.get(type);
+    if (set) {
+      set.forEach((h) => {
+        try {
+          h(payload);
+        } catch (err) {
+          console.error(err);
+        }
+      });
+    }
+  }
+
+  on<T = any>(type: string, handler: Handler<T>) {
+    if (!this.handlers.has(type)) this.handlers.set(type, new Set());
+    this.handlers.get(type)!.add(handler as Handler);
+  }
+
+  off<T = any>(type: string, handler: Handler<T>) {
+    this.handlers.get(type)?.delete(handler as Handler);
+  }
+
+  emit(type: string, payload?: any) {
+    const message: Message = { type, payload };
+    if (this.port) {
+      try {
+        this.port.postMessage(message);
+        return;
+      } catch {
+        this.port = null; // fall back
+      }
+    }
+    window.parent.postMessage(message, '*');
+  }
+
+  private startHeartbeat() {
+    this.heartbeatTimer = window.setInterval(() => {
+      const now = Date.now();
+      if (now - this.lastPong > this.heartbeatInterval * 2) {
+        this.emitToHandlers('disconnect', undefined);
+      }
+      this.emit('ping', now);
+    }, this.heartbeatInterval);
+  }
+
+  destroy() {
+    window.removeEventListener('message', this.handleWindowMessage);
+    this.port?.close();
+    if (this.heartbeatTimer) window.clearInterval(this.heartbeatTimer);
+  }
+}

--- a/src/editorBridgeDemo.ts
+++ b/src/editorBridgeDemo.ts
@@ -1,0 +1,29 @@
+import EditorBridge from './EditorBridge';
+
+// Allowed origins the bridge will accept messages from
+const bridge = new EditorBridge(['https://parent.example']);
+
+bridge.on('style-update', (payload) => {
+  console.log('style-update received', payload);
+});
+
+// Send a message using simple postMessage mode
+bridge.emit('style-update', { color: 'red' });
+
+// Simulate the parent providing a MessageChannel
+const channel = new MessageChannel();
+window.dispatchEvent(
+  new MessageEvent('message', {
+    data: { type: 'init-channel' },
+    origin: 'https://parent.example',
+    ports: [channel.port1],
+  })
+);
+
+// Parent side (demo only)
+channel.port2.onmessage = (e) => {
+  console.log('parent received', e.data);
+};
+
+// Now emits go through the MessageChannel
+bridge.emit('style-update', { color: 'blue' });


### PR DESCRIPTION
## Summary
- add EditorBridge utility with postMessage and MessageChannel support
- provide heartbeat ping/pong and allowed origin filtering
- add demo showcasing switch to MessageChannel after `init-channel`

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a2e8805770832c9049e9e848024f1e