### PR TITLE
feat: add toggleable HUD overlay

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,8 @@ import logging
 import hashlib
 import subprocess
 import tempfile
+import random
+import time
 from pathlib import Path
 
 import httpx
@@ -311,6 +313,21 @@ async def page_ws(websocket: WebSocket, page_id: str):
         room.discard(websocket)
         presence_map.get(page_id, set()).discard(user_id)
         await broadcast_presence(page_id)
+
+@app.get("/api/notifications")
+def list_notifications():
+    return [{"id": str(uuid4()), "source":"slack","channel":"general","text":"ダミー通知","ts": int(time.time())}]
+
+@app.websocket("/ws/notifications")
+async def ws_notifications(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            await asyncio.sleep(random.randint(5,10))
+            msg = {"id": str(uuid4()), "source":"slack", "channel":"general", "text":"新しいメッセージが届きました", "ts": int(time.time())}
+            await ws.send_json(msg)
+    except Exception:
+        pass
 
 @app.post("/api/codegen")
 def codegen(req: CodegenRequest):

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,10 +1,14 @@
+"use client"
 import './globals.css'
 import React, { ReactNode } from 'react'
+import { HUDProvider } from '../components/hud/hudStore'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <HUDProvider>{children}</HUDProvider>
+      </body>
     </html>
   )
 }

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -4,6 +4,7 @@ import { useEditorState, useEditorActions, ComponentNode } from './store'
 import { registry } from '../lib/registry'
 import SelectionOverlay from './canvas/SelectionOverlay'
 import Viewport from './canvas/Viewport'
+import HUDContainer from './hud/HUDContainer'
 
 function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
@@ -27,13 +28,16 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
 export default function Canvas() {
   const { tree } = useEditorState()
   return (
-    <Viewport>
-      <div className="relative w-[2000px] h-[2000px]">
-        {tree.map(n => (
-          <NodeRenderer key={n.id} node={n} />
-        ))}
-        <SelectionOverlay />
-      </div>
-    </Viewport>
+    <div className="relative h-full w-full">
+      <Viewport>
+        <div className="relative w-[2000px] h-[2000px]">
+          {tree.map(n => (
+            <NodeRenderer key={n.id} node={n} />
+          ))}
+          <SelectionOverlay />
+        </div>
+      </Viewport>
+      <HUDContainer />
+    </div>
   )
 }

--- a/web/components/PublishBar.tsx
+++ b/web/components/PublishBar.tsx
@@ -43,6 +43,7 @@ export default function PublishBar({ pageId = 'home' }: Props) {
         return
       }
       alert('Published')
