### PR TITLE
feat: add canvas viewport management

### DIFF
--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -5,6 +5,9 @@ import { registry } from '../lib/registry'
 import SelectionOverlay from './canvas/SelectionOverlay'
 import Viewport from './canvas/Viewport'
 import HUDContainer from './hud/HUDContainer'
+import { ViewportProvider } from './canvas/ViewportStore'
+import GridOverlay from './canvas/GridOverlay'
+import Rulers from './canvas/Rulers'
 
 function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
@@ -28,16 +31,20 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
 export default function Canvas() {
   const { tree } = useEditorState()
   return (
-    <div className="relative h-full w-full">
-      <Viewport>
-        <div className="relative w-[2000px] h-[2000px]">
-          {tree.map(n => (
-            <NodeRenderer key={n.id} node={n} />
-          ))}
-          <SelectionOverlay />
-        </div>
-      </Viewport>
-      <HUDContainer />
-    </div>
+    <ViewportProvider>
+      <div className="relative h-full w-full">
+        <Viewport>
+          <div className="relative w-[2000px] h-[2000px]">
+            {tree.map(n => (
+              <NodeRenderer key={n.id} node={n} />
+            ))}
+            <SelectionOverlay />
+          </div>
+        </Viewport>
+        <GridOverlay />
+        <Rulers />
+        <HUDContainer />
+      </div>
+    </ViewportProvider>
   )
 }

--- a/web/components/canvas/GridOverlay.tsx
+++ b/web/components/canvas/GridOverlay.tsx
@@ -1,0 +1,17 @@
+'use client'
+import React from 'react'
+import { useViewport } from './ViewportStore'
+export default function GridOverlay(){
+  const {vp} = useViewport()
+  if(!vp.showGrid) return null
+  const size = 8 * vp.zoom
+  const bg = `linear-gradient(to right, rgba(0,0,0,.06) 1px, transparent 1px),
+              linear-gradient(to bottom, rgba(0,0,0,.06) 1px, transparent 1px)`
+  return (
+    <div className="pointer-events-none absolute inset-0" style={{
+      backgroundImage:bg, backgroundSize:`${size}px ${size}px`,
+      transform:`translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`,
+      transformOrigin:'0 0'
+    }}/>
+  )
+}

--- a/web/components/canvas/Rulers.tsx
+++ b/web/components/canvas/Rulers.tsx
@@ -1,0 +1,24 @@
+'use client'
+import React from 'react'
+import { useViewport } from './ViewportStore'
+export default function Rulers(){
+  const {vp} = useViewport()
+  if(!vp.showRulers) return null
+  const size = 50 * vp.zoom
+  return (
+    <>
+      <div className="pointer-events-none absolute top-0 left-0 h-6 w-full bg-white/80 border-b" style={{
+        backgroundImage:'linear-gradient(to right, rgba(0,0,0,0.2) 1px, transparent 1px)',
+        backgroundSize:`${size}px 100%`,
+        transform:`translate(${vp.x}px,0)`,
+        transformOrigin:'0 0'
+      }}/>
+      <div className="pointer-events-none absolute top-0 left-0 w-6 h-full bg-white/80 border-r" style={{
+        backgroundImage:'linear-gradient(to bottom, rgba(0,0,0,0.2) 1px, transparent 1px)',
+        backgroundSize:`100% ${size}px`,
+        transform:`translate(0,${vp.y}px)`,
+        transformOrigin:'0 0'
+      }}/>
+    </>
+  )
+}

--- a/web/components/canvas/SnapManager.ts
+++ b/web/components/canvas/SnapManager.ts
@@ -1,0 +1,7 @@
+export type Rect={x:number;y:number;w:number;h:number}
+export function getSnapDelta(target:Rect, siblings:Rect[], grid=8){
+  // まずはグリッドにのみ吸着（シンプル版）
+  const dx = Math.round(target.x / grid)*grid - target.x
+  const dy = Math.round(target.y / grid)*grid - target.y
+  return {dx,dy}
+}

--- a/web/components/canvas/Viewport.tsx
+++ b/web/components/canvas/Viewport.tsx
@@ -1,10 +1,9 @@
 'use client'
 import React, { useRef, useState } from 'react'
+import { useViewport } from './ViewportStore'
 
 export default function Viewport({children}:{children:React.ReactNode}) {
-  const [scale, setScale] = useState(1)
-  const [tx, setTx] = useState(0)
-  const [ty, setTy] = useState(0)
+  const { vp, setZoom, panBy } = useViewport()
   const wrapRef = useRef<HTMLDivElement>(null)
   const [panning, setPanning] = useState(false)
   const [sx, setSx] = useState(0)
@@ -14,34 +13,33 @@ export default function Viewport({children}:{children:React.ReactNode}) {
     if (!e.ctrlKey) return
     e.preventDefault()
     const delta = -e.deltaY * 0.001
-    const next = Math.min(2, Math.max(0.25, scale * (1 + delta)))
+    const next = Math.min(4, Math.max(0.25, vp.zoom * (1 + delta)))
     const rect = wrapRef.current?.getBoundingClientRect()
     const cx = e.clientX - (rect?.left||0)
     const cy = e.clientY - (rect?.top||0)
-    setTx(cx - (cx - tx) * (next / scale))
-    setTy(cy - (cy - ty) * (next / scale))
-    setScale(next)
+    const nx = cx - (cx - vp.x) * (next / vp.zoom)
+    const ny = cy - (cy - vp.y) * (next / vp.zoom)
+    panBy(nx - vp.x, ny - vp.y)
+    setZoom(next)
   }
 
   const onMouseDown: React.MouseEventHandler = (e) => {
-    if ((e as any).buttons === 1 && (e.nativeEvent as any).buttons === 1 && (e as any).shiftKey === false && (e as any).altKey === false && (e as any).metaKey === false) {
-      if (!(e as any).nativeEvent.getModifierState('Space')) return
-      setPanning(true); setSx(e.clientX - tx); setSy(e.clientY - ty)
+    if (e.button === 1 || (e.button === 0 && (e.nativeEvent as any).getModifierState('Space'))) {
+      e.preventDefault()
+      setPanning(true); setSx(e.clientX - vp.x); setSy(e.clientY - vp.y)
     }
   }
   const onMouseMove: React.MouseEventHandler = (e) => {
     if (!panning) return
-    setTx(e.clientX - sx); setTy(e.clientY - sy)
+    const nx = e.clientX - sx
+    const ny = e.clientY - sy
+    panBy(nx - vp.x, ny - vp.y)
   }
   const onMouseUp = ()=> setPanning(false)
 
   return (
-    <div ref={wrapRef} className="relative h-full w-full overflow-hidden bg-[linear-gradient(90deg,rgba(0,0,0,0.03)_1px,transparent_1px),linear-gradient(0deg,rgba(0,0,0,0.03)_1px,transparent_1px)] bg-[length:8px_8px]" onWheel={onWheel} onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp}>
-      <div className="absolute left-0 top-0 h-6 w-full bg-white/80 backdrop-blur border-b text-[10px] flex items-end">
-        <div className="px-2">scale:{(scale*100)|0}%</div>
-      </div>
-      <div className="absolute top-0 left-0 w-6 h-full bg-white/80 backdrop-blur border-r" />
-      <div className="absolute inset-0" style={{ transform:`translate(${tx}px, ${ty}px) scale(${scale})`, transformOrigin:'0 0' }}>
+    <div ref={wrapRef} className="relative h-full w-full overflow-hidden" onWheel={onWheel} onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp} onMouseLeave={onMouseUp}>
+      <div className="absolute inset-0" style={{ transform:`translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`, transformOrigin:'0 0' }}>
         {children}
       </div>
     </div>

--- a/web/components/canvas/ViewportStore.tsx
+++ b/web/components/canvas/ViewportStore.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React,{createContext,useContext,useState} from 'react'
+type VP = { zoom:number; x:number; y:number; showGrid:boolean; showRulers:boolean; snapOn:boolean }
+const Ctx = createContext<{
+  vp:VP; setZoom:(z:number)=>void; panBy:(dx:number,dy:number)=>void;
+  toggle:(k:'showGrid'|'showRulers'|'snapOn')=>void;
+} | null>(null)
+export const ViewportProvider:React.FC<{children:React.ReactNode}> = ({children})=>{
+  const [vp,set] = useState<VP>({zoom:1,x:0,y:0,showGrid:false,showRulers:false,snapOn:true})
+  const setZoom = (z:number)=> set(s=>({...s, zoom:Math.min(4,Math.max(0.25,z))}))
+  const panBy = (dx:number,dy:number)=> set(s=>({...s, x:s.x+dx, y:s.y+dy}))
+  const toggle = (k:any)=> set(s=>({...s,[k]:!s[k]}))
+  return <Ctx.Provider value={{vp,setZoom,panBy,toggle}}>{children}</Ctx.Provider>
+}
+export const useViewport = ()=>{ const c=useContext(Ctx); if(!c) throw new Error('vp'); return c }


### PR DESCRIPTION
## Summary
- introduce viewport context for zoom, pan and display toggles
- add grid and ruler overlays and snap utility
- update canvas to wrap provider and apply viewport transforms

## Testing
- `npm test` (no test script)
- `npm test` (root)


------
https://chatgpt.com/codex/tasks/task_e_68a6c5a0e460832cb1c563a7e15402cc