### PR TITLE
feat: add publish and deploy bar with login

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -5,6 +5,7 @@ import Library from '../../components/Library'
 import Inspector from '../../components/Inspector'
 import { EditorProvider } from '../../components/store'
 import LayersPanel from '../../components/LayersPanel'
+import PublishBar from '../../components/PublishBar'
 
 const initialTree = [
   { id: 'node1', type: 'div', props: { children: 'Box 1', className: 'bg-gray-200' }, layout: { x: 40, y: 40, w: 320, h: 180 } }
@@ -13,11 +14,16 @@ const initialTree = [
 export default function BuilderPage() {
   return (
     <EditorProvider initialTree={initialTree}>
-      <div className="flex h-screen">
-        <div className="w-64 border-r overflow-y-auto"><Library /></div>
-        <div className="w-64 border-r overflow-y-auto"><LayersPanel /></div>
-        <div className="flex-1 overflow-hidden"><CanvasFree /></div>
-        <div className="w-80 border-l overflow-y-auto"><Inspector /></div>
+      <div className="flex flex-col h-screen">
+        <div className="flex justify-end border-b p-2">
+          <PublishBar pageId="home" />
+        </div>
+        <div className="flex flex-1">
+          <div className="w-64 border-r overflow-y-auto"><Library /></div>
+          <div className="w-64 border-r overflow-y-auto"><LayersPanel /></div>
+          <div className="flex-1 overflow-hidden"><CanvasFree /></div>
+          <div className="w-80 border-l overflow-y-auto"><Inspector /></div>
+        </div>
       </div>
     </EditorProvider>
   )

--- a/web/components/LoginDialog.tsx
+++ b/web/components/LoginDialog.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+
+interface Props {
+  onClose: () => void
+  onSuccess: (token: string) => void
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_BASE
+
+export default function LoginDialog({ onClose, onSuccess }: Props) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${BASE}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      if (!res.ok) {
+        alert('Login failed')
+        return
+      }
+      const data = await res.json()
+      localStorage.setItem('token', data.access_token)
+      onSuccess(data.access_token)
+      onClose()
+    } catch (e) {
+      alert('Login error')
+    }
+  }
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <form onSubmit={submit} className="bg-white p-4 rounded flex flex-col gap-2 min-w-[240px]">
+        <input
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          placeholder="Email"
+          className="border p-2"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-2"
+        />
+        <div className="flex gap-2 justify-end">
+          <button type="button" onClick={onClose} className="px-3 py-1 border rounded">
+            Cancel
+          </button>
+          <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">
+            Login
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/web/components/PublishBar.tsx
+++ b/web/components/PublishBar.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react'
+import { useEditorState } from './store'
+import LoginDialog from './LoginDialog'
+
+interface Props {
+  pageId?: string
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_BASE
+
+export default function PublishBar({ pageId = 'home' }: Props) {
+  const { tree } = useEditorState()
+  const [token, setToken] = useState<string | null>(null)
+  const [autoDeploy, setAutoDeploy] = useState(false)
+  const [showLogin, setShowLogin] = useState(false)
+
+  useEffect(() => {
+    const t = localStorage.getItem('token')
+    if (t) setToken(t)
+  }, [])
+
+  const publish = async () => {
+    const t = token || localStorage.getItem('token')
+    if (!t) {
+      setShowLogin(true)
+      return
+    }
+    try {
+      const res = await fetch(`${BASE}/api/pages/${pageId}/publish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${t}`
+        },
+        body: JSON.stringify({ author: 'demo', json: tree })
+      })
+      if (res.status === 401) {
+        setShowLogin(true)
+        return
+      }
+      if (!res.ok) {
+        alert('Publish failed')
+        return
+      }
+      alert('Published')
+      if (autoDeploy) {
+        const res2 = await fetch(`${BASE}/api/pages/${pageId}/deploy`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${t}` }
+        })
+        if (res2.status === 401) {
+          setShowLogin(true)
+          return
+        }
+        if (!res2.ok) {
+          alert('Deploy failed')
+          return
+        }
+        alert('Deployed')
+      }
+    } catch (e) {
+      alert('Request error')
+    }
+  }
+
+  const onLoginSuccess = (tok: string) => {
+    setToken(tok)
+    setShowLogin(false)
+  }
+
+  return (
+    <>
+      {showLogin && <LoginDialog onClose={() => setShowLogin(false)} onSuccess={onLoginSuccess} />}
+      <div className="flex items-center gap-2">
+        <label className="flex items-center gap-1">
+          <input type="checkbox" checked={autoDeploy} onChange={e => setAutoDeploy(e.target.checked)} />
+          Auto-deploy
+        </label>
+        <button onClick={publish} className="px-3 py-1 bg-blue-500 text-white rounded">
+          Save
+        </button>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add LoginDialog for email/password authentication
- add PublishBar with Save and optional auto-deploy
- show Save & Publish bar in builder header

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a68c2b02e4832cac5948045a90e2c4