### PR TITLE
feat: add hover variant support

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,23 @@
+export interface PropBinding {
+  source: string
+  endpoint: string
+  path: string
+  fallback?: string
+}
+
+export interface VariantStyle {
+  className?: string
+}
+
+export interface Variants {
+  hover?: VariantStyle
+}
+
+export interface IRComponentNode {
+  id: string
+  type: string
+  props?: Record<string, any>
+  bindings?: Record<string, PropBinding>
+  variants?: Variants
+  children?: IRComponentNode[]
+}

--- a/src/AutoPropsEditor.tsx
+++ b/src/AutoPropsEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDataSources } from './dataSources';
-import { PropBinding } from './store';
+import { PropBinding, useEditorState, useEditorActions } from './store';
 
 interface PropMeta {
   name: string;
@@ -21,6 +21,8 @@ interface AutoPropsEditorProps {
   onChange: (nextProps: Record<string, any>) => void;
   bindings?: Record<string, PropBinding>;
   onBindingsChange?: (next: Record<string, PropBinding>) => void;
+  variants?: { hover?: { className?: string } };
+  onVariantsChange?: (v: { hover?: { className?: string } }) => void;
 }
 
 // Attempt to extract union/enum values from a type string like '"a" | "b"' or 'Enum.A | Enum.B'
@@ -53,11 +55,16 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
   onChange,
   bindings = {},
   onBindingsChange,
+  variants = {},
+  onVariantsChange,
 }) => {
   const [componentMeta, setComponentMeta] = useState<ComponentMeta[]>([]);
   const [localProps, setLocalProps] = useState<Record<string, any>>({});
   const [localBindings, setLocalBindings] = useState<Record<string, PropBinding>>({});
+  const [localVariants, setLocalVariants] = useState<{ hover?: { className?: string } }>({});
   const { sources } = useDataSources();
+  const { inspectorTab } = useEditorState();
+  const { setInspectorTab } = useEditorActions();
 
   // load component meta
   useEffect(() => {
@@ -83,7 +90,8 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
   useEffect(() => {
     setLocalProps(selectedProps || {});
     setLocalBindings(bindings || {});
-  }, [selectedComponentType, selectedProps, bindings]);
+    setLocalVariants(variants || {});
+  }, [selectedComponentType, selectedProps, bindings, variants]);
 
   // debounce onChange
   useEffect(() => {
@@ -101,6 +109,14 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
     return () => clearTimeout(handle);
   }, [localBindings, onBindingsChange]);
 
+  useEffect(() => {
+    if (!onVariantsChange) return;
+    const handle = setTimeout(() => {
+      onVariantsChange(localVariants);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [localVariants, onVariantsChange]);
+
   const meta = useMemo(
     () => componentMeta.find((m) => m.displayName === selectedComponentType),
     [componentMeta, selectedComponentType]
@@ -117,6 +133,10 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
       else next[name] = value;
       return next;
     });
+  };
+
+  const updateVariant = (value: string) => {
+    setLocalVariants((prev) => ({ ...prev, hover: { ...prev.hover, className: value } }));
   };
 
   const renderControl = (prop: PropMeta, missing: boolean) => {
@@ -240,19 +260,35 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
   return (
     <div className="space-y-4 p-2">
       <div>
-        <label className="block text-sm font-medium mb-1">className</label>
-        <input
-          type="text"
+        <div className="flex border-b mb-1">
+          <button
+            className={`px-2 py-1 text-sm ${inspectorTab === 'default' ? 'border-b-2 border-blue-500' : ''}`}
+            onClick={() => setInspectorTab('default')}
+          >
+            Default
+          </button>
+          <button
+            className={`px-2 py-1 text-sm ${inspectorTab === 'hover' ? 'border-b-2 border-blue-500' : ''}`}
+            onClick={() => setInspectorTab('hover')}
+          >
+            Hover
+          </button>
+        </div>
+        <textarea
           className="w-full border border-gray-300 rounded px-2 py-1"
-          value={localProps.className ?? ''}
-          onChange={(e) => updateProp('className', e.target.value)}
+          value={inspectorTab === 'default' ? localProps.className ?? '' : localVariants.hover?.className ?? ''}
+          onChange={(e) =>
+            inspectorTab === 'default'
+              ? updateProp('className', e.target.value)
+              : updateVariant(e.target.value)
+          }
         />
       </div>
-        {meta ? (
-          meta.props
-            .filter((p) => p.name !== 'className')
-            .map((prop) => {
-              const value = localProps[prop.name];
+      {meta ? (
+        meta.props
+          .filter((p) => p.name !== 'className')
+          .map((prop) => {
+            const value = localProps[prop.name];
               const missing = prop.required && (value === undefined || value === '');
               return (
                 <div key={prop.name} className="flex items-center space-x-2">

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PageRenderer from './PageRenderer';
+import { useEditorState, useEditorActions } from './store';
+
+const Canvas: React.FC = () => {
+  const { tree, hoverPreview } = useEditorState();
+  const { setHoverPreview } = useEditorActions();
+  return (
+    <div className="h-full w-full">
+      <div className="p-2 border-b flex items-center space-x-2">
+        <input type="checkbox" checked={hoverPreview} onChange={(e) => setHoverPreview(e.target.checked)} />
+        <span className="text-sm">Hover preview</span>
+      </div>
+      <div className="p-4">
+        <PageRenderer tree={tree} previewHover={hoverPreview} />
+      </div>
+    </div>
+  );
+};
+
+export default Canvas;

--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -30,9 +30,10 @@ async function fetchBinding(binding: PropBinding, sources: DataSource[]) {
 
 interface NodeRendererProps {
   node: ComponentNode;
+  previewHover: boolean;
 }
 
-const NodeRenderer: React.FC<NodeRendererProps> = ({ node }) => {
+const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
   const { sources } = useDataSources();
   const [dataMap, setDataMap] = useState<Record<string, any>>({});
   const [status, setStatus] = useState<Record<string, { loading: boolean; error: boolean }>>({});
@@ -54,6 +55,10 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node }) => {
   }, [node.bindings, sources]);
 
   const props: Record<string, any> = { ...(node.props || {}) };
+  if (previewHover && node.variants?.hover?.className) {
+    const base = props.className ?? '';
+    props.className = [base, node.variants.hover.className].filter(Boolean).join(' ').trim();
+  }
   if (node.bindings) {
     for (const [prop, binding] of Object.entries(node.bindings)) {
       const st = status[prop];
@@ -70,16 +75,19 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node }) => {
     }
   }
 
-  const children = node.children?.map((c) => <NodeRenderer key={c.id} node={c} />);
+  const children = node.children?.map((c) => (
+    <NodeRenderer key={c.id} node={c} previewHover={previewHover} />
+  ));
   return React.createElement(node.type as any, props, children);
 };
 
 interface PageRendererProps {
   tree: ComponentNode[];
+  previewHover?: boolean;
 }
 
-const PageRenderer: React.FC<PageRendererProps> = ({ tree }) => {
-  return <>{tree.map((n) => <NodeRenderer key={n.id} node={n} />)}</>;
+const PageRenderer: React.FC<PageRendererProps> = ({ tree, previewHover = false }) => {
+  return <>{tree.map((n) => <NodeRenderer key={n.id} node={n} previewHover={previewHover} />)}</>;
 };
 
 export default PageRenderer;

--- a/src/__tests__/PageRenderer.test.tsx
+++ b/src/__tests__/PageRenderer.test.tsx
@@ -5,7 +5,7 @@ import PageRenderer from '../PageRenderer';
 import { ComponentNode } from '../store';
 import { DataSourcesProvider, useDataSources, DataSource } from '../dataSources';
 
-function renderTree(tree: ComponentNode[], sources: DataSource[] = []) {
+function renderTree(tree: ComponentNode[], sources: DataSource[] = [], previewHover = false) {
   const SetSources: React.FC<{ sources: DataSource[] }> = ({ sources }) => {
     const { setSources } = useDataSources();
     useEffect(() => {
@@ -19,7 +19,7 @@ function renderTree(tree: ComponentNode[], sources: DataSource[] = []) {
     renderer = TestRenderer.create(
       <DataSourcesProvider>
         <SetSources sources={sources} />
-        <PageRenderer tree={tree} />
+        <PageRenderer tree={tree} previewHover={previewHover} />
       </DataSourcesProvider>
     );
     await Promise.resolve();
@@ -96,5 +96,22 @@ test('uses fallback on fetch error', async () => {
     type: 'div',
     props: {},
     children: ['fb'],
+  });
+});
+
+test('applies hover variant', async () => {
+  const tree: ComponentNode[] = [
+    {
+      id: '1',
+      type: 'div',
+      props: { className: 'bg-blue-500' },
+      variants: { hover: { className: 'bg-blue-600' } },
+    },
+  ];
+  const renderer = await renderTree(tree, [], true);
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: { className: 'bg-blue-500 bg-blue-600' },
+    children: null,
   });
 });

--- a/src/applyPageDiff.ts
+++ b/src/applyPageDiff.ts
@@ -5,6 +5,7 @@ export interface PageNode {
   type: string;
   props?: Record<string, any>;
   bindings?: Record<string, PropBinding>;
+  variants?: { hover?: { className?: string } };
   children?: PageNode[];
 }
 

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -5,6 +5,7 @@ export interface ComponentNode {
   type: string;
   props?: Record<string, any>;
   bindings?: Record<string, PropBinding>;
+  variants?: { hover?: { className?: string } };
   children?: ComponentNode[];
   isContainer?: boolean;
 }
@@ -19,6 +20,8 @@ export interface PropBinding {
 interface EditorState {
   tree: ComponentNode[];
   selectedComponentId: string | null;
+  hoverPreview: boolean;
+  inspectorTab: 'default' | 'hover';
 }
 
 interface EditorActions {
@@ -26,6 +29,8 @@ interface EditorActions {
   moveComponent: (dragId: string, parentId: string | null, index: number) => void;
   duplicateComponent: (id: string) => void;
   deleteComponent: (id: string) => void;
+  setHoverPreview: (v: boolean) => void;
+  setInspectorTab: (t: 'default' | 'hover') => void;
 }
 
 interface EditorContextValue {
@@ -41,6 +46,8 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
 }) => {
   const [tree, setTree] = useState<ComponentNode[]>(initialTree);
   const [selectedComponentId, setSelectedComponentId] = useState<string | null>(null);
+  const [hoverPreview, setHoverPreview] = useState(false);
+  const [inspectorTab, setInspectorTab] = useState<'default' | 'hover'>('default');
 
   const selectComponent = (id: string | null) => setSelectedComponentId(id);
 
@@ -58,8 +65,8 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
   };
 
   const value: EditorContextValue = {
-    state: { tree, selectedComponentId },
-    actions: { selectComponent, moveComponent, duplicateComponent, deleteComponent },
+    state: { tree, selectedComponentId, hoverPreview, inspectorTab },
+    actions: { selectComponent, moveComponent, duplicateComponent, deleteComponent, setHoverPreview, setInspectorTab },
   };
 
   return <EditorContext.Provider value={value}>{children}</EditorContext.Provider>;


### PR DESCRIPTION
## Summary
- support hover variant class overrides in IR and editor store
- add inspector tabs for default and hover class editing
- enable hover preview on canvas with toggle

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a51f808e1c832caafd100ce1a9a898