### PR TITLE
feat: add smart guides and snapping

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -85,7 +85,7 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
   const children = node.children?.map((c) => (
     <NodeRenderer key={c.id} node={c} previewHover={previewHover} />
   ));
-  return React.createElement(Comp as any, props, children);
+  return React.createElement(Comp as any, { ...props, 'data-node-id': node.id }, children);
 };
 
 interface PageRendererProps {

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useEditorState, useEditorActions, ComponentNode } from './store'
 import { registry } from '../lib/registry'
 import SelectionOverlay from './canvas/SelectionOverlay'
@@ -8,13 +8,31 @@ import HUDContainer from './hud/HUDContainer'
 import { ViewportProvider } from './canvas/ViewportStore'
 import GridOverlay from './canvas/GridOverlay'
 import Rulers from './canvas/Rulers'
+import { RectsProvider, useRects } from './canvas/RectsStore'
+import SmartGuidesOverlay from './canvas/SmartGuidesOverlay'
+import type { Guide } from './canvas/snap'
 
 function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
+  const { setRect } = useRects()
+  const ref = useRef<HTMLDivElement>(null)
   const Comp = (registry as any)[node.type] || ((p:any)=><div {...p}>{p.children}</div>)
   const style = node.props?.style || {}
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const root = el.closest('[data-canvas-root]') as HTMLElement | null
+    const r = el.getBoundingClientRect()
+    const base = root?.getBoundingClientRect()
+    const x = base ? r.left - base.left : r.left
+    const y = base ? r.top - base.top : r.top
+    setRect(node.id, { x, y, w: r.width, h: r.height })
+  })
+
   return (
     <div
+      ref={ref}
       data-node-id={node.id}
       style={{ position: 'absolute', ...style }}
       onMouseDown={e => { e.stopPropagation(); selectComponent(node.id) }}
@@ -30,21 +48,25 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
 
 export default function Canvas() {
   const { tree } = useEditorState()
+  const [guides, setGuides] = useState<Guide[]>([])
   return (
     <ViewportProvider>
-      <div className="relative h-full w-full">
-        <Viewport>
-          <div className="relative w-[2000px] h-[2000px]">
-            {tree.map(n => (
-              <NodeRenderer key={n.id} node={n} />
-            ))}
-            <SelectionOverlay />
-          </div>
-        </Viewport>
-        <GridOverlay />
-        <Rulers />
-        <HUDContainer />
-      </div>
+      <RectsProvider>
+        <div className="relative h-full w-full">
+          <Viewport>
+            <div data-canvas-root className="relative w-[2000px] h-[2000px]">
+              {tree.map(n => (
+                <NodeRenderer key={n.id} node={n} />
+              ))}
+              <SelectionOverlay setGuides={setGuides} />
+            </div>
+          </Viewport>
+          <GridOverlay />
+          <Rulers />
+          <HUDContainer />
+          <SmartGuidesOverlay guides={guides} />
+        </div>
+      </RectsProvider>
     </ViewportProvider>
   )
 }

--- a/web/components/canvas/RectsStore.tsx
+++ b/web/components/canvas/RectsStore.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React,{createContext,useContext,useRef,useState,useEffect} from 'react'
+export type R = {x:number;y:number;w:number;h:number}
+type MapT = Record<string,R>
+const Ctx = createContext<{
+  rects:MapT; setRect:(id:string, r:R)=>void
+} | null>(null)
+export const RectsProvider:React.FC<{children:React.ReactNode}> = ({children})=>{
+  const [rects,setRects] = useState<MapT>({})
+  const setRect = (id:string, r:R)=> setRects(m=>({...m,[id]:r}))
+  return <Ctx.Provider value={{rects,setRect}}>{children}</Ctx.Provider>
+}
+export const useRects = ()=>{const c=useContext(Ctx); if(!c) throw new Error('rects'); return c}

--- a/web/components/canvas/SelectionOverlay.tsx
+++ b/web/components/canvas/SelectionOverlay.tsx
@@ -1,71 +1,41 @@
 'use client'
-import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { useEditorState, useEditorActions } from '../store'
-import { useNodeBounds } from './useNodeBounds'
+import { useRects } from './RectsStore'
+import { getSmartSnap, Guide } from './snap'
 
 const GRID = 8
 const snap = (v:number)=> Math.round(v/GRID)*GRID
-
-interface GuideLine { x?:number,y?:number,x1?:number,x2?:number,y1?:number,y2?:number }
 
 type DragState = { dx:number, dy:number }
 
 type ResizeState = { dir:string, startX:number, startY:number, startW:number, startH:number, startLeft:number, startTop:number }
 
-export default function SelectionOverlay() {
-  const { selectedComponentId } = useEditorState()
+function findNode(nodes:any[], id:string):any|null{
+  for(const n of nodes){
+    if(n.id===id) return n
+    if(n.children){ const f=findNode(n.children,id); if(f) return f }
+  }
+  return null
+}
+
+export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>void}) {
+  const { selectedComponentId, tree } = useEditorState()
   const { setProp } = useEditorActions() as any
-  const { rectFor, siblingRects } = useNodeBounds()
-  const rect = selectedComponentId ? rectFor(selectedComponentId) : null
+  const { rects } = useRects()
+  const rect = selectedComponentId ? rects[selectedComponentId] : null
+  const node = selectedComponentId ? findNode(tree, selectedComponentId) : null
+  const siblings = selectedComponentId ? Object.entries(rects).filter(([id])=>id!==selectedComponentId).map(([,r])=>r) : []
   const overlayRef = useRef<HTMLDivElement>(null)
   const [drag, setDrag] = useState<DragState|null>(null)
   const [resize, setResize] = useState<ResizeState|null>(null)
+  const style = node?.props?.style || {}
 
-  // convert rect/sibling rects to container relative
   const containerRect = overlayRef.current?.getBoundingClientRect()
-  const relRect = rect && containerRect ? {
-    ...rect,
-    left: rect.left - containerRect.left,
-    top: rect.top - containerRect.top,
-    right: rect.right - containerRect.left,
-    bottom: rect.bottom - containerRect.top
-  } : rect
-
-  const siblings = useMemo(()=>{
-    if(!selectedComponentId) return [] as DOMRect[]
-    const sibs = siblingRects(selectedComponentId)
-    if(containerRect) return sibs.map(r=>({
-      left:r.left-containerRect.left,
-      top:r.top-containerRect.top,
-      right:r.right-containerRect.left,
-      bottom:r.bottom-containerRect.top,
-      width:r.width,
-      height:r.height
-    } as DOMRect))
-    return sibs
-  },[selectedComponentId, siblingRects, containerRect])
-
-  // guides
-  const guides = useMemo<GuideLine[]>(() => {
-    if (!relRect || !selectedComponentId) return []
-    const g:GuideLine[] = []
-    const near = (a:number,b:number)=> Math.abs(a-b)<=4
-    for (const r of siblings) {
-      if (near(relRect.left, r.left)) g.push({x: r.left, y1: Math.min(relRect.top,r.top), y2: Math.max(relRect.bottom,r.bottom)})
-      if (near(relRect.right, r.right)) g.push({x: r.right, y1: Math.min(relRect.top,r.top), y2: Math.max(relRect.bottom,r.bottom)})
-      if (near(relRect.top, r.top)) g.push({y: r.top, x1: Math.min(relRect.left,r.left), x2: Math.max(relRect.right,r.right)})
-      if (near(relRect.bottom, r.bottom)) g.push({y: r.bottom, x1: Math.min(relRect.left,r.left), x2: Math.max(relRect.right,r.right)})
-      const cx1=(relRect.left+relRect.right)/2, cx2=(r.left+r.right)/2
-      const cy1=(relRect.top+relRect.bottom)/2, cy2=(r.top+r.bottom)/2
-      if (near(cx1,cx2)) g.push({x: cx2, y1: Math.min(relRect.top,r.top), y2: Math.max(relRect.bottom,r.bottom)})
-      if (near(cy1,cy2)) g.push({y: cy2, x1: Math.min(relRect.left,r.left), x2: Math.max(relRect.right,r.right)})
-    }
-    return g
-  }, [relRect, siblings, selectedComponentId])
 
   // keyboard move
   useEffect(()=>{
-    if(!selectedComponentId || !relRect) return
+    if(!selectedComponentId || !rect) return
     const handler = (e:KeyboardEvent) => {
       const map:{[k:string]:[number,number]} = {
         ArrowLeft:[-1,0], ArrowRight:[1,0], ArrowUp:[0,-1], ArrowDown:[0,1]
@@ -74,39 +44,42 @@ export default function SelectionOverlay() {
       e.preventDefault()
       const mult = e.shiftKey ? 10 : 1
       const [dx,dy]=map[e.key].map(v=>v*mult) as [number,number]
-      const left = snap(relRect.left + dx)
-      const top = snap(relRect.top + dy)
-      setProp(selectedComponentId, 'style', { ...(rect?.style||{}), position:'absolute', left, top })
+      const left = snap((rect.x||0) + dx)
+      const top = snap((rect.y||0) + dy)
+      setProp(selectedComponentId, 'style', { ...style, position:'absolute', left, top })
     }
     window.addEventListener('keydown', handler)
     return ()=> window.removeEventListener('keydown', handler)
-  },[selectedComponentId, relRect, rect, setProp])
+  },[selectedComponentId, rect, style, setProp])
 
   const startDrag = (e:React.MouseEvent) => {
-    if(!relRect) return
+    if(!rect) return
     e.stopPropagation()
-    setDrag({dx: e.clientX - relRect.left - (containerRect?.left||0), dy: e.clientY - relRect.top - (containerRect?.top||0)})
+    setDrag({dx: e.clientX - rect.x - (containerRect?.left||0), dy: e.clientY - rect.y - (containerRect?.top||0)})
   }
 
   const startResize = (dir:string)=>(e:React.MouseEvent)=>{
-    if(!relRect) return
+    if(!rect) return
     e.stopPropagation()
     setResize({
       dir,
       startX: e.clientX,
       startY: e.clientY,
-      startW: relRect.width,
-      startH: relRect.height,
-      startLeft: relRect.left,
-      startTop: relRect.top
+      startW: rect.w,
+      startH: rect.h,
+      startLeft: rect.x,
+      startTop: rect.y
     })
   }
 
   const onMouseMove = useCallback((ev:MouseEvent)=>{
-    if(drag && selectedComponentId){
-      const left = snap(ev.clientX - drag.dx - (containerRect?.left||0))
-      const top  = snap(ev.clientY - drag.dy - (containerRect?.top||0))
-      setProp(selectedComponentId, 'style', { ...(rect?.style||{}), position:'absolute', left, top })
+    if(drag && selectedComponentId && rect){
+      let left = ev.clientX - drag.dx - (containerRect?.left||0)
+      let top  = ev.clientY - drag.dy - (containerRect?.top||0)
+      const {dx,dy,guides} = getSmartSnap({x:left,y:top,w:rect.w,h:rect.h}, siblings)
+      left += dx; top += dy
+      setGuides(guides)
+      setProp(selectedComponentId, 'style', { ...style, position:'absolute', left, top })
     } else if(resize && selectedComponentId){
       let {startX,startY,startW,startH,startLeft,startTop,dir}=resize
       let dx = ev.clientX - startX
@@ -116,13 +89,13 @@ export default function SelectionOverlay() {
       if(dir.includes('s')) height = snap(startH + dy)
       if(dir.includes('w')){ width = snap(startW - dx); left = snap(startLeft + dx) }
       if(dir.includes('n')){ height = snap(startH - dy); top = snap(startTop + dy) }
-      setProp(selectedComponentId, 'style', { ...(rect?.style||{}), position:'absolute', left, top, width, height })
+      setProp(selectedComponentId, 'style', { ...style, position:'absolute', left, top, width, height })
     }
-  },[drag, resize, selectedComponentId, rect, setProp, containerRect])
+  },[drag, resize, selectedComponentId, rect, setProp, containerRect, siblings, setGuides, style])
 
   const stopAll = useCallback(()=>{
-    setDrag(null); setResize(null)
-  },[])
+    setDrag(null); setResize(null); setGuides([])
+  },[setGuides])
 
   useEffect(()=>{
     if(drag||resize){
@@ -132,33 +105,29 @@ export default function SelectionOverlay() {
     }
   },[drag, resize, onMouseMove, stopAll])
 
-  if (!relRect) return null
+  if (!rect) return null
 
   const handlePos = [
-    {dir:'nw', style:{left:relRect.left, top:relRect.top}},
-    {dir:'n', style:{left:relRect.left+relRect.width/2, top:relRect.top}},
-    {dir:'ne', style:{left:relRect.right, top:relRect.top}},
-    {dir:'e', style:{left:relRect.right, top:relRect.top+relRect.height/2}},
-    {dir:'se', style:{left:relRect.right, top:relRect.bottom}},
-    {dir:'s', style:{left:relRect.left+relRect.width/2, top:relRect.bottom}},
-    {dir:'sw', style:{left:relRect.left, top:relRect.bottom}},
-    {dir:'w', style:{left:relRect.left, top:relRect.top+relRect.height/2}}
+    {dir:'nw', style:{left:rect.x, top:rect.y}},
+    {dir:'n', style:{left:rect.x+rect.w/2, top:rect.y}},
+    {dir:'ne', style:{left:rect.x+rect.w, top:rect.y}},
+    {dir:'e', style:{left:rect.x+rect.w, top:rect.y+rect.h/2}},
+    {dir:'se', style:{left:rect.x+rect.w, top:rect.y+rect.h}},
+    {dir:'s', style:{left:rect.x+rect.w/2, top:rect.y+rect.h}},
+    {dir:'sw', style:{left:rect.x, top:rect.y+rect.h}},
+    {dir:'w', style:{left:rect.x, top:rect.y+rect.h/2}}
   ]
 
   return (
     <div className="pointer-events-none absolute inset-0 z-20" ref={overlayRef}>
       <div
         className="pointer-events-auto border-2 border-blue-500"
-        style={{position:'absolute', left:relRect.left, top:relRect.top, width:relRect.width, height:relRect.height}}
+        style={{position:'absolute', left:rect.x, top:rect.y, width:rect.w, height:rect.h}}
         onMouseDown={startDrag}
       />
       {handlePos.map(h=> (
         <div key={h.dir} className="absolute w-2 h-2 bg-white border border-blue-500 rounded-full pointer-events-auto" style={{left:h.style.left-4, top:h.style.top-4, cursor:h.dir+'-resize'}} onMouseDown={startResize(h.dir)} />
       ))}
-      {guides.map((g,i)=> g.x!=null
-        ? <div key={i} className="absolute w-px bg-red-500/60" style={{left:g.x, top:g.y1, height:(g.y2!-g.y1!)}}/>
-        : <div key={i} className="absolute h-px bg-red-500/60" style={{top:g.y, left:g.x1, width:(g.x2!-g.x1!)}}/>
-      )}
     </div>
   )
 }

--- a/web/components/canvas/SmartGuidesOverlay.tsx
+++ b/web/components/canvas/SmartGuidesOverlay.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+import type { Guide } from './snap'
+export default function SmartGuidesOverlay({guides}:{guides?:Guide[]}) {
+  if(!guides?.length) return null
+  return (
+    <svg className="pointer-events-none absolute inset-0 z-40">
+      {guides.map((g,i)=> g.type==='v'
+        ? <line key={i} x1={g.pos} x2={g.pos} y1={g.from} y2={g.to} stroke="#ef4444" strokeWidth="1.5"/>
+        : <line key={i} y1={g.pos} y2={g.pos} x1={g.from} x2={g.to} stroke="#ef4444" strokeWidth="1.5"/> )}
+    </svg>
+  )
+}

--- a/web/components/canvas/snap.ts
+++ b/web/components/canvas/snap.ts
@@ -1,0 +1,34 @@
+import type { R } from './RectsStore'
+export type Guide = { type:'v'|'h'; pos:number; from:number; to:number }
+export function getSmartSnap(target:R, others:R[], grid=8, tol=6){
+  // 1) grid snap
+  const gdx = Math.round(target.x/grid)*grid - target.x
+  const gdy = Math.round(target.y/grid)*grid - target.y
+  let dx=gdx, dy=gdy
+  const guides:Guide[]=[]
+  const tCenterX = target.x + target.w/2
+  const tCenterY = target.y + target.h/2
+  const candidatesX:number[] = [], candidatesY:number[] = []
+  others.forEach(o=>{
+    candidatesX.push(o.x, o.x+o.w, o.x+o.w/2)
+    candidatesY.push(o.y, o.y+o.h, o.y+o.h/2)
+  })
+  // 2) edge/center snap (closest within tol)
+  const best = (arr:number[], val:number)=> {
+    let d=Infinity, p=val; for(const v of arr){ const dd=Math.abs(v-val); if(dd<d){d=dd;p=v} }
+    return {d,p}
+  }
+  const bx1 = best(candidatesX, target.x)
+  const bx2 = best(candidatesX, target.x+target.w)
+  const bxc = best(candidatesX, tCenterX)
+  const by1 = best(candidatesY, target.y)
+  const by2 = best(candidatesY, target.y+target.h)
+  const byc = best(candidatesY, tCenterY)
+  if(bx1.d<tol){ dx = (bx1.p - target.x); guides.push({type:'v',pos:bx1.p,from:target.y-2000,to:target.y+target.h+2000}) }
+  else if(bx2.d<tol){ dx = (bx2.p - (target.x+target.w)); guides.push({type:'v',pos:bx2.p,from:target.y-2000,to:target.y+target.h+2000}) }
+  else if(bxc.d<tol){ dx = (bxc.p - tCenterX); guides.push({type:'v',pos:bxc.p,from:target.y-2000,to:target.y+target.h+2000}) }
+  if(by1.d<tol){ dy = (by1.p - target.y); guides.push({type:'h',pos:by1.p,from:target.x-2000,to:target.x+target.w+2000}) }
+  else if(by2.d<tol){ dy = (by2.p - (target.y+target.h)); guides.push({type:'h',pos:by2.p,from:target.x-2000,to:target.x+target.w+2000}) }
+  else if(byc.d<tol){ dy = (byc.p - tCenterY); guides.push({type:'h',pos:byc.p,from:target.x-2000,to:target.x+target.w+2000}) }
+  return {dx,dy,guides}
+}


### PR DESCRIPTION
## Summary
- collect DOM rects for canvas nodes and expose via RectsStore
- implement smart snapping with visual guides for edges, centers and grid
- integrate SmartGuidesOverlay and snapping into canvas selection handling

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d08d5878832cbf68e7d23a8b5507