### PR TITLE
feat: add data source bindings

### DIFF
--- a/src/AutoPropsEditor.tsx
+++ b/src/AutoPropsEditor.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useDataSources } from './dataSources';
+import { PropBinding } from './store';
 
 interface PropMeta {
   name: string;
@@ -17,6 +19,8 @@ interface AutoPropsEditorProps {
   selectedComponentType: string;
   selectedProps: Record<string, any>;
   onChange: (nextProps: Record<string, any>) => void;
+  bindings?: Record<string, PropBinding>;
+  onBindingsChange?: (next: Record<string, PropBinding>) => void;
 }
 
 // Attempt to extract union/enum values from a type string like '"a" | "b"' or 'Enum.A | Enum.B'
@@ -47,9 +51,13 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
   selectedComponentType,
   selectedProps,
   onChange,
+  bindings = {},
+  onBindingsChange,
 }) => {
   const [componentMeta, setComponentMeta] = useState<ComponentMeta[]>([]);
   const [localProps, setLocalProps] = useState<Record<string, any>>({});
+  const [localBindings, setLocalBindings] = useState<Record<string, PropBinding>>({});
+  const { sources } = useDataSources();
 
   // load component meta
   useEffect(() => {
@@ -74,7 +82,8 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
   // keep local props in sync with selected props
   useEffect(() => {
     setLocalProps(selectedProps || {});
-  }, [selectedComponentType, selectedProps]);
+    setLocalBindings(bindings || {});
+  }, [selectedComponentType, selectedProps, bindings]);
 
   // debounce onChange
   useEffect(() => {
@@ -83,6 +92,14 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
     }, 300);
     return () => clearTimeout(handle);
   }, [localProps, onChange]);
+
+  useEffect(() => {
+    if (!onBindingsChange) return;
+    const handle = setTimeout(() => {
+      onBindingsChange(localBindings);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [localBindings, onBindingsChange]);
 
   const meta = useMemo(
     () => componentMeta.find((m) => m.displayName === selectedComponentType),
@@ -93,9 +110,64 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
     setLocalProps((prev) => ({ ...prev, [name]: value }));
   };
 
+  const updateBinding = (name: string, value: PropBinding | undefined) => {
+    setLocalBindings((prev) => {
+      const next = { ...prev };
+      if (!value) delete next[name];
+      else next[name] = value;
+      return next;
+    });
+  };
+
   const renderControl = (prop: PropMeta, missing: boolean) => {
     const value = localProps[prop.name];
+    const binding = localBindings[prop.name];
     const common = `w-full border rounded px-2 py-1 ${missing ? 'border-red-500' : 'border-gray-300'}`;
+
+    if (binding) {
+      return (
+        <div className="space-y-1">
+          <div className="flex space-x-1">
+            <select
+              className="border rounded px-2 py-1 flex-1"
+              value={binding.source}
+              onChange={(e) => updateBinding(prop.name, { ...binding, source: e.target.value })}
+            >
+              <option value="">Select source</option>
+              {sources.map((s) => (
+                <option key={s.name} value={s.name}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+            <button
+              className="text-xs text-red-500"
+              onClick={() => updateBinding(prop.name, undefined)}
+            >
+              Unbind
+            </button>
+          </div>
+          <input
+            className="w-full border rounded px-2 py-1"
+            placeholder="Endpoint"
+            value={binding.endpoint}
+            onChange={(e) => updateBinding(prop.name, { ...binding, endpoint: e.target.value })}
+          />
+          <input
+            className="w-full border rounded px-2 py-1"
+            placeholder="JSONPath"
+            value={binding.path}
+            onChange={(e) => updateBinding(prop.name, { ...binding, path: e.target.value })}
+          />
+          <input
+            className="w-full border rounded px-2 py-1"
+            placeholder="Fallback"
+            value={binding.fallback ?? ''}
+            onChange={(e) => updateBinding(prop.name, { ...binding, fallback: e.target.value })}
+          />
+        </div>
+      );
+    }
 
     const unionValues = parseLiteralUnion(prop.type);
     if (unionValues) {
@@ -142,14 +214,22 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
       );
     }
 
-    // default to text input
+    // default to text input with bind option
     return (
-      <input
-        type="text"
-        className={common}
-        value={value ?? ''}
-        onChange={(e) => updateProp(prop.name, e.target.value)}
-      />
+      <div className="flex space-x-1">
+        <input
+          type="text"
+          className={common + ' flex-1'}
+          value={value ?? ''}
+          onChange={(e) => updateProp(prop.name, e.target.value)}
+        />
+        <button
+          className="text-xs text-blue-600"
+          onClick={() => updateBinding(prop.name, { source: '', endpoint: '', path: '' })}
+        >
+          Bind
+        </button>
+      </div>
     );
   };
 

--- a/src/DataSourcesPanel.tsx
+++ b/src/DataSourcesPanel.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { useDataSources, DataSource } from './dataSources';
+
+const emptySource: DataSource = { name: '', baseURL: '', headers: {}, token: '' };
+
+const DataSourcesPanel: React.FC = () => {
+  const { sources, setSources } = useDataSources();
+  const [tests, setTests] = useState<Record<number, string>>({});
+
+  const updateSource = (idx: number, field: keyof DataSource, value: any) => {
+    setSources((prev) =>
+      prev.map((s, i) => (i === idx ? { ...s, [field]: value } : s))
+    );
+  };
+
+  const removeSource = (idx: number) => {
+    setSources((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const addSource = () => setSources((prev) => [...prev, { ...emptySource }]);
+
+  const testSource = async (idx: number) => {
+    const src = sources[idx];
+    if (!src) return;
+    try {
+      const headers: Record<string, string> = { ...(src.headers || {}) };
+      if (src.token) headers['Authorization'] = `Bearer ${src.token}`;
+      const res = await fetch(src.baseURL, { headers });
+      setTests((t) => ({ ...t, [idx]: res.ok ? 'success' : `error ${res.status}` }));
+    } catch (err: any) {
+      setTests((t) => ({ ...t, [idx]: 'error' }));
+    }
+  };
+
+  return (
+    <div className="p-2 space-y-4">
+      {sources.map((src, idx) => (
+        <div key={idx} className="border rounded p-2 space-y-2">
+          <div className="flex space-x-2">
+            <input
+              className="flex-1 border rounded px-2 py-1"
+              placeholder="Name"
+              value={src.name}
+              onChange={(e) => updateSource(idx, 'name', e.target.value)}
+            />
+            <button
+              className="text-red-500 text-sm"
+              onClick={() => removeSource(idx)}
+            >
+              Remove
+            </button>
+          </div>
+          <input
+            className="w-full border rounded px-2 py-1"
+            placeholder="Base URL"
+            value={src.baseURL}
+            onChange={(e) => updateSource(idx, 'baseURL', e.target.value)}
+          />
+          <textarea
+            className="w-full border rounded px-2 py-1 text-sm"
+            placeholder="Headers (JSON)"
+            value={JSON.stringify(src.headers || {})}
+            onChange={(e) => {
+              try {
+                const val = JSON.parse(e.target.value || '{}');
+                updateSource(idx, 'headers', val);
+              } catch {
+                // ignore parse errors
+              }
+            }}
+          />
+          <input
+            className="w-full border rounded px-2 py-1"
+            placeholder="Bearer Token"
+            value={src.token || ''}
+            onChange={(e) => updateSource(idx, 'token', e.target.value)}
+          />
+          <button
+            className="px-2 py-1 bg-blue-500 text-white rounded"
+            onClick={() => testSource(idx)}
+          >
+            Test connection
+          </button>
+          {tests[idx] && (
+            <div className="text-sm">
+              {tests[idx] === 'success' ? (
+                <span className="text-green-600">Connection OK</span>
+              ) : (
+                <span className="text-red-600">Connection failed</span>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+      <button
+        className="px-2 py-1 bg-green-500 text-white rounded"
+        onClick={addSource}
+      >
+        Add Source
+      </button>
+    </div>
+  );
+};
+
+export default DataSourcesPanel;
+

--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { ComponentNode, PropBinding } from './store';
+import { useDataSources, DataSource } from './dataSources';
+
+function getByPath(obj: any, path: string) {
+  if (!path || !path.startsWith('$.')) return undefined;
+  const parts = path.slice(2).split('.');
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+const fetchCache = new Map<string, any>();
+
+async function fetchBinding(binding: PropBinding, sources: DataSource[]) {
+  const src = sources.find((s) => s.name === binding.source);
+  if (!src) throw new Error('unknown source');
+  const key = `${binding.source}:${binding.endpoint}`;
+  if (fetchCache.has(key)) return fetchCache.get(key);
+  const headers: Record<string, string> = { ...(src.headers || {}) };
+  if (src.token) headers['Authorization'] = `Bearer ${src.token}`;
+  const res = await fetch(src.baseURL + binding.endpoint, { headers });
+  const data = await res.json();
+  fetchCache.set(key, data);
+  return data;
+}
+
+interface NodeRendererProps {
+  node: ComponentNode;
+}
+
+const NodeRenderer: React.FC<NodeRendererProps> = ({ node }) => {
+  const { sources } = useDataSources();
+  const [dataMap, setDataMap] = useState<Record<string, any>>({});
+  const [status, setStatus] = useState<Record<string, { loading: boolean; error: boolean }>>({});
+
+  useEffect(() => {
+    if (!node.bindings) return;
+    Object.entries(node.bindings).forEach(([prop, binding]) => {
+      setStatus((s) => ({ ...s, [prop]: { loading: true, error: false } }));
+      fetchBinding(binding, sources)
+        .then((data) => {
+          const val = getByPath(data, binding.path);
+          setDataMap((m) => ({ ...m, [prop]: val }));
+          setStatus((s) => ({ ...s, [prop]: { loading: false, error: false } }));
+        })
+        .catch(() => {
+          setStatus((s) => ({ ...s, [prop]: { loading: false, error: true } }));
+        });
+    });
+  }, [node.bindings, sources]);
+
+  const props: Record<string, any> = { ...(node.props || {}) };
+  if (node.bindings) {
+    for (const [prop, binding] of Object.entries(node.bindings)) {
+      const st = status[prop];
+      if (st?.loading) {
+        props[prop] = (
+          <span className="inline-block bg-gray-200 animate-pulse h-4 w-16" />
+        );
+      } else if (st?.error) {
+        props[prop] = binding.fallback ?? '';
+      } else if (prop in dataMap) {
+        const val = dataMap[prop];
+        props[prop] = val !== undefined ? val : binding.fallback ?? '';
+      }
+    }
+  }
+
+  const children = node.children?.map((c) => <NodeRenderer key={c.id} node={c} />);
+  return React.createElement(node.type as any, props, children);
+};
+
+interface PageRendererProps {
+  tree: ComponentNode[];
+}
+
+const PageRenderer: React.FC<PageRendererProps> = ({ tree }) => {
+  return <>{tree.map((n) => <NodeRenderer key={n.id} node={n} />)}</>;
+};
+
+export default PageRenderer;
+

--- a/src/applyPageDiff.ts
+++ b/src/applyPageDiff.ts
@@ -1,7 +1,10 @@
+import { PropBinding } from './store';
+
 export interface PageNode {
   id: string;
   type: string;
   props?: Record<string, any>;
+  bindings?: Record<string, PropBinding>;
   children?: PageNode[];
 }
 
@@ -9,7 +12,8 @@ export type PatchOp =
   | { op: 'add'; path: string; node: PageNode }
   | { op: 'remove'; path: string }
   | { op: 'move'; from: string; path: string }
-  | { op: 'replaceProps'; path: string; props: Record<string, any> };
+  | { op: 'replaceProps'; path: string; props: Record<string, any> }
+  | { op: 'replaceBindings'; path: string; bindings: Record<string, PropBinding> };
 
 function parsePath(path: string): string[] {
   if (path === '' || path === '/') return [];
@@ -51,6 +55,7 @@ function cloneNode(node: PageNode): PageNode {
   return {
     ...node,
     props: node.props ? { ...node.props } : undefined,
+    bindings: node.bindings ? { ...node.bindings } : undefined,
     children: node.children ? node.children.map(cloneNode) : undefined,
   };
 }
@@ -96,6 +101,18 @@ function replaceProps(root: PageNode, path: string, props: Record<string, any>):
   }));
 }
 
+function replaceBindings(
+  root: PageNode,
+  path: string,
+  bindings: Record<string, PropBinding>
+): PageNode {
+  const segments = parsePath(path);
+  return updateNode(root, segments, (node) => ({
+    ...node,
+    bindings: { ...(node.bindings || {}), ...bindings },
+  }));
+}
+
 export function applyPageDiff(currentTree: PageNode, diff: PatchOp[]): PageNode {
   let tree = currentTree;
   for (const op of diff) {
@@ -113,6 +130,9 @@ export function applyPageDiff(currentTree: PageNode, diff: PatchOp[]): PageNode 
       }
       case 'replaceProps':
         tree = replaceProps(tree, op.path, op.props);
+        break;
+      case 'replaceBindings':
+        tree = replaceBindings(tree, op.path, op.bindings);
         break;
       default: {
         const _exhaustive: never = op;

--- a/src/dataSources.tsx
+++ b/src/dataSources.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface DataSource {
+  name: string;
+  baseURL: string;
+  headers?: Record<string, string>;
+  token?: string;
+}
+
+interface DataSourcesContextValue {
+  sources: DataSource[];
+  setSources: React.Dispatch<React.SetStateAction<DataSource[]>>;
+}
+
+const DataSourcesContext = createContext<DataSourcesContextValue | undefined>(undefined);
+
+export const DataSourcesProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [sources, setSources] = useState<DataSource[]>([]);
+  return (
+    <DataSourcesContext.Provider value={{ sources, setSources }}>
+      {children}
+    </DataSourcesContext.Provider>
+  );
+};
+
+export const useDataSources = () => {
+  const ctx = useContext(DataSourcesContext);
+  if (!ctx) throw new Error('useDataSources must be used within DataSourcesProvider');
+  return ctx;
+};
+

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -3,8 +3,17 @@ import React, { createContext, useContext, useState, ReactNode } from 'react';
 export interface ComponentNode {
   id: string;
   type: string;
+  props?: Record<string, any>;
+  bindings?: Record<string, PropBinding>;
   children?: ComponentNode[];
   isContainer?: boolean;
+}
+
+export interface PropBinding {
+  source: string;
+  endpoint: string;
+  path: string;
+  fallback?: string;
 }
 
 interface EditorState {


### PR DESCRIPTION
## Summary
- manage REST data sources with headers and bearer auth
- bind component props to API endpoints with JSONPath and fallbacks
- fetch bound data at runtime with loading and error handling

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a2f43a44e0832c9fff6983a12e00b9