### PR TITLE
Automate commit and PR creation via codegen endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,9 @@ from datetime import datetime
 import os
 import json
 import asyncio
+import subprocess
+import tempfile
+from pathlib import Path
 
 import httpx
 from fastapi import FastAPI, HTTPException, Response
@@ -24,6 +27,15 @@ class PublishRequest(BaseModel):
 
 class RollbackRequest(BaseModel):
     author: Optional[str] = None
+
+
+class CodegenRequest(BaseModel):
+    spec: Dict[str, Any]
+    out_file: str
+    branch: str
+    base: str
+    title: str
+    body: Optional[str] = None
 
 app = FastAPI()
 app.add_middleware(
@@ -172,6 +184,41 @@ async def get_edge_config(page_id: str):
         media_type="application/json",
         headers={"Cache-Control": "public, max-age=60"},
     )
+
+
+@app.post("/api/codegen")
+def codegen(req: CodegenRequest):
+    """Generate code and open a pull request with the changes."""
+    repo_root = Path(__file__).resolve().parent.parent
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
+        json.dump(req.spec, tmp)
+        tmp_path = tmp.name
+
+    out_path = repo_root / req.out_file
+    subprocess.run(
+        ["node", str(repo_root / "scripts" / "json2tsx.js"), "--in", tmp_path, "--out", str(out_path)],
+        check=True,
+        cwd=repo_root,
+    )
+
+    cmd = [
+        "npx",
+        "ts-node",
+        str(repo_root / "commit-and-pr.ts"),
+        "--branch",
+        req.branch,
+        "--base",
+        req.base,
+        "--title",
+        req.title,
+        "--body",
+        req.body or "",
+        "--paths",
+        req.out_file,
+    ]
+    pr_proc = subprocess.run(cmd, capture_output=True, text=True, cwd=repo_root, check=True)
+    pr_url = pr_proc.stdout.strip().splitlines()[-1]
+    return {"pr_url": pr_url}
 
 @app.get("/health")
 def health_check():

--- a/commit-and-pr.ts
+++ b/commit-and-pr.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+function run(cmd: string, args: string[]) {
+  const res = spawnSync(cmd, args, { stdio: "inherit" });
+  if (res.status !== 0) {
+    process.exit(res.status === null ? 1 : res.status);
+  }
+}
+
+function getArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  return idx !== -1 ? process.argv[idx + 1] : undefined;
+}
+
+async function main() {
+  const branch = getArg("branch");
+  const base = getArg("base");
+  const title = getArg("title");
+  const body = getArg("body") || "";
+  const pathsArg = getArg("paths") || "";
+
+  if (!branch || !base || !title) {
+    console.error("Missing required arguments: --branch, --base, --title");
+    process.exit(1);
+  }
+
+  const paths = pathsArg.split(",").filter(Boolean);
+
+  run("git", ["checkout", "-B", branch]);
+  for (const p of paths) {
+    run("git", ["add", p]);
+  }
+  run("git", ["commit", "-m", title]);
+  run("git", ["push", "--force", "-u", "origin", branch]);
+
+  const token = process.env.GH_TOKEN;
+  const repo = process.env.REPO;
+  const owner = process.env.OWNER;
+  if (!token || !repo || !owner) {
+    console.error("Missing GH_TOKEN, REPO, or OWNER environment variable");
+    process.exit(1);
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "commit-and-pr-script",
+      },
+      body: JSON.stringify({ title, head: branch, base, body }),
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    console.error(`Failed to create PR: ${response.status} ${text}`);
+    process.exit(1);
+  }
+
+  const data = (await response.json()) as { html_url?: string };
+  if (data.html_url) {
+    console.log(data.html_url);
+  } else {
+    console.error("PR created but no URL returned");
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `commit-and-pr.ts` script to stage files, commit, push and open GitHub PRs
- extend FastAPI backend with `/api/codegen` that generates code and invokes the PR script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2f6b865d0832cb35e93c7f16b53e7