### PR TITLE
feat: add layers panel for node visibility and locking

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -4,6 +4,7 @@ import CanvasFree from '../../components/CanvasFree'
 import Library from '../../components/Library'
 import Inspector from '../../components/Inspector'
 import { EditorProvider } from '../../components/store'
+import LayersPanel from '../../components/LayersPanel'
 
 const initialTree = [
   { id: 'node1', type: 'div', props: { children: 'Box 1', className: 'bg-gray-200' }, layout: { x: 40, y: 40, w: 320, h: 180 } }
@@ -14,6 +15,7 @@ export default function BuilderPage() {
     <EditorProvider initialTree={initialTree}>
       <div className="flex h-screen">
         <div className="w-64 border-r overflow-y-auto"><Library /></div>
+        <div className="w-64 border-r overflow-y-auto"><LayersPanel /></div>
         <div className="flex-1 overflow-hidden"><CanvasFree /></div>
         <div className="w-80 border-l overflow-y-auto"><Inspector /></div>
       </div>

--- a/web/components/CanvasFree.tsx
+++ b/web/components/CanvasFree.tsx
@@ -153,12 +153,13 @@ const NodeBox: React.FC<{
   onChangeLayout: (id: string, layout: { x: number; y: number; w: number; h: number }) => void
   setGuides: (g: Guide[]) => void
 }> = ({ node, siblings, selectedIds, onMouseDown, onChangeLayout, setGuides }) => {
+  if (node.hidden) return null
   const l = node.layout || { x: 40, y: 40, w: 320, h: 180 }
   const Comp: any = node.type === 'Group' ? 'div' : (node.type as any)
   const [temp, setTemp] = useState<Rect | null>(null)
   const current = temp || l
   const others = siblings
-    .filter(n => n.id !== node.id)
+    .filter(n => n.id !== node.id && !n.hidden)
     .map(n => n.layout || { x: 40, y: 40, w: 320, h: 180 })
   return (
     <Rnd
@@ -197,7 +198,8 @@ const NodeBox: React.FC<{
         onChangeLayout(node.id, rect)
       }}
       bounds="parent"
-      enableResizing
+      disableDragging={node.locked}
+      enableResizing={!node.locked}
       onMouseDown={e => {
         e.stopPropagation()
         onMouseDown(e, node.id)
@@ -360,6 +362,7 @@ const CanvasFree: React.FC = () => {
   const collectRects = (nodes: ComponentNode[], ox = 0, oy = 0): { id: string; rect: Rect }[] => {
     const res: { id: string; rect: Rect }[] = []
     nodes.forEach(n => {
+      if (n.hidden) return
       const l = n.layout || { x: 40, y: 40, w: 320, h: 180 }
       const r = { x: ox + l.x, y: oy + l.y, w: l.w, h: l.h }
       res.push({ id: n.id, rect: r })

--- a/web/components/LayersPanel.tsx
+++ b/web/components/LayersPanel.tsx
@@ -1,0 +1,99 @@
+'use client'
+import React, { useState } from 'react'
+import { ComponentNode, useEditorState, useEditorActions } from './store'
+import { DndContext, PointerSensor, useSensor, useSensors, DragEndEvent, useDroppable } from '@dnd-kit/core'
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+interface TreeProps {
+  nodes: ComponentNode[]
+  path: number[]
+}
+
+const Tree: React.FC<TreeProps> = ({ nodes, path }) => {
+  const id = 'drop-' + path.join('-')
+  const { setNodeRef } = useDroppable({ id, data: { path: [...path, nodes.length] } })
+  return (
+    <div ref={setNodeRef} className="pl-2">
+      <SortableContext items={nodes.map(n => n.id)} strategy={verticalListSortingStrategy}>
+        {nodes.map((n, i) => (
+          <TreeItem key={n.id} node={n} path={[...path, i]} />
+        ))}
+      </SortableContext>
+    </div>
+  )
+}
+
+const TreeItem: React.FC<{ node: ComponentNode; path: number[] }> = ({ node, path }) => {
+  const { selectComponent, setNodeName, setHidden, setLocked } = useEditorActions()
+  const { selectedIds } = useEditorState()
+  const [editing, setEditing] = useState(false)
+  const [name, setName] = useState(node.name || '')
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: node.id,
+    data: { path }
+  })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  }
+  return (
+    <div>
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={`flex items-center gap-1 px-1 cursor-pointer ${selectedIds.includes(node.id) ? 'bg-blue-100' : ''}`}
+        onClick={() => selectComponent(node.id)}
+        {...attributes}
+        {...listeners}
+      >
+        <button onClick={e => { e.stopPropagation(); setHidden(node.id, !node.hidden) }}>
+          {node.hidden ? '🙈' : '👁'}
+        </button>
+        <button onClick={e => { e.stopPropagation(); setLocked(node.id, !node.locked) }}>
+          {node.locked ? '🔒' : '🔓'}
+        </button>
+        {editing ? (
+          <input
+            className="border px-1 text-sm flex-1"
+            value={name}
+            autoFocus
+            onChange={e => setName(e.target.value)}
+            onBlur={() => { setEditing(false); setNodeName(node.id, name) }}
+            onKeyDown={e => {
+              if (e.key === 'Enter') { setEditing(false); setNodeName(node.id, name) }
+            }}
+          />
+        ) : (
+          <span className="flex-1 text-sm" onDoubleClick={() => setEditing(true)}>
+            {node.name || node.type}
+          </span>
+        )}
+      </div>
+      {node.children && node.children.length > 0 && (
+        <Tree nodes={node.children} path={[...path]} />
+      )}
+    </div>
+  )
+}
+
+const LayersPanel: React.FC = () => {
+  const { tree } = useEditorState()
+  const { moveNode } = useEditorActions()
+  const sensors = useSensors(useSensor(PointerSensor))
+  const handleDragEnd = (e: DragEndEvent) => {
+    const from = e.active.data.current?.path as number[] | undefined
+    const to = e.over?.data.current?.path as number[] | undefined
+    if (from && to) {
+      moveNode(from, to)
+    }
+  }
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <Tree nodes={tree} path={[]} />
+    </DndContext>
+  )
+}
+
+export default LayersPanel
+

--- a/web/components/store.tsx
+++ b/web/components/store.tsx
@@ -9,6 +9,9 @@ export interface ComponentNode {
   children?: ComponentNode[]
   isContainer?: boolean
   layout?: { x: number; y: number; w: number; h: number }
+  name?: string
+  hidden?: boolean
+  locked?: boolean
 }
 
 export interface PropBinding {
@@ -44,6 +47,9 @@ interface EditorActions {
   setInspectorTab: (t: 'default' | 'hover') => void
   setLayout: (id: string, layout: { x: number; y: number; w: number; h: number }) => void
   setProp: (id: string, prop: string, value: any) => void
+  setNodeName: (id: string, name: string) => void
+  setHidden: (id: string, hidden: boolean) => void
+  setLocked: (id: string, locked: boolean) => void
 }
 
 interface EditorContextValue {
@@ -208,6 +214,18 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
     setTree(prev => setNodeProp(prev, id, prop, value))
   }
 
+  const setNodeName = (id: string, name: string) => {
+    setTree(prev => setNodeData(prev, id, { name }))
+  }
+
+  const setHidden = (id: string, hidden: boolean) => {
+    setTree(prev => setNodeData(prev, id, { hidden }))
+  }
+
+  const setLocked = (id: string, locked: boolean) => {
+    setTree(prev => setNodeData(prev, id, { locked }))
+  }
+
   const value: EditorContextValue = {
     state: { tree, selectedComponentId, selectedIds, hoverPreview, inspectorTab },
     actions: {
@@ -227,7 +245,10 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
       setHoverPreview,
       setInspectorTab,
       setLayout,
-      setProp
+      setProp,
+      setNodeName,
+      setHidden,
+      setLocked
     }
   }
 
@@ -407,6 +428,18 @@ function setNodeLayout(nodes: ComponentNode[], id: string, layout: { x: number; 
       return { ...n, layout: next }
     }
     if (n.children) return { ...n, children: setNodeLayout(n.children, id, layout) }
+    return n
+  })
+}
+
+function setNodeData(
+  nodes: ComponentNode[],
+  id: string,
+  data: Partial<ComponentNode>
+): ComponentNode[] {
+  return nodes.map(n => {
+    if (n.id === id) return { ...n, ...data }
+    if (n.children) return { ...n, children: setNodeData(n.children, id, data) }
     return n
   })
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -3,4 +3,7 @@ export type NodeIR = {
   type: string
   props: Record<string, any>
   children: NodeIR[]
+  name?: string
+  hidden?: boolean
+  locked?: boolean
 }

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,10 @@
     "react-dom": "18.3.1",
     "react-rnd": "^10.5.1",
     "tailwindcss": "3.4.4",
-    "zustand": "4.5.2"
+    "zustand": "4.5.2",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "20.11.30",


### PR DESCRIPTION
## Summary
- add LayersPanel component with drag-and-drop, visibility, lock, and rename controls
- extend editor store and canvas to respect hidden and locked node states
- wire layers panel into builder layout and add dnd-kit dependencies

## Testing
- `npm test` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a684c53a7c832c819368d85a309dd2