### PR TITLE
feat: add rotation controls and aspect resize

### DIFF
--- a/web/components/CanvasFree.tsx
+++ b/web/components/CanvasFree.tsx
@@ -1,9 +1,10 @@
 'use client'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Rnd } from 'react-rnd'
-import { useEditorState, useEditorActions, ComponentNode } from './store'
+import { useEditorState, useEditorActions, ComponentNode, Layout } from './store'
 
 type Rect = { x: number; y: number; w: number; h: number }
+type NodeLayout = Layout
 type Guide = { orientation: 'v' | 'h'; pos: number }
 
 const GRID_SIZE = 8
@@ -150,24 +151,76 @@ const NodeBox: React.FC<{
   siblings: ComponentNode[]
   selectedIds: string[]
   onMouseDown: (e: any, id: string) => void
-  onChangeLayout: (id: string, layout: { x: number; y: number; w: number; h: number }) => void
+  onChangeLayout: (id: string, layout: Partial<NodeLayout>) => void
   setGuides: (g: Guide[]) => void
 }> = ({ node, siblings, selectedIds, onMouseDown, onChangeLayout, setGuides }) => {
   if (node.hidden) return null
-  const l = node.layout || { x: 40, y: 40, w: 320, h: 180 }
+  const l = node.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
   const Comp: any = node.type === 'Group' ? 'div' : (node.type as any)
-  const [temp, setTemp] = useState<Rect | null>(null)
+  const [temp, setTemp] = useState<NodeLayout | null>(null)
   const current = temp || l
   const others = siblings
     .filter(n => n.id !== node.id && !n.hidden)
-    .map(n => n.layout || { x: 40, y: 40, w: 320, h: 180 })
+    .map(n => n.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 })
+  const rndRef = useRef<HTMLDivElement>(null)
+
+  const startRotate = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const rect = rndRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const cx = rect.left + rect.width / 2
+    const cy = rect.top + rect.height / 2
+    const startAngle = Math.atan2(e.clientY - cy, e.clientX - cx) * 180 / Math.PI
+    const startRotation = current.rotation
+    const base = { ...current }
+    const move = (ev: MouseEvent) => {
+      const ang = Math.atan2(ev.clientY - cy, ev.clientX - cx) * 180 / Math.PI
+      let rotation = startRotation + ang - startAngle
+      rotation = (rotation + 360) % 360
+      if (ev.shiftKey) rotation = Math.round(rotation / 15) * 15
+      setTemp({ ...base, rotation })
+    }
+    const up = (ev: MouseEvent) => {
+      const ang = Math.atan2(ev.clientY - cy, ev.clientX - cx) * 180 / Math.PI
+      let rotation = startRotation + ang - startAngle
+      rotation = (rotation + 360) % 360
+      if (ev.shiftKey) rotation = Math.round(rotation / 15) * 15
+      setTemp(null)
+      onChangeLayout(node.id, { rotation })
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
+
+  const applyModifiers = (
+    e: MouseEvent | React.MouseEvent,
+    rect: Rect,
+  ): Rect => {
+    let { x, y, w, h } = rect
+    if (e.shiftKey) {
+      const ratio = l.w / l.h
+      if (w / h > ratio) w = h * ratio
+      else h = w / ratio
+    }
+    if (e.altKey) {
+      const cx = l.x + l.w / 2
+      const cy = l.y + l.h / 2
+      x = cx - w / 2
+      y = cy - h / 2
+    }
+    return { x, y, w, h }
+  }
+
   return (
     <Rnd
+      ref={rndRef}
       size={{ width: current.w, height: current.h }}
       position={{ x: current.x, y: current.y }}
       onDrag={(e, d) => {
         const { rect, guides } = snapRect({ x: d.x, y: d.y, w: l.w, h: l.h }, others, e.shiftKey, 'move')
-        setTemp(rect)
+        setTemp({ ...rect, rotation: l.rotation })
         setGuides(guides)
       }}
       onDragStop={(e, d) => {
@@ -177,22 +230,16 @@ const NodeBox: React.FC<{
         onChangeLayout(node.id, rect)
       }}
       onResize={(e, __, ref, ___, pos) => {
-        const { rect, guides } = snapRect(
-          { x: pos.x, y: pos.y, w: ref.offsetWidth, h: ref.offsetHeight },
-          others,
-          e.shiftKey,
-          'resize'
-        )
-        setTemp(rect)
+        const raw: Rect = { x: pos.x, y: pos.y, w: ref.offsetWidth, h: ref.offsetHeight }
+        const modified = applyModifiers(e as MouseEvent, raw)
+        const { rect, guides } = snapRect(modified, others, (e as MouseEvent).shiftKey, 'resize')
+        setTemp({ ...rect, rotation: l.rotation })
         setGuides(guides)
       }}
       onResizeStop={(e, __, ref, ___, pos) => {
-        const { rect } = snapRect(
-          temp || { x: pos.x, y: pos.y, w: ref.offsetWidth, h: ref.offsetHeight },
-          others,
-          e.shiftKey,
-          'resize'
-        )
+        const raw: Rect = temp || { x: pos.x, y: pos.y, w: ref.offsetWidth, h: ref.offsetHeight }
+        const modified = applyModifiers(e as MouseEvent, raw)
+        const { rect } = snapRect(modified, others, (e as MouseEvent).shiftKey, 'resize')
         setTemp(null)
         setGuides([])
         onChangeLayout(node.id, rect)
@@ -206,12 +253,21 @@ const NodeBox: React.FC<{
       }}
       className={selectedIds.includes(node.id) ? 'outline outline-2 outline-blue-500' : ''}
     >
-      <div className="relative w-full h-full">
+      {selectedIds.includes(node.id) && (
+        <div
+          className="absolute -top-5 -right-5 w-4 h-4 rounded-full border border-blue-500 bg-white cursor-pointer"
+          onMouseDown={startRotate}
+        />
+      )}
+      <div
+        className="relative w-full h-full"
+        style={{ transform: `rotate(${current.rotation}deg)`, transformOrigin: 'center' }}
+      >
         {React.createElement(Comp, node.props || {})}
         {node.children?.map(child => (
           <NodeBox
             key={child.id}
-            node={{ ...child, layout: child.layout || { x: 40, y: 40, w: 320, h: 180 } }}
+            node={{ ...child, layout: child.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 } }}
             siblings={node.children!}
             selectedIds={selectedIds}
             onMouseDown={onMouseDown}
@@ -267,7 +323,7 @@ const CanvasFree: React.FC = () => {
           selectedIds.forEach(id => {
             const node = find(treeRef.current, id)
             if (!node) return
-            const l = node.layout || { x: 40, y: 40, w: 320, h: 180 }
+            const l = node.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
             let { x, y } = l
             if (e.key === 'ArrowUp') y -= step
             if (e.key === 'ArrowDown') y += step
@@ -297,7 +353,7 @@ const CanvasFree: React.FC = () => {
               }
               const newNode = findCopy(treeRef.current)
               if (newNode) {
-                const l = newNode.layout || { x: 40, y: 40, w: 320, h: 180 }
+                const l = newNode.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
                 setLayout(newNode.id, { ...l, x: l.x + 10, y: l.y + 10 })
                 selectComponent(newNode.id)
               }
@@ -339,7 +395,7 @@ const CanvasFree: React.FC = () => {
     if (!type) return
     const pt = clientToCanvas(e.clientX, e.clientY)
     const id = addComponent(type)
-    setLayout(id, { x: pt.x, y: pt.y, w: 320, h: 180 })
+    setLayout(id, { x: pt.x, y: pt.y, w: 320, h: 180, rotation: 0 })
     setHighlight(pt)
   }
 
@@ -363,7 +419,7 @@ const CanvasFree: React.FC = () => {
     const res: { id: string; rect: Rect }[] = []
     nodes.forEach(n => {
       if (n.hidden) return
-      const l = n.layout || { x: 40, y: 40, w: 320, h: 180 }
+      const l = n.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
       const r = { x: ox + l.x, y: oy + l.y, w: l.w, h: l.h }
       res.push({ id: n.id, rect: r })
       if (n.children) res.push(...collectRects(n.children, r.x, r.y))
@@ -454,7 +510,7 @@ const CanvasFree: React.FC = () => {
           {tree.map(node => (
             <NodeBox
               key={node.id}
-              node={{ ...node, layout: node.layout || { x: 40, y: 40, w: 320, h: 180 } }}
+              node={{ ...node, layout: node.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 } }}
               siblings={tree}
               selectedIds={selectedIds}
               onMouseDown={handleNodeMouseDown}

--- a/web/components/store.tsx
+++ b/web/components/store.tsx
@@ -1,5 +1,13 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react'
 
+export interface Layout {
+  x: number
+  y: number
+  w: number
+  h: number
+  rotation: number
+}
+
 export interface ComponentNode {
   id: string
   type: string
@@ -8,7 +16,7 @@ export interface ComponentNode {
   variants?: { hover?: { className?: string } }
   children?: ComponentNode[]
   isContainer?: boolean
-  layout?: { x: number; y: number; w: number; h: number }
+  layout?: Layout
   name?: string
   hidden?: boolean
   locked?: boolean
@@ -45,7 +53,7 @@ interface EditorActions {
   loadTemplate: (t: ComponentNode[]) => void
   setHoverPreview: (v: boolean) => void
   setInspectorTab: (t: 'default' | 'hover') => void
-  setLayout: (id: string, layout: { x: number; y: number; w: number; h: number }) => void
+  setLayout: (id: string, layout: Partial<Layout>) => void
   setProp: (id: string, prop: string, value: any) => void
   setNodeName: (id: string, name: string) => void
   setHidden: (id: string, hidden: boolean) => void
@@ -109,11 +117,12 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
     setTree(prev => moveByPath(prev, from, to))
   }
 
-  const defaultLayout = (): { x: number; y: number; w: number; h: number } => ({
+  const defaultLayout = (): Layout => ({
     x: 40,
     y: 40,
     w: 320,
-    h: 180
+    h: 180,
+    rotation: 0
   })
 
   const addComponent = (type: string): string => {
@@ -157,13 +166,13 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
     const parentPath = paths[0].slice(0, -1)
     if (!paths.every(p => p.slice(0, -1).every((v, i) => v === parentPath[i]))) return
     const nodes = paths.map(p => getNode(tree, p)!)
-    const rects = nodes.map(n => n.layout || { x: 40, y: 40, w: 320, h: 180 })
+    const rects = nodes.map(n => n.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 })
     const minX = Math.min(...rects.map(r => r.x))
     const minY = Math.min(...rects.map(r => r.y))
     const maxX = Math.max(...rects.map(r => r.x + r.w))
     const maxY = Math.max(...rects.map(r => r.y + r.h))
     const adjusted = nodes.map(n => {
-      const l = n.layout || { x: 40, y: 40, w: 320, h: 180 }
+      const l = n.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
       return { ...n, layout: { ...l, x: l.x - minX, y: l.y - minY } }
     })
     let t = tree
@@ -179,7 +188,7 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
       id: groupId,
       type: 'Group',
       isContainer: true,
-      layout: { x: minX, y: minY, w: maxX - minX, h: maxY - minY },
+      layout: { x: minX, y: minY, w: maxX - minX, h: maxY - minY, rotation: 0 },
       children: adjusted
     }
     t = insertAt(t, [...parentPath, insertIndex], groupNode)
@@ -192,21 +201,24 @@ export const EditorProvider: React.FC<{ initialTree?: ComponentNode[]; children:
     if (!path) return
     const node = getNode(tree, path)
     if (!node || !node.children) return
-    const groupLayout = node.layout || { x: 40, y: 40, w: 320, h: 180 }
+    const groupLayout = node.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
     const parentPath = path.slice(0, -1)
     const index = path[path.length - 1]
     const { nodes: without } = removeAt(tree, path)
     let t = without
     node.children.forEach((child, i) => {
-      const l = child.layout || { x: 40, y: 40, w: 320, h: 180 }
-      const adjusted = { ...child, layout: { ...l, x: l.x + groupLayout.x, y: l.y + groupLayout.y } }
+      const l = child.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
+      const adjusted = {
+        ...child,
+        layout: { ...l, x: l.x + groupLayout.x, y: l.y + groupLayout.y, rotation: l.rotation ?? 0 }
+      }
       t = insertAt(t, [...parentPath, index + i], adjusted)
     })
     pushHistory(t)
     setSelectedIds(node.children.map(c => c.id))
   }
 
-  const setLayout = (id: string, layout: { x: number; y: number; w: number; h: number }) => {
+  const setLayout = (id: string, layout: Partial<Layout>) => {
     setTree(prev => setNodeLayout(prev, id, layout))
   }
 
@@ -284,7 +296,7 @@ function duplicateNode(nodes: ComponentNode[], id: string): ComponentNode[] {
       result.push(n)
       const copy = cloneNode(n)
       copy.id = `${n.id}_copy_${Math.random().toString(36).slice(2, 8)}`
-      if (!copy.layout) copy.layout = { x: 40, y: 40, w: 320, h: 180 }
+      if (!copy.layout) copy.layout = { x: 40, y: 40, w: 320, h: 180, rotation: 0 }
       result.push(copy)
     } else if (n.children) {
       result.push({ ...n, children: duplicateNode(n.children, id) })
@@ -421,10 +433,10 @@ function setNodeProp(nodes: ComponentNode[], id: string, prop: string, value: an
   })
 }
 
-function setNodeLayout(nodes: ComponentNode[], id: string, layout: { x: number; y: number; w: number; h: number }): ComponentNode[] {
+function setNodeLayout(nodes: ComponentNode[], id: string, layout: Partial<Layout>): ComponentNode[] {
   return nodes.map(n => {
     if (n.id === id) {
-      const next = { ...(n.layout || { x: 40, y: 40, w: 320, h: 180 }), ...layout }
+      const next = { ...(n.layout || { x: 40, y: 40, w: 320, h: 180, rotation: 0 }), ...layout }
       return { ...n, layout: next }
     }
     if (n.children) return { ...n, children: setNodeLayout(n.children, id, layout) }


### PR DESCRIPTION
## Summary
- add rotation field to component layout
- add rotation handle with snapping and center resize options

## Testing
- `npm test` *(fails: Cannot find module 'react')*
- `npm install --no-save --prefix .tmp jest ts-jest @testing-library/react @testing-library/jest-dom react-test-renderer @types/jest jest-environment-jsdom react react-dom @types/react && NODE_PATH="$(pwd)/.tmp/node_modules:$(pwd)/node_modules" node .tmp/node_modules/jest/bin/jest.js --config jest.config.cjs --coverage` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a687678c60832cb9f4eb056ab342fd