+      window.dispatchEvent(new CustomEvent('exp:tick', { detail: { type: 'publish' } }))
       if (autoDeploy) {
         const res2 = await fetch(`${BASE}/api/pages/${pageId}/deploy`, {
           method: 'POST',

--- a/web/components/hud/HUDBar.tsx
+++ b/web/components/hud/HUDBar.tsx
@@ -1,0 +1,25 @@
+'use client'
+import React from 'react'
+import { useHUD } from './hudStore'
+
+export default function HUDBar(){
+  const {hud, toggle} = useHUD()
+  const Btn = ({k,label}:{k:keyof typeof hud,label:string})=> (
+    <button
+      onClick={(e)=>{ e.stopPropagation(); toggle(k) }}
+      className={`pointer-events-auto text-xs px-2 py-1 rounded border ${hud[k]?'bg-blue-600 text-white':'bg-white/80 backdrop-blur'}`}
+      title={label}
+    >{label}</button>
+  )
+  return (
+    <div className="pointer-events-none absolute right-2 top-2 z-50">
+      <div className="pointer-events-auto flex gap-1 p-1 rounded-xl bg-white/70 shadow">
+        <Btn k="arGuide" label="ARガイド"/>
+        <Btn k="workMap" label="業務マップ"/>
+        <Btn k="skillShortcuts" label="スキル"/>
+        <Btn k="expGauge" label="EXP"/>
+        <Btn k="contextNotify" label="通知"/>
+      </div>
+    </div>
+  )
+}

--- a/web/components/hud/HUDContainer.tsx
+++ b/web/components/hud/HUDContainer.tsx
@@ -1,0 +1,23 @@
+'use client'
+import React from 'react'
+import { useHUD } from './hudStore'
+import ARGuide from './ar/ARGuide'
+import WorkMapHUD from './workmap/WorkMapHUD'
+import SkillShortcutsHUD from './skills/SkillShortcutsHUD'
+import ExpGaugeHUD from './exp/ExpGaugeHUD'
+import ContextNotificationsHUD from './notify/ContextNotificationsHUD'
+import HUDBar from './HUDBar'
+
+export default function HUDContainer(){
+  const { hud } = useHUD()
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40">
+      <HUDBar />
+      {hud.arGuide && <ARGuide/>}
+      {hud.workMap && <WorkMapHUD/>}
+      {hud.skillShortcuts && <SkillShortcutsHUD/>}
+      {hud.expGauge && <ExpGaugeHUD/>}
+      {hud.contextNotify && <ContextNotificationsHUD/>}
+    </div>
+  )
+}

--- a/web/components/hud/ar/ARGuide.tsx
+++ b/web/components/hud/ar/ARGuide.tsx
@@ -1,0 +1,33 @@
+'use client'
+import React, {useEffect, useMemo, useState} from 'react'
+import { AR_STEPS } from './steps'
+
+export default function ARGuide(){
+  const [idx, setIdx] = useState<number>(()=> Number(localStorage.getItem('uibuilder.arGuide.step')||0))
+  const target = useMemo(()=>{
+    const sel = AR_STEPS[idx]?.selector
+    return sel ? document.querySelector(sel) as HTMLElement|null : null
+  },[idx])
+  useEffect(()=>{ localStorage.setItem('uibuilder.arGuide.step', String(idx)) },[idx])
+
+  if(!AR_STEPS[idx]) return null
+  const rect = target?.getBoundingClientRect()
+  return (
+    <div className="absolute inset-0">
+      <div className="absolute inset-0 bg-black/0" />
+      {rect && (
+        <div
+          className="pointer-events-auto absolute bg-white/90 backdrop-blur rounded-xl shadow p-3 w-72"
+          style={{ left: rect.left + rect.width + 8, top: rect.top }}
+        >
+          <div className="font-medium">{AR_STEPS[idx].title}</div>
+          <div className="text-sm text-gray-600">{AR_STEPS[idx].body}</div>
+          <div className="mt-2 flex justify-end gap-2">
+            <button className="text-xs px-2 py-1" onClick={()=> setIdx(AR_STEPS.length)}>スキップ</button>
+            <button className="text-xs px-2 py-1 rounded bg-blue-600 text-white" onClick={()=> setIdx(i=>i+1)}>次へ</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/hud/ar/steps.ts
+++ b/web/components/hud/ar/steps.ts
@@ -1,0 +1,4 @@
+export const AR_STEPS = [
+  { selector: '[data-node-id]', title: '選択', body: 'キャンバス上の要素をクリックで選択できます。' },
+  { selector: '[data-toolbar-publish]', title: 'Publish', body: '保存したらここから公開できます。', pin:'bottom' },
+]

--- a/web/components/hud/exp/ExpGaugeHUD.tsx
+++ b/web/components/hud/exp/ExpGaugeHUD.tsx
@@ -1,0 +1,21 @@
+'use client'
+import React, {useEffect, useState} from 'react'
+import { getTodayExpTotal, addExp } from './expStore'
+
+export default function ExpGaugeHUD(){
+  const [n, setN] = useState(0)
+  useEffect(()=>{
+    const onTick = (e:any)=>{ addExp(e.detail?.type||'other'); setN(getTodayExpTotal()) }
+    window.addEventListener('exp:tick', onTick as any); setN(getTodayExpTotal())
+    return ()=> window.removeEventListener('exp:tick', onTick as any)
+  },[])
+  const pct = Math.min(100, Math.round((n/20)*100))
+  return (
+    <div className="pointer-events-none absolute right-2 top-14">
+      <div className="pointer-events-auto bg-white/80 backdrop-blur rounded-full w-16 h-16 grid place-items-center shadow relative overflow-hidden">
+        <div className="text-xs font-semibold z-10">{n}</div>
+        <div className="absolute inset-0 rounded-full" style={{background: `conic-gradient(#2563eb ${pct*3.6}deg, transparent 0)`}}/>
+      </div>
+    </div>
+  )
+}

--- a/web/components/hud/exp/expStore.ts
+++ b/web/components/hud/exp/expStore.ts
@@ -1,0 +1,12 @@
+'use client'
+export function addExp(type:string){
+  const d = new Date(); const key = `uib.exp.${d.toISOString().slice(0,10)}`
+  const obj = JSON.parse(localStorage.getItem(key) || '{}')
+  obj[type] = (obj[type]||0) + 1
+  localStorage.setItem(key, JSON.stringify(obj))
+}
+export function getTodayExpTotal(){
+  const key = `uib.exp.${new Date().toISOString().slice(0,10)}`
+  const obj = JSON.parse(localStorage.getItem(key) || '{}')
+  return Object.values(obj).reduce((a:number,b:any)=> a + Number(b||0), 0)
+}

--- a/web/components/hud/hudStore.tsx
+++ b/web/components/hud/hudStore.tsx
@@ -1,0 +1,23 @@
+'use client'
+import React, {createContext, useContext, useState} from 'react'
+
+export type HUDKey = 'arGuide'|'workMap'|'skillShortcuts'|'expGauge'|'contextNotify'
+type HUDState = Record<HUDKey, boolean>
+
+const HudCtx = createContext<{
+  hud: HUDState
+  toggle: (k:HUDKey)=>void
+} | null>(null)
+
+export const HUDProvider: React.FC<{children:React.ReactNode}> = ({children}) => {
+  const [hud, setHud] = useState<HUDState>({
+    arGuide:false, workMap:false, skillShortcuts:false, expGauge:false, contextNotify:false
+  })
+  const toggle = (k:HUDKey)=> setHud(s=>({...s, [k]:!s[k]}))
+  return <HudCtx.Provider value={{hud, toggle}}>{children}</HudCtx.Provider>
+}
+export const useHUD = ()=>{
+  const ctx = useContext(HudCtx)
+  if(!ctx) throw new Error('useHUD must be used within HUDProvider')
+  return ctx
+}

--- a/web/components/hud/notify/ContextNotificationsHUD.tsx
+++ b/web/components/hud/notify/ContextNotificationsHUD.tsx
@@ -1,0 +1,31 @@
+'use client'
+import React, {useEffect, useState} from 'react'
+type Note = { id:string; source:string; channel?:string; text:string; ts:number }
+
+export default function ContextNotificationsHUD(){
+  const [notes, setNotes] = useState<Note[]>([])
+  useEffect(()=>{
+    let ws:WebSocket|undefined
+    try {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+      const wsUrl = `${proto}://${location.host}/ws/notifications`
+      ws = new WebSocket(wsUrl)
+      ws.onmessage = (ev)=> {
+        const n = JSON.parse(ev.data) as Note
+        setNotes(s=> [n, ...s].slice(0,3))
+        setTimeout(()=> setNotes(s=> s.filter(x=> x.id !== n.id)), 7000)
+      }
+    } catch {}
+    return ()=> ws?.close()
+  },[])
+  return (
+    <div className="pointer-events-none absolute left-2 bottom-2 flex flex-col gap-2">
+      {notes.map(n=>(
+        <div key={n.id} className="pointer-events-auto bg-white/90 backdrop-blur rounded-lg shadow p-2 w-80">
+          <div className="text-[10px] text-gray-500">{n.source} {n.channel ? `#${n.channel}`:''}</div>
+          <div className="text-sm">{n.text}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/components/hud/skills/SkillShortcutsHUD.tsx
+++ b/web/components/hud/skills/SkillShortcutsHUD.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React, {useEffect, useState} from 'react'
+import { LIFE_TABLE, ACCOUNTS } from './tools'
+
+export default function SkillShortcutsHUD(){
+  const [open, setOpen] = useState(false)
+  const [q, setQ] = useState('')
+  useEffect(()=>{
+    const key=(e:KeyboardEvent)=> {
+      if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='k'){ e.preventDefault(); setOpen(o=>!o) }
+    }
+    window.addEventListener('keydown', key); return ()=> window.removeEventListener('keydown', key)
+  },[])
+  const life = LIFE_TABLE.filter(x=> x.keyword.includes(q))
+  const acs = ACCOUNTS.filter(a=> a.includes(q))
+
+  return (
+    <div className="pointer-events-none absolute top-1/2 right-2 -translate-y-1/2">
+      <div className={`pointer-events-auto transition-all ${open?'translate-x-0 opacity-100':'translate-x-4 opacity-0 pointer-events-none'}`}>
+        <div className="w-80 bg-white/90 backdrop-blur rounded-xl shadow p-3">
+          <input value={q} onChange={e=>setQ(e.target.value)} placeholder="キーワード…" className="w-full border rounded px-2 py-1 text-sm"/>
+          <div className="mt-2 text-xs text-gray-600">耐用年数</div>
+          {life.map(x=>(
+            <button key={x.keyword} className="block w-full text-left text-sm hover:bg-gray-100 px-2 py-1 rounded"
+              onClick={()=> window.dispatchEvent(new CustomEvent('skill:paste',{detail:`耐用年数:${x.years}年`}))}>
+              {x.keyword} → {x.years}年
+            </button>
+          ))}
+          <div className="mt-2 text-xs text-gray-600">勘定科目</div>
+          {acs.map(a=>(
+            <button key={a} className="block w-full text-left text-sm hover:bg-gray-100 px-2 py-1 rounded"
+              onClick={()=> window.dispatchEvent(new CustomEvent('skill:paste',{detail:a}))}>
+              {a}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/hud/skills/tools.ts
+++ b/web/components/hud/skills/tools.ts
@@ -1,0 +1,4 @@
+export const LIFE_TABLE = [
+  {keyword:'パソコン', years:4}, {keyword:'サーバー', years:5}
+]
+export const ACCOUNTS = ['消耗品費','減価償却費','通信費','旅費交通費']

--- a/web/components/hud/workmap/WorkMapHUD.tsx
+++ b/web/components/hud/workmap/WorkMapHUD.tsx
@@ -1,0 +1,26 @@
+'use client'
+import React, {useEffect, useState} from 'react'
+import { STAGES } from './stages'
+
+export default function WorkMapHUD(){
+  const [cur, setCur] = useState<string>(()=> localStorage.getItem('uibuilder.workStage') || STAGES[0].id)
+  useEffect(()=>{ localStorage.setItem('uibuilder.workStage', cur) },[cur])
+  const idx = STAGES.findIndex(s=> s.id===cur)
+  const pct = Math.round(((idx+1)/STAGES.length)*100)
+
+  return (
+    <div className="pointer-events-none absolute right-2 bottom-2">
+      <div className="pointer-events-auto bg-white/80 backdrop-blur rounded-xl shadow p-3 w-64">
+        <div className="text-xs text-gray-600 mb-1">業務マップ</div>
+        <div className="flex gap-1 flex-wrap">
+          {STAGES.map((s,i)=>(
+            <div key={s.id} className={`text-xs px-2 py-1 rounded ${i<=idx?'bg-blue-600 text-white':'bg-gray-100'}`}>{s.label}</div>
+          ))}
+        </div>
+        <div className="mt-2 h-1 bg-gray-200 rounded">
+          <div className="h-1 bg-blue-600 rounded" style={{width:`${pct}%`}}/>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/hud/workmap/stages.ts
+++ b/web/components/hud/workmap/stages.ts
@@ -1,0 +1,6 @@
+export const STAGES = [
+  {id:'design', label:'設計'},
+  {id:'build', label:'実装'},
+  {id:'review', label:'レビュー'},
+  {id:'ship', label:'公開'},
+]


### PR DESCRIPTION
## Summary
- overlay HUD bar toggles AR guide, progress map, skill shortcuts, EXP gauge, and notifications
- wrap app in HUDProvider and layer HUD over Canvas
- expose notification APIs in backend and dispatch EXP tick on publish

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c36abdfc832c838e71e05baef605