### PR TITLE
feat: add publish and versioning UI

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,28 +1,24 @@
 'use client'
 import React from 'react'
-import CanvasFree from '../../components/CanvasFree'
+import Toolbar from '../../components/Toolbar'
+import VersionsPanel from '../../components/VersionsPanel'
+import Canvas from '../../components/Canvas'
 import Library from '../../components/Library'
 import Inspector from '../../components/Inspector'
+import LoadInitialTree from '../../components/LoadInitialTree'
 import { EditorProvider } from '../../components/store'
-import LayersPanel from '../../components/LayersPanel'
-import PublishBar from '../../components/PublishBar'
-
-const initialTree = [
-  { id: 'node1', type: 'div', props: { children: 'Box 1', className: 'bg-gray-200' }, layout: { x: 40, y: 40, w: 320, h: 180 } }
-]
 
 export default function BuilderPage() {
   return (
-    <EditorProvider initialTree={initialTree}>
-      <div className="flex flex-col h-screen">
-        <div className="flex justify-end border-b p-2">
-          <PublishBar pageId="home" />
-        </div>
-        <div className="flex flex-1">
-          <div className="w-64 border-r overflow-y-auto"><Library /></div>
-          <div className="w-64 border-r overflow-y-auto"><LayersPanel /></div>
-          <div className="flex-1 overflow-hidden"><CanvasFree /></div>
-          <div className="w-80 border-l overflow-y-auto"><Inspector /></div>
+    <EditorProvider initialTree={[]}>
+      <div className="h-screen flex flex-col">
+        <Toolbar />
+        <LoadInitialTree />
+        <div className="flex flex-1 min-h-0">
+          <div className="w-60 border-r overflow-y-auto"><Library/></div>
+          <div className="flex-1 overflow-auto"><Canvas/></div>
+          <div className="w-80 border-l overflow-y-auto"><Inspector/></div>
+          <VersionsPanel />
         </div>
       </div>
     </EditorProvider>

--- a/web/components/Auth/LoginModal.tsx
+++ b/web/components/Auth/LoginModal.tsx
@@ -1,0 +1,67 @@
+'use client'
+import React, { useState } from 'react'
+import { apiFetch, setToken } from '../../lib/api'
+
+type Props = { open: boolean; onClose: () => void; onLoggedIn?: () => void }
+
+const LoginModal: React.FC<Props> = ({ open, onClose, onLoggedIn }) => {
+  const [email, setEmail] = useState('demo@example.com')
+  const [password, setPassword] = useState('demo')
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  if (!open) return null
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setErr(null)
+    try {
+      const res = await apiFetch<{ access_token: string }>('/auth/login', {
+        method: 'POST',
+        json: { email, password },
+      })
+      setToken(res.access_token)
+      onLoggedIn?.()
+      onClose()
+    } catch (e: any) {
+      setErr(e.message || 'Login failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-xl p-4 w-96 space-y-3">
+        <div className="text-lg font-semibold">Sign in</div>
+        {err && <div className="text-sm text-red-600">{err}</div>}
+        <form onSubmit={submit} className="space-y-2">
+          <input
+            className="w-full border rounded px-3 py-2"
+            placeholder="Email"
+            value={email}
+            onChange={(e)=>setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            className="w-full border rounded px-3 py-2"
+            placeholder="Password"
+            value={password}
+            onChange={(e)=>setPassword(e.target.value)}
+          />
+          <button
+            className="w-full rounded bg-blue-600 text-white py-2 disabled:opacity-60"
+            disabled={loading}
+          >
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+        <button className="text-sm text-gray-600" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  )
+}
+
+export default LoginModal
+

--- a/web/components/LoadInitialTree.tsx
+++ b/web/components/LoadInitialTree.tsx
@@ -1,0 +1,25 @@
+'use client'
+import React, { useEffect } from 'react'
+import { useEditorActions } from './store'
+import { apiFetch } from '../lib/api'
+
+const PAGE_ID = 'home'
+
+const LoadInitialTree: React.FC = () => {
+  const { loadTemplate } = useEditorActions()
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await apiFetch(`/edge-config/${PAGE_ID}`)
+        const next = Array.isArray((data as any).children) ? (data as any).children : []
+        if (next.length) loadTemplate(next)
+      } catch {
+        // silent
+      }
+    })()
+  }, [loadTemplate])
+  return null
+}
+
+export default LoadInitialTree
+

--- a/web/components/Toolbar.tsx
+++ b/web/components/Toolbar.tsx
@@ -1,0 +1,65 @@
+'use client'
+import React, { useState } from 'react'
+import { useEditorState, useEditorActions } from './store'
+import { apiFetch, getToken, clearToken } from '../lib/api'
+import LoginModal from './Auth/LoginModal'
+
+const PAGE_ID = 'home'
+
+const Toolbar: React.FC = () => {
+  const { tree } = useEditorState()
+  const { loadTemplate } = useEditorActions()
+  const [loginOpen, setLoginOpen] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  const show = (m: string) => { setMsg(m); setTimeout(()=>setMsg(null), 2500) }
+
+  const publish = async () => {
+    const token = getToken()
+    if (!token) { setLoginOpen(true); return }
+    const payload = {
+      author: 'web',
+      json: { id:'root', type:'div', children: tree }
+    }
+    await apiFetch(`/api/pages/${PAGE_ID}/publish`, { method:'POST', json: payload })
+    show('Published ✅')
+  }
+
+  const deploy = async () => {
+    const token = getToken()
+    if (!token) { setLoginOpen(true); return }
+    await apiFetch(`/api/pages/${PAGE_ID}/deploy`, { method:'POST' })
+    show('Deployed to KV ✅')
+  }
+
+  const loadLatest = async () => {
+    const data = await apiFetch(`/edge-config/${PAGE_ID}`)
+    // data = {id:'root', type:'div', children:[...]} or children がない場合もあり得る
+    const root = data as any
+    const next = Array.isArray(root.children) ? root.children : []
+    loadTemplate(next)
+    show('Loaded from Edge ✅')
+  }
+
+  const logout = () => { clearToken(); show('Logged out') }
+
+  return (
+    <>
+      <div className="sticky top-0 z-20 bg-white/80 backdrop-blur border-b">
+        <div className="flex items-center gap-2 p-2">
+          <button className="px-3 py-1 rounded border" onClick={()=>setLoginOpen(true)}>Login</button>
+          <button className="px-3 py-1 rounded border" onClick={logout}>Logout</button>
+          <div className="mx-2 w-px h-6 bg-gray-200" />
+          <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={publish}>Publish</button>
+          <button className="px-3 py-1 rounded bg-emerald-600 text-white" onClick={deploy}>Deploy</button>
+          <button className="px-3 py-1 rounded border" onClick={loadLatest}>Load (Edge)</button>
+          {msg && <span className="text-sm text-gray-600 ml-2">{msg}</span>}
+        </div>
+      </div>
+      <LoginModal open={loginOpen} onClose={()=>setLoginOpen(false)} onLoggedIn={()=>show('Logged in ✅')} />
+    </>
+  )
+}
+
+export default Toolbar
+

--- a/web/components/VersionsPanel.tsx
+++ b/web/components/VersionsPanel.tsx
@@ -1,0 +1,71 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { apiFetch, getToken } from '../lib/api'
+import { useEditorActions } from './store'
+
+const PAGE_ID = 'home'
+
+type VersionMeta = { id: string; created_at: string; author?: string }
+
+const VersionsPanel: React.FC = () => {
+  const { loadTemplate } = useEditorActions()
+  const [items, setItems] = useState<VersionMeta[]>([])
+  const [open, setOpen] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const refresh = async () => {
+    setLoading(true); setErr(null)
+    try {
+      const res = await apiFetch<VersionMeta[]>(`/api/pages/${PAGE_ID}/versions`)
+      setItems(res)
+    } catch (e:any) {
+      setErr(e.message || 'failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(()=>{ refresh() }, [])
+
+  const loadVersion = async (vid: string) => {
+    const json = await apiFetch<any>(`/api/pages/${PAGE_ID}/versions/${vid}`)
+    const next = Array.isArray(json.children) ? json.children : []
+    loadTemplate(next)
+  }
+
+  const rollback = async (vid: string) => {
+    const token = getToken()
+    if (!token) { alert('Login required'); return }
+    await apiFetch(`/api/pages/${PAGE_ID}/rollback/${vid}`, { method:'POST' })
+    await refresh()
+    alert('Rollback created (new head version)')
+  }
+
+  return (
+    <div className="border-l w-80 h-full flex flex-col">
+      <div className="p-2 border-b flex items-center justify-between">
+        <div className="font-medium">Versions</div>
+        <button className="text-sm text-blue-600" onClick={refresh}>Refresh</button>
+      </div>
+      {loading && <div className="p-2 text-sm text-gray-500">Loading…</div>}
+      {err && <div className="p-2 text-sm text-red-600">{err}</div>}
+      <div className="flex-1 overflow-auto">
+        {items.map(v => (
+          <div key={v.id} className="p-2 border-b space-y-1">
+            <div className="text-xs text-gray-500">{new Date(v.created_at).toLocaleString()}</div>
+            <div className="text-sm">{v.author ?? '—'}</div>
+            <div className="flex gap-2">
+              <button className="text-xs px-2 py-1 rounded border" onClick={()=>loadVersion(v.id)}>Load</button>
+              <button className="text-xs px-2 py-1 rounded border" onClick={()=>rollback(v.id)}>Rollback</button>
+            </div>
+          </div>
+        ))}
+        {items.length === 0 && !loading && <div className="p-2 text-sm text-gray-500">No versions yet</div>}
+      </div>
+    </div>
+  )
+}
+
+export default VersionsPanel
+

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,58 @@
+'use client'
+
+export const API_BASE =
+  (typeof window !== 'undefined' && (window as any).NEXT_PUBLIC_API_BASE) ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  'http://127.0.0.1:8000';
+
+const KEY = 'uibuilder.jwt';
+
+export function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(KEY);
+}
+
+export function setToken(t: string) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(KEY, t);
+}
+
+export function clearToken() {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(KEY);
+}
+
+type FetchOpts = RequestInit & { json?: any };
+
+export async function apiFetch<T = any>(path: string, opts: FetchOpts = {}): Promise<T> {
+  const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(opts.headers as any),
+  };
+  const token = getToken();
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(url, {
+    ...opts,
+    headers,
+    body: opts.json !== undefined ? JSON.stringify(opts.json) : opts.body,
+  });
+
+  if (res.status === 401) {
+    clearToken();
+    throw new Error('Unauthorized: please login again.');
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}: ${text}`);
+  }
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('application/json')) return res.json();
+  // for /edge-config/* where response is JSON but may be streamed
+  try { return (await res.json()) as T; } catch {
+    return (await res.text()) as any;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add API helper with token management
- add login modal and toolbar for publish/deploy flows
- show page versions with load and rollback support
- load initial tree from edge config and integrate into builder page

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*
- `cd web && npm test` *(fails: Missing script: "test")*
- `cd web && npm run build` *(fails: Type error: Type 'MutableRefObject<HTMLDivElement>' is not assignable to type 'LegacyRef<Rnd>')*


------
https://chatgpt.com/codex/tasks/task_e_68a6a414fa98832ca46a4cdedc5d52d5