### PR TITLE
feat: add json to tsx generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "uibuilder",
       "version": "1.0.0",
       "dependencies": {
+        "@babel/generator": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "prettier": "^3.6.2",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-docgen-typescript": "^2.2.2",
@@ -20,11 +23,83 @@
         "typescript": "^5.4.0"
       }
     },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
       "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -42,11 +117,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -56,7 +150,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -235,6 +328,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -267,6 +372,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -5,16 +5,22 @@
   "scripts": {
     "gen:component-meta": "ts-node scripts/gen-component-meta.ts --root ./src/components --out ./public/component-meta.json"
   },
+  "bin": {
+    "json2tsx": "./scripts/json2tsx.js"
+  },
   "dependencies": {
-    "react-docgen-typescript": "^2.2.2",
+    "@babel/generator": "^7.28.3",
+    "@babel/types": "^7.28.2",
+    "prettier": "^3.6.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
+    "react-docgen-typescript": "^2.2.2",
+    "react-dom": "^18.2.0",
     "react-window": "^1.8.9"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
+    "@types/react": "^18.2.47",
     "ts-node": "^10.9.1",
-    "@types/react": "^18.2.47"
+    "typescript": "^5.4.0"
   }
 }

--- a/scripts/json2tsx.js
+++ b/scripts/json2tsx.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const prettier = require('prettier');
+const t = require('@babel/types');
+const generate = require('@babel/generator').default;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let inFile;
+  let outFile;
+  let componentName = 'GeneratedPage';
+  let registry = './components';
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--in') {
+      inFile = args[++i];
+    } else if (arg === '--out') {
+      outFile = args[++i];
+    } else if (arg === '--component-name') {
+      componentName = args[++i];
+    } else if (arg === '--registry') {
+      registry = args[++i];
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      console.error('Usage: json2tsx --in <file> --out <file> --component-name <name> [--registry <importPath>]');
+      process.exit(1);
+    }
+  }
+  return { inFile, outFile, componentName, registry };
+}
+
+function valueToJsx(value) {
+  if (typeof value === 'string') {
+    return t.stringLiteral(value);
+  }
+  return t.jsxExpressionContainer(t.valueToNode(value));
+}
+
+function buildElement(node, imports) {
+  const type = node.type;
+  const props = node.props || {};
+  const children = node.children || [];
+  imports.add(type);
+
+  const attrs = Object.entries(props).map(([key, val]) =>
+    t.jsxAttribute(t.jsxIdentifier(key), valueToJsx(val))
+  );
+
+  const childNodes = children.map((c) => buildElement(c, imports));
+  const opening = t.jsxOpeningElement(t.jsxIdentifier(type), attrs, childNodes.length === 0);
+  const closing = childNodes.length === 0 ? null : t.jsxClosingElement(t.jsxIdentifier(type));
+  return t.jsxElement(opening, closing, childNodes, childNodes.length === 0);
+}
+
+async function main() {
+  const { inFile, outFile, componentName, registry } = parseArgs();
+  try {
+    const jsonStr = inFile ? await fs.promises.readFile(inFile, 'utf8') : await new Promise((res, rej) => {
+      let data = '';
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', (chunk) => (data += chunk));
+      process.stdin.on('end', () => res(data));
+      process.stdin.on('error', rej);
+    });
+    const json = JSON.parse(jsonStr);
+    const imports = new Set();
+    const jsx = buildElement(json, imports);
+
+    const reactImport = t.importDeclaration(
+      [t.importDefaultSpecifier(t.identifier('React'))],
+      t.stringLiteral('react')
+    );
+
+    const importSpecifiers = Array.from(imports).sort().map((name) =>
+      t.importSpecifier(t.identifier(name), t.identifier(name))
+    );
+    const registryImport = t.importDeclaration(importSpecifiers, t.stringLiteral(registry));
+
+    const propsInterface = t.tsInterfaceDeclaration(
+      t.identifier(`${componentName}Props`),
+      null,
+      [],
+      t.tsInterfaceBody([])
+    );
+    const exportedProps = t.exportNamedDeclaration(propsInterface, []);
+
+    const param = t.identifier('props');
+    param.typeAnnotation = t.tsTypeAnnotation(
+      t.tsTypeReference(t.identifier(`${componentName}Props`))
+    );
+    const func = t.functionDeclaration(
+      t.identifier(componentName),
+      [param],
+      t.blockStatement([t.returnStatement(jsx)])
+    );
+
+    const exportDefault = t.exportDefaultDeclaration(t.identifier(componentName));
+
+    const program = t.program([
+      reactImport,
+      registryImport,
+      exportedProps,
+      func,
+      exportDefault,
+    ]);
+
+    const generated = generate(program, { jsescOption: { minimal: true } }).code;
+    const formatted = await prettier.format(generated, { parser: 'typescript' });
+
+    if (outFile) {
+      await fs.promises.mkdir(path.dirname(outFile), { recursive: true });
+      await fs.promises.writeFile(outFile, formatted, 'utf8');
+    } else {
+      process.stdout.write(formatted);
+    }
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `json2tsx` CLI that converts page JSON into TSX via Babel AST and Prettier
- expose CLI through package bin
- add Babel and Prettier dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx json2tsx --in sample.json --out GeneratedPage3.tsx --component-name Third`


------
https://chatgpt.com/codex/tasks/task_e_68a2f576c3f4832cb27bcaedc6f0e471