### PR TITLE
feat: basic auto layout support

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -2,6 +2,75 @@
 import { useEditorStore } from '@/store/editorStore';
 import SelectionBox from './SelectionBox';
 import ResizeHandles from './ResizeHandles';
+import type { ComponentNode } from '@/types/editor';
+import { sizeStyle } from '@/lib/flex';
+
+function NodeView({
+  node,
+  parentLayout,
+  parentAxis,
+}: {
+  node: ComponentNode;
+  parentLayout?: string;
+  parentAxis?: 'horizontal' | 'vertical';
+}) {
+  const style: any = {};
+  const layout = node.props?.layout || 'free';
+  if (layout === 'auto') {
+    style.display = 'flex';
+    style.flexDirection = node.props?.axis === 'horizontal' ? 'row' : 'column';
+    if (node.props?.gap !== undefined) style.gap = node.props.gap;
+    if (node.props?.padding !== undefined) {
+      const p = node.props.padding;
+      if (typeof p === 'number') style.padding = p;
+      else
+        style.padding = `${p.top}px ${p.right}px ${p.bottom}px ${p.left}px`;
+    }
+    if (node.props?.alignItems) style.alignItems = node.props.alignItems;
+    if (node.props?.justifyContent)
+      style.justifyContent = node.props.justifyContent;
+    if (node.props?.wrap) style.flexWrap = 'wrap';
+  } else {
+    style.position = parentLayout === 'auto' ? 'absolute' : 'absolute';
+    style.left = node.props?.x || 0;
+    style.top = node.props?.y || 0;
+    Object.assign(style, sizeStyle(node, parentAxis));
+  }
+
+  if (layout === 'auto') {
+    return (
+      <div
+        className="border border-gray-700 text-xs text-white"
+        style={style}
+      >
+        {node.children?.map((c) => (
+          <NodeView
+            key={c.id}
+            node={c}
+            parentLayout={layout}
+            parentAxis={node.props?.axis}
+          />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div
+      className="border border-gray-700 text-xs text-white"
+      style={style}
+    >
+      {node.type}
+      {node.children?.map((c) => (
+        <NodeView
+          key={c.id}
+          node={c}
+          parentLayout={layout}
+          parentAxis={node.props?.axis}
+        />
+      ))}
+    </div>
+  );
+}
 
 export default function CanvasStage() {
   const tree = useEditorStore((s) => s.tree);
@@ -9,18 +78,7 @@ export default function CanvasStage() {
   return (
     <div className="relative bg-gray-900 overflow-hidden">
       {tree.map((n) => (
-        <div
-          key={n.id}
-          className="absolute border border-gray-700 text-xs text-white"
-          style={{
-            left: n.props?.x || 0,
-            top: n.props?.y || 0,
-            width: n.props?.w || 0,
-            height: n.props?.h || 0,
-          }}
-        >
-          {n.type}
-        </div>
+        <NodeView key={n.id} node={n} />
       ))}
       {selected.length === 1 && <SelectionBox />}
       {selected.length === 1 && <ResizeHandles />}

--- a/web/components/editor/LeftPanel.tsx
+++ b/web/components/editor/LeftPanel.tsx
@@ -3,12 +3,29 @@ import { useEditorStore } from '@/store/editorStore';
 
 export default function LeftPanel() {
   const tree = useEditorStore((s) => s.tree);
+  const reorder = useEditorStore((s) => s.reorderChild);
+
+  const handleDragStart = (e: React.DragEvent<HTMLLIElement>, idx: number) => {
+    e.dataTransfer.setData('text/plain', String(idx));
+  };
+  const handleDrop = (e: React.DragEvent<HTMLLIElement>, idx: number) => {
+    const from = Number(e.dataTransfer.getData('text/plain'));
+    reorder('', from, idx);
+  };
+
   return (
     <div className="bg-gray-800 p-2 overflow-y-auto">
       <h2 className="text-sm mb-2">Layers</h2>
       <ul className="space-y-1">
-        {tree.map((n) => (
-          <li key={n.id} className="text-xs">
+        {tree.map((n, i) => (
+          <li
+            key={n.id}
+            className="text-xs"
+            draggable
+            onDragStart={(e) => handleDragStart(e, i)}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => handleDrop(e, i)}
+          >
             {n.name || n.type}
           </li>
         ))}

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -8,6 +8,7 @@ export default function RightInspector() {
     s.tree.find((n) => n.id === s.selectedIds[0])
   );
   const update = useEditorStore((s) => s.updateNode);
+  const setLayout = useEditorStore((s) => s.setLayoutProps);
   const [form, setForm] = useState({
     x: node?.props?.x || 0,
     y: node?.props?.y || 0,
@@ -37,6 +38,36 @@ export default function RightInspector() {
           />
         </label>
       ))}
+      <div className="mt-2 space-y-1">
+        <label className="block text-xs">
+          Layout:
+          <select
+            className="w-full bg-gray-700 ml-1 p-1 text-white"
+            value={node?.props?.layout || 'free'}
+            onChange={(e) =>
+              setLayout(selected, { layout: e.target.value as any })
+            }
+          >
+            <option value="free">Free</option>
+            <option value="auto">Auto</option>
+          </select>
+        </label>
+        {node?.props?.layout === 'auto' && (
+          <label className="block text-xs">
+            Direction:
+            <select
+              className="w-full bg-gray-700 ml-1 p-1 text-white"
+              value={node?.props?.axis || 'vertical'}
+              onChange={(e) =>
+                setLayout(selected, { axis: e.target.value as any })
+              }
+            >
+              <option value="horizontal">Row</option>
+              <option value="vertical">Column</option>
+            </select>
+          </label>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/lib/flex.ts
+++ b/web/lib/flex.ts
@@ -1,0 +1,32 @@
+import type { ComponentNode } from '@/types/editor';
+
+export function sizeStyle(
+  node: ComponentNode,
+  parentAxis: 'horizontal' | 'vertical' | undefined
+) {
+  const style: any = {};
+  const p = node.props || {};
+  switch (p.widthMode) {
+    case 'FILL':
+      if (parentAxis === 'horizontal') style.flex = '1 1 auto';
+      else style.width = '100%';
+      break;
+    case 'HUG':
+      style.width = 'fit-content';
+      break;
+    default:
+      if (p.w !== undefined) style.width = p.w;
+  }
+  switch (p.heightMode) {
+    case 'FILL':
+      if (parentAxis === 'vertical') style.flex = '1 1 auto';
+      else style.height = '100%';
+      break;
+    case 'HUG':
+      style.height = 'fit-content';
+      break;
+    default:
+      if (p.h !== undefined) style.height = p.h;
+  }
+  return style;
+}

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -6,7 +6,9 @@ export type Command =
   | 'delete'
   | 'duplicate'
   | 'undo'
-  | 'redo';
+  | 'redo'
+  | 'makeAutoLayout'
+  | 'removeAutoLayout';
 
 const map: Record<string, Command> = {
   KeyV: 'select',
@@ -23,6 +25,8 @@ export function getCommand(e: KeyboardEvent): Command | undefined {
     if (e.code === 'KeyD') return 'duplicate';
     if (e.code === 'KeyZ' && e.shiftKey) return 'redo';
     if (e.code === 'KeyZ') return 'undo';
+    if (e.code === 'KeyA' && e.shiftKey) return 'removeAutoLayout';
   }
+  if (e.code === 'KeyA' && e.shiftKey) return 'makeAutoLayout';
   return map[e.code];
 }

--- a/web/lib/measure.ts
+++ b/web/lib/measure.ts
@@ -1,0 +1,3 @@
+export function measureHug(el: HTMLElement) {
+  return { width: el.offsetWidth, height: el.offsetHeight };
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -1,7 +1,11 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { produceWithPatches } from 'immer';
-import type { EditorState, ComponentNode } from '@/types/editor';
+import type {
+  EditorState,
+  ComponentNode,
+  SizeMode,
+} from '@/types/editor';
 import { idbStorage } from '@/lib/idb';
 import { push, undo as undoStack, redo as redoStack } from './undoRedo';
 
@@ -15,6 +19,19 @@ interface EditorActions {
   remove: (ids?: string[]) => void;
   undo: () => void;
   redo: () => void;
+  makeAutoLayout: (frameId?: string) => void;
+  removeAutoLayout: (frameId?: string) => void;
+  reorderChild: (parentId: string, from: number, to: number) => void;
+  setLayoutProps: (
+    id: string,
+    patch: Partial<NonNullable<ComponentNode['props']>>
+  ) => void;
+  setSizeMode: (
+    id: string,
+    axis: 'w' | 'h',
+    mode: SizeMode,
+    value?: number
+  ) => void;
 }
 
 function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
@@ -110,6 +127,61 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             draft.selectedIds = [];
           });
         },
+        makeAutoLayout(frameId) {
+          apply((draft) => {
+            const target = frameId
+              ? findNode(draft.tree, frameId)
+              : findNode(draft.tree, draft.selectedIds[0]);
+            if (target) {
+              target.props = target.props || {};
+              target.props.layout = 'auto';
+              if (!target.props.axis) target.props.axis = 'vertical';
+            }
+          });
+        },
+        removeAutoLayout(frameId) {
+          apply((draft) => {
+            const target = frameId
+              ? findNode(draft.tree, frameId)
+              : findNode(draft.tree, draft.selectedIds[0]);
+            if (target && target.props) {
+              target.props.layout = 'free';
+            }
+          });
+        },
+        reorderChild(parentId, from, to) {
+          apply((draft) => {
+            const parent = parentId
+              ? findNode(draft.tree, parentId)
+              : ({ children: draft.tree } as ComponentNode);
+            if (parent && parent.children) {
+              const c = parent.children.splice(from, 1)[0];
+              parent.children.splice(to, 0, c);
+            }
+          });
+        },
+        setLayoutProps(id, patch) {
+          apply((draft) => {
+            const node = findNode(draft.tree, id);
+            if (node) {
+              node.props = { ...(node.props || {}), ...patch };
+            }
+          });
+        },
+        setSizeMode(id, axis, mode, value) {
+          apply((draft) => {
+            const node = findNode(draft.tree, id);
+            if (!node) return;
+            node.props = node.props || {};
+            if (axis === 'w') {
+              node.props.widthMode = mode;
+              if (mode === 'FIXED' && value !== undefined) node.props.w = value;
+            } else {
+              node.props.heightMode = mode;
+              if (mode === 'FIXED' && value !== undefined) node.props.h = value;
+            }
+          });
+        },
         undo() {
           set((state) => undoStack(state));
         },
@@ -121,7 +193,20 @@ export const useEditorStore = create<EditorState & EditorActions>()(
     {
       name: 'uibuilder:editor',
       storage: createJSONStorage(() => idbStorage),
-      version: 3,
+      version: 4,
+      migrate: (persisted, version) => {
+        if (version < 4 && persisted) {
+          const setLayout = (nodes: ComponentNode[]) => {
+            nodes.forEach((n) => {
+              n.props = n.props || {};
+              if (!n.props.layout) n.props.layout = 'free';
+              if (n.children) setLayout(n.children);
+            });
+          };
+          setLayout((persisted as EditorState).tree);
+        }
+        return persisted;
+      },
     }
   )
 );

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -1,3 +1,8 @@
 .canvas-stage {
   cursor: default;
 }
+
+.hug {
+  width: fit-content;
+  height: fit-content;
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -1,8 +1,37 @@
+export type LayoutMode = 'free' | 'auto';
+export type Axis = 'horizontal' | 'vertical';
+export type SizeMode = 'HUG' | 'FIXED' | 'FILL';
+
 export interface ComponentNode {
   id: string;
   type: string; // 'Frame' | 'Rect' | 'Text' | 'Button' etc
   name?: string;
-  props?: Record<string, any>; // x,y,w,h,rotation,style etc
+  props?: {
+    x?: number;
+    y?: number;
+    w?: number;
+    h?: number;
+    rotation?: number;
+    layout?: LayoutMode;
+    axis?: Axis;
+    gap?: number;
+    padding?: number | { top: number; right: number; bottom: number; left: number };
+    alignItems?: 'start' | 'center' | 'end' | 'stretch';
+    justifyContent?:
+      | 'start'
+      | 'center'
+      | 'end'
+      | 'space-between'
+      | 'space-around'
+      | 'space-evenly';
+    wrap?: boolean;
+    widthMode?: SizeMode;
+    heightMode?: SizeMode;
+    minW?: number;
+    minH?: number;
+    maxW?: number;
+    maxH?: number;
+  };
   bindings?: Record<string, PropBinding>;
   variants?: {
     hover?: { className?: string };


### PR DESCRIPTION
## Summary
- extend node types and store with auto layout properties and actions
- render flex-based frames and simple inspector controls
- add drag-and-drop reordering and flex utilities

## Testing
- `npm test` *(no tests found)*
- `npx tsc -p web/tsconfig.json --noEmit` *(fails: JSX element 'div' has no corresponding closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2ad7230832c9c68492705febe9f