### PR TITLE
chore: automate prompt indexing and run scripts

### DIFF
--- a/.github/workflows/prompts-index.yml
+++ b/.github/workflows/prompts-index.yml
@@ -1,0 +1,43 @@
+name: Build Prompts Index
+on:
+  push:
+    branches: [ main ]
+    paths: [ "prompts/**" ]
+  workflow_dispatch: {}
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Generate PROMPTS_INDEX.md
+        run: |
+          mkdir -p scripts
+          cat > scripts/build-prompts-index.mjs <<'EOF'
+          import { readdir, readFile, writeFile, stat } from 'fs/promises';
+          import { join, extname } from 'path';
+          const ROOT = process.cwd(), DIR = join(ROOT,'prompts'), OUT = join(ROOT,'PROMPTS_INDEX.md');
+          async function walk(d){const es=await readdir(d,{withFileTypes:true});const xs=[];for(const e of es){const p=join(d,e.name);xs.push(e.isDirectory()?walk(p):p);}return (await Promise.all(xs)).flat();}
+          const files=(await walk(DIR)).filter(f=>new Set(['.md','.txt']).has(extname(f)));
+          const rows=[];
+          for(const f of files){const c=await readFile(f,'utf8');const m=await stat(f);
+            const title = (c.split(/\r?\n/)[0]||'').replace(/^#+\s*/,'') || f.split('/').pop();
+            rows.push({ path: f.replace(ROOT+'\/',''), title, bytes: c.length, mtime: m.mtime.toISOString() });
+          }
+          rows.sort((a,b)=>a.path.localeCompare(b.path));
+          let md='# Prompts Index\n\n| File | Title | Size | Modified |\n|---|---|---:|---|\n';
+          for(const r of rows){ md+=`| ${r.path} | ${r.title} | ${r.bytes} | ${r.mtime} |\n`; }
+          await writeFile(OUT, md,'utf8'); console.log('Wrote', OUT);
+          EOF
+          node scripts/build-prompts-index.mjs
+      - name: Commit index
+        run: |
+          if git diff --quiet PROMPTS_INDEX.md; then
+            echo "No changes."
+          else
+            git config user.name "github-actions"; git config user.email "actions@github.com"
+            git add PROMPTS_INDEX.md
+            git commit -m "chore: update PROMPTS_INDEX.md"
+            git push
+          fi

--- a/PROMPTS_INDEX.md
+++ b/PROMPTS_INDEX.md
@@ -1,0 +1,4 @@
+# Prompts Index
+
+| File | Title | Size | Modified |
+|---|---|---:|---|

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "commonjs",
   "scripts": {
     "gen:component-meta": "ts-node scripts/gen-component-meta.ts --root ./src/components --out ./public/component-meta.json",
-    "test": "npm install --no-save --prefix .tmp jest ts-jest @testing-library/react @testing-library/jest-dom react-test-renderer @types/jest jest-environment-jsdom > /dev/null && NODE_PATH=\"$(pwd)/.tmp/node_modules\" node .tmp/node_modules/jest/bin/jest.js --config jest.config.cjs --coverage"
+    "test": "npm install --no-save --prefix .tmp jest ts-jest @testing-library/react @testing-library/jest-dom react-test-renderer @types/jest jest-environment-jsdom > /dev/null && NODE_PATH=\"$(pwd)/.tmp/node_modules\" node .tmp/node_modules/jest/bin/jest.js --config jest.config.cjs --coverage",
+    "run:prompts": "node scripts/run-prompts.mjs"
   },
   "bin": {
     "json2tsx": "./scripts/json2tsx.js"

--- a/prompts/MANIFEST.json
+++ b/prompts/MANIFEST.json
@@ -1,0 +1,21 @@
+{
+  "sprintOrder": [
+    "00-zustand-store.md",
+    "01-component-palette.md",
+    "02-hierarchy-tree.md",
+    "03-props-editor-auto.md",
+    "04-save-load-fastapi.md",
+    "05-page-renderer.md",
+    "06-postmessage-bridge.md",
+    "07-cf-kv-deploy.md",
+    "08-diff-apply-engine.md",
+    "09-versioning-rollback.md",
+    "10-edge-config-client.md",
+    "11-data-binding-ui-runtime.md",
+    "12-json-to-tsx-codegen.md",
+    "13-commit-and-pr.md",
+    "14-auth-rbac.md",
+    "15-websocket-collab.md",
+    "16-tests-renderer-diff.md"
+  ]
+}

--- a/scripts/run-prompts.mjs
+++ b/scripts/run-prompts.mjs
@@ -1,0 +1,27 @@
+import { readFile } from 'fs/promises';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { join } from 'path';
+const sh = promisify(execFile);
+const ROOT=process.cwd();
+const manifest = JSON.parse(await readFile(join(ROOT,'prompts','MANIFEST.json'),'utf8'));
+for (const file of manifest.sprintOrder) {
+  const p = join(ROOT,'prompts',file);
+  const prompt = await readFile(p,'utf8');
+
+  // ここで Codex に投げて生成（あなたの実行環境で）
+  // const output = await callCodex(prompt) // <- 実装は手元で
+
+  // 生成済みの成果物を outPaths に配置した前提で PR を作成
+  const branch = `feat/prompt-${file.replace(/\W+/g,'-')}`;
+  const args = [
+    'npx','ts-node','commit-and-pr.ts',
+    '--branch', branch, '--base', 'main',
+    '--title', `feat: ${file}`,
+    '--body', `Generated from prompts/${file}`,
+    '--paths', 'CHANGE_ME/output_file_paths'
+  ];
+  console.log(`> opening PR for ${file}`);
+  const { stdout } = await sh(args[0], args.slice(1), { cwd: ROOT });
+  console.log(stdout.trim());
+}


### PR DESCRIPTION
## Summary
- add workflow to build PROMPTS_INDEX.md on prompt changes
- add manifest and runner script for prompt PR generation

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 1 of 2 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dffc68c8832c99872fdcf425b568