### PR TITLE
Add login and publish flow

### DIFF
--- a/components/PublishButton.tsx
+++ b/components/PublishButton.tsx
@@ -1,44 +1,44 @@
-import React from 'react';
-import { useEditorState } from '../src/store';
-
-const PublishButton: React.FC = () => {
-  const { tree } = useEditorState();
-
-  const handlePublish = async () => {
-    try {
-      const token = localStorage.getItem('token');
-      const res = await fetch('/api/pages/home/publish', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({
-          author: 'demo',
-          json: tree,
-        }),
-      });
-
-      if (!res.ok) {
-        console.error('Publish failed', res.statusText);
-        return;
-      }
-
-      const data = await res.json();
-      console.log(data.version_id);
-    } catch (err) {
-      console.error('Publish error', err);
+'use client'
+import React,{useState} from 'react'
+import { useEditorState } from '../src/store'
+const PublishButton:React.FC=()=>{
+  const{tree}=useEditorState()
+  const[edge,setEdge]=useState<string|null>(null)
+  const handlePublish=async()=>{
+    const token=localStorage.getItem('token')
+    if(!token){
+      window.location.href='/login'
+      return
     }
-  };
-
-  return (
-    <button
-      onClick={handlePublish}
-      className="px-4 py-2 bg-blue-500 text-white rounded"
-    >
-      Publish
-    </button>
-  );
-};
-
-export default PublishButton;
+    try{
+      const res=await fetch('/api/pages/home/publish',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({author:'demo',json:tree})})
+      if(!res.ok){
+        alert('Publish failed')
+        return
+      }
+      const data=await res.json()
+      alert(JSON.stringify(data))
+      const edgeRes=await fetch('/edge-config/home')
+      if(edgeRes.ok){
+        const txt=await edgeRes.text()
+        setEdge(txt)
+      }
+    }catch(err){
+      alert('Publish error')
+    }
+  }
+  return(
+    <>
+      <button onClick={handlePublish} className="px-4 py-2 bg-blue-500 text-white rounded">Publish</button>
+      {edge&&(
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="bg-white p-4 max-w-lg">
+            <pre className="overflow-auto max-h-96">{edge}</pre>
+            <button onClick={()=>setEdge(null)} className="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Close</button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+export default PublishButton

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+import React from 'react'
+import PublishButton from '../../components/PublishButton'
+export default function Page() {
+  return <div className="p-4"><PublishButton/></div>
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+export default function RootLayout({children}:{children:React.ReactNode}) {
+  return(
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+export default function Page() {
+  const [email,setEmail]=useState('')
+  const [password,setPassword]=useState('')
+  const router=useRouter()
+  const submit=async(e:React.FormEvent)=>{
+    e.preventDefault()
+    const res=await fetch('/auth/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email,password})})
+    if(!res.ok) return
+    const data=await res.json()
+    localStorage.setItem('token',data.access_token)
+    router.push('/builder')
+  }
+  return(
+    <form onSubmit={submit} className="flex flex-col gap-2 p-4">
+      <input type="email" value={email} onChange={e=>setEmail(e.target.value)} className="border p-2"/>
+      <input type="password" value={password} onChange={e=>setPassword(e.target.value)} className="border p-2"/>
+      <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">Login</button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- add login page storing token to localStorage
- redirect publish to login when no token
- show publish response and edge-config modal

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a51f99b8fc832c8e08b80b5bd5ccb0