### PR TITLE
feat: add draggable UI builder editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,18 @@
       "dependencies": {
         "@babel/generator": "^7.28.3",
         "@babel/types": "^7.28.2",
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/sortable": "^8.0.0",
         "prettier": "^3.6.2",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-docgen-typescript": "^2.2.2",
         "react-dom": "^18.2.0",
-        "react-window": "^1.8.9"
+        "react-window": "^1.8.9",
+        "zustand": "^4.5.2"
+      },
+      "bin": {
+        "json2tsx": "scripts/json2tsx.js"
       },
       "devDependencies": {
         "@types/react": "^18.2.47",
@@ -115,6 +121,59 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -582,6 +641,12 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -612,6 +677,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -627,6 +701,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-docgen-typescript": "^2.2.2",
     "react-dom": "^18.2.0",
-    "react-window": "^1.8.9"
+    "react-window": "^1.8.9",
+    "zustand": "^4.5.2",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^8.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.47",

--- a/src/features/uibuilder/editor/Canvas.tsx
+++ b/src/features/uibuilder/editor/Canvas.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { useEditorStore, EditorNode } from './useEditorStore';
+import { getComponentByName } from './componentRegistry';
+
+function buildClass(node: EditorNode): string {
+  const classes = [node.props.className || ''];
+  if (node.props.variants) {
+    for (const [state, cls] of Object.entries(node.props.variants)) {
+      classes.push(`${state}:${cls}`);
+    }
+  }
+  return classes.filter(Boolean).join(' ');
+}
+
+const RenderNode: React.FC<{ node: EditorNode }> = ({ node }) => {
+  const select = useEditorStore((s) => s.select);
+  const selectedId = useEditorStore((s) => s.selectedId);
+  const Tag = getComponentByName(node.type) || (node.type as any) || 'div';
+  return (
+    <Tag
+      className={`${buildClass(node)} ${selectedId === node.id ? 'outline outline-blue-500' : ''}`}
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        select(node.id);
+      }}
+    >
+      {node.props.text}
+      {node.children.map((c) => (
+        <RenderNode key={c.id} node={c} />
+      ))}
+    </Tag>
+  );
+};
+
+export const Canvas: React.FC = () => {
+  const root = useEditorStore((s) => s.root);
+  const { setNodeRef } = useDroppable({ id: 'canvas' });
+  return (
+    <div ref={setNodeRef} className="h-full overflow-auto p-4">
+      {root.children.length ? (
+        root.children.map((c) => <RenderNode key={c.id} node={c} />)
+      ) : (
+        <div className="text-gray-400">Drop components here</div>
+      )}
+    </div>
+  );
+};
+

--- a/src/features/uibuilder/editor/ComponentLibrary.tsx
+++ b/src/features/uibuilder/editor/ComponentLibrary.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import { getRegisteredComponents } from './componentRegistry';
+
+const builtin = ['Header', 'Section', 'Button'];
+
+const LibraryItem: React.FC<{ type: string }> = ({ type }) => {
+  const { attributes, listeners, setNodeRef } = useDraggable({ id: `lib-${type}`, data: { type } });
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className="p-2 border rounded bg-white cursor-move"
+    >
+      {type}
+    </div>
+  );
+};
+
+export const ComponentLibrary: React.FC = () => {
+  const registered = getRegisteredComponents().map((c) => c.name);
+  const items = [...builtin, ...registered];
+  return (
+    <div className="p-2 space-y-2 overflow-y-auto h-full bg-gray-50">
+      {items.map((t) => (
+        <LibraryItem key={t} type={t} />
+      ))}
+    </div>
+  );
+};
+

--- a/src/features/uibuilder/editor/EditorShell.tsx
+++ b/src/features/uibuilder/editor/EditorShell.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { ComponentLibrary } from './ComponentLibrary';
+import { Canvas } from './Canvas';
+import { PropertyPanel } from './PropertyPanel';
+import { useEditorStore } from './useEditorStore';
+import { templates } from './templates';
+import './registerComponents';
+
+export const EditorShell: React.FC = () => {
+  const addNode = useEditorStore((s) => s.addNode);
+  const undo = useEditorStore((s) => s.undo);
+  const redo = useEditorStore((s) => s.redo);
+  const applyTemplate = useEditorStore((s) => s.applyTemplate);
+
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragEnd={(e) => {
+        if (e.over?.id === 'canvas') {
+          const type = e.active.data.current?.type;
+          if (type) addNode(type);
+        }
+      }}
+    >
+      <div className="grid grid-cols-[200px_1fr_250px] h-screen">
+        <ComponentLibrary />
+        <Canvas />
+        <PropertyPanel />
+      </div>
+      <div className="absolute top-2 right-2 space-x-2">
+        <button className="px-2 py-1 border rounded" onClick={undo}>
+          Undo
+        </button>
+        <button className="px-2 py-1 border rounded" onClick={redo}>
+          Redo
+        </button>
+        {Object.entries(templates).map(([name, tmpl]) => (
+          <button
+            key={name}
+            className="px-2 py-1 border rounded"
+            onClick={() => applyTemplate(tmpl)}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+    </DndContext>
+  );
+};
+

--- a/src/features/uibuilder/editor/PropertyPanel.tsx
+++ b/src/features/uibuilder/editor/PropertyPanel.tsx
@@ -1,0 +1,55 @@
+import React, { useState, useMemo } from 'react';
+import { useEditorStore, EditorNode } from './useEditorStore';
+
+function findNode(root: EditorNode, id: string): EditorNode | null {
+  if (root.id === id) return root;
+  for (const child of root.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+export const PropertyPanel: React.FC = () => {
+  const selectedId = useEditorStore((s) => s.selectedId);
+  const root = useEditorStore((s) => s.root);
+  const node = useMemo(() => (selectedId ? findNode(root, selectedId) : null), [root, selectedId]);
+  const updateProps = useEditorStore((s) => s.updateProps);
+  const updateVariant = useEditorStore((s) => s.updateVariant);
+  const [tab, setTab] = useState<'default' | 'hover'>('default');
+
+  if (!node) return <div className="p-4 text-gray-500">No selection</div>;
+
+  const handleClassChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (tab === 'default') updateProps(node.id, { className: e.target.value });
+    else updateVariant(node.id, tab, e.target.value);
+  };
+
+  const classValue = tab === 'default' ? node.props.className || '' : node.props.variants?.[tab] || '';
+
+  return (
+    <div className="p-4 space-y-2">
+      <div>
+        <label className="block text-sm">Text</label>
+        <input
+          className="w-full border rounded px-2 py-1"
+          value={node.props.text || ''}
+          onChange={(e) => updateProps(node.id, { text: e.target.value })}
+        />
+      </div>
+      <div>
+        <div className="flex space-x-2 text-sm">
+          <button className={tab === 'default' ? 'font-bold' : ''} onClick={() => setTab('default')}>default</button>
+          <button className={tab === 'hover' ? 'font-bold' : ''} onClick={() => setTab('hover')}>hover</button>
+        </div>
+        <input
+          className="w-full border rounded px-2 py-1 mt-1"
+          value={classValue}
+          onChange={handleClassChange}
+          placeholder="className"
+        />
+      </div>
+    </div>
+  );
+};
+

--- a/src/features/uibuilder/editor/componentRegistry.ts
+++ b/src/features/uibuilder/editor/componentRegistry.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface RegisteredComponent {
+  name: string;
+  component: React.ComponentType<any>;
+}
+
+const registry: Record<string, RegisteredComponent> = {};
+
+export function registerComponent(component: React.ComponentType<any>, meta: { name: string }) {
+  registry[meta.name] = { name: meta.name, component };
+}
+
+export function getRegisteredComponents(): RegisteredComponent[] {
+  return Object.values(registry);
+}
+
+export function getComponentByName(name: string): React.ComponentType<any> | undefined {
+  return registry[name]?.component;
+}
+

--- a/src/features/uibuilder/editor/registerComponents.ts
+++ b/src/features/uibuilder/editor/registerComponents.ts
@@ -1,0 +1,5 @@
+import PublishButton from '../../../../components/PublishButton';
+import { registerComponent } from './componentRegistry';
+
+registerComponent(PublishButton, { name: 'PublishButton' });
+

--- a/src/features/uibuilder/editor/templates.ts
+++ b/src/features/uibuilder/editor/templates.ts
@@ -1,0 +1,14 @@
+import { EditorNode, createNode } from './useEditorStore';
+
+export const templates: Record<string, EditorNode> = {
+  'Dashboard Layout': {
+    id: 'root',
+    type: 'div',
+    props: { className: 'flex' },
+    children: [
+      createNode('Sidebar', { id: 'sidebar' }),
+      createNode('MainContent', { id: 'main' }),
+    ],
+  },
+};
+

--- a/src/features/uibuilder/editor/useEditorStore.ts
+++ b/src/features/uibuilder/editor/useEditorStore.ts
@@ -1,0 +1,129 @@
+import { create } from 'zustand';
+
+export interface EditorNode {
+  id: string;
+  type: string;
+  props: {
+    text?: string;
+    className?: string;
+    variants?: Record<string, string>;
+    [key: string]: any;
+  };
+  children: EditorNode[];
+}
+
+const createNode = (type: string, overrides: Partial<EditorNode> = {}): EditorNode => ({
+  id: `node-${Math.random().toString(36).slice(2, 9)}`,
+  type,
+  props: { text: type, className: '', variants: {}, ...(overrides.props || {}) },
+  children: overrides.children || [],
+  ...overrides,
+});
+
+function cloneTree<T>(tree: T): T {
+  return JSON.parse(JSON.stringify(tree));
+}
+
+function findNode(node: EditorNode, id: string): EditorNode | null {
+  if (node.id === id) return node;
+  for (const child of node.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function updateNode(node: EditorNode, id: string, updater: (n: EditorNode) => void): EditorNode {
+  if (node.id === id) {
+    updater(node);
+  } else {
+    node.children = node.children.map((c) => updateNode(c, id, updater));
+  }
+  return node;
+}
+
+export interface EditorState {
+  root: EditorNode;
+  selectedId: string | null;
+  history: EditorNode[];
+  future: EditorNode[];
+  select: (id: string | null) => void;
+  addNode: (type: string, parentId?: string) => void;
+  updateProps: (id: string, props: Partial<EditorNode['props']>) => void;
+  updateVariant: (id: string, variant: string, className: string) => void;
+  removeNode: (id: string) => void;
+  applyTemplate: (root: EditorNode) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+const pushHistory = (history: EditorNode[], node: EditorNode): EditorNode[] => {
+  const next = [...history, cloneTree(node)];
+  return next.length > 10 ? next.slice(next.length - 10) : next;
+};
+
+export const useEditorStore = create<EditorState>((set, get) => ({
+  root: createNode('div', { id: 'root' }),
+  selectedId: null,
+  history: [],
+  future: [],
+  select: (id) => set({ selectedId: id }),
+  addNode: (type, parentId = 'root') =>
+    set((state) => {
+      const root = cloneTree(state.root);
+      const parent = findNode(root, parentId);
+      if (parent) {
+        parent.children.push(createNode(type));
+      }
+      return { root, history: pushHistory(state.history, state.root), future: [] };
+    }),
+  updateProps: (id, props) =>
+    set((state) => {
+      const root = cloneTree(state.root);
+      updateNode(root, id, (n) => {
+        n.props = { ...n.props, ...props };
+      });
+      return { root, history: pushHistory(state.history, state.root), future: [] };
+    }),
+  updateVariant: (id, variant, className) =>
+    set((state) => {
+      const root = cloneTree(state.root);
+      updateNode(root, id, (n) => {
+        n.props.variants = { ...(n.props.variants || {}), [variant]: className };
+      });
+      return { root, history: pushHistory(state.history, state.root), future: [] };
+    }),
+  removeNode: (id) =>
+    set((state) => {
+      const root = cloneTree(state.root);
+      const remove = (parent: EditorNode) => {
+        parent.children = parent.children.filter((c) => c.id !== id);
+        parent.children.forEach(remove);
+      };
+      remove(root);
+      return { root, history: pushHistory(state.history, state.root), future: [] };
+    }),
+  applyTemplate: (root) =>
+    set((state) => ({
+      root: cloneTree(root),
+      history: pushHistory(state.history, state.root),
+      future: [],
+      selectedId: null,
+    })),
+  undo: () =>
+    set((state) => {
+      if (!state.history.length) return state;
+      const prev = state.history[state.history.length - 1];
+      const history = state.history.slice(0, -1);
+      return { root: cloneTree(prev), history, future: [cloneTree(state.root), ...state.future] };
+    }),
+  redo: () =>
+    set((state) => {
+      if (!state.future.length) return state;
+      const [next, ...rest] = state.future;
+      return { root: cloneTree(next), history: pushHistory(state.history, state.root), future: rest };
+    }),
+}));
+
+export { createNode };
+


### PR DESCRIPTION
## Summary
- add Zustand-based store with undo/redo and template support
- implement 3-column EditorShell with drag-and-drop and property panel
- allow Tailwind variant editing for hover state and dynamic component registration

## Testing
- `npm test` *(fails: expect(res.children?.map((c) => c.id)).toEqual(['b', 'c']) and TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a51fb2c5d8832cbd6447e72559a017