### PR TITLE
feat: implement basic component instances with variants

### DIFF
--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -1,24 +1,46 @@
 'use client';
 import { useEditorStore } from '@/store/editorStore';
-import type { ComponentNode } from '@/types/editor';
+import type { ComponentNode, InstanceNode } from '@/types/editor';
+import { resolveVariant } from '@/lib/variantResolver';
+import { applyOverrides } from '@/lib/overrideMerge';
 
-function renderNode(node: ComponentNode) {
+function renderNode(
+  node: ComponentNode,
+  components: Record<string, any>
+): JSX.Element {
+  if (node.type === 'Instance') {
+    const inst = node as InstanceNode;
+    const def = components[inst.componentId];
+    if (def) {
+      let resolved = resolveVariant(def, inst.variant);
+      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+      resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
+      return renderNode(resolved, components);
+    }
+  }
   const style: React.CSSProperties = {
     position: 'absolute',
     left: node.props?.x || 0,
     top: node.props?.y || 0,
     width: node.props?.w || 0,
     height: node.props?.h || 0,
-    transform: `rotate(${node.props?.rotation || 0}deg)`
+    transform: `rotate(${node.props?.rotation || 0}deg)`,
   };
+  if (node.props?.visible === false) style.display = 'none';
   return (
     <div key={node.id} style={style} className={node.props?.className}>
-      {node.children?.map(renderNode)}
+      {node.props?.text}
+      {node.children?.map((c) => renderNode(c, components))}
     </div>
   );
 }
 
 export default function PreviewPage() {
   const tree = useEditorStore((s) => s.tree);
-  return <div className="relative w-full h-full">{tree.map(renderNode)}</div>;
+  const components = useEditorStore((s) => s.components);
+  return (
+    <div className="relative w-full h-full">
+      {tree.map((n) => renderNode(n, components))}
+    </div>
+  );
 }

--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -2,20 +2,42 @@
 import { useEditorStore } from '@/store/editorStore';
 import SelectionBox from './SelectionBox';
 import ResizeHandles from './ResizeHandles';
-import type { ComponentNode } from '@/types/editor';
+import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
+import { resolveVariant } from '@/lib/variantResolver';
+import { applyOverrides } from '@/lib/overrideMerge';
 
 function NodeView({
   node,
+  components,
   parentLayout,
   parentAxis,
 }: {
   node: ComponentNode;
+  components: Record<string, any>;
   parentLayout?: string;
   parentAxis?: 'horizontal' | 'vertical';
 }) {
+  if (node.type === 'Instance') {
+    const inst = node as InstanceNode;
+    const def = components[inst.componentId];
+    if (def) {
+      let resolved = resolveVariant(def, inst.variant);
+      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+      resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
+      return (
+        <NodeView
+          node={resolved}
+          components={components}
+          parentLayout={parentLayout}
+          parentAxis={parentAxis}
+        />
+      );
+    }
+  }
   const style: any = {};
   const layout = node.props?.layout || 'free';
+  if (node.props?.visible === false) style.display = 'none';
   if (layout === 'auto') {
     style.display = 'flex';
     style.flexDirection = node.props?.axis === 'horizontal' ? 'row' : 'column';
@@ -43,10 +65,12 @@ function NodeView({
         className="border border-gray-700 text-xs text-white"
         style={style}
       >
+        {node.props?.text}
         {node.children?.map((c) => (
           <NodeView
             key={c.id}
             node={c}
+            components={components}
             parentLayout={layout}
             parentAxis={node.props?.axis}
           />
@@ -59,11 +83,12 @@ function NodeView({
       className="border border-gray-700 text-xs text-white"
       style={style}
     >
-      {node.type}
+      {node.props?.text || node.type}
       {node.children?.map((c) => (
         <NodeView
           key={c.id}
           node={c}
+          components={components}
           parentLayout={layout}
           parentAxis={node.props?.axis}
         />
@@ -75,10 +100,11 @@ function NodeView({
 export default function CanvasStage() {
   const tree = useEditorStore((s) => s.tree);
   const selected = useEditorStore((s) => s.selectedIds);
+  const components = useEditorStore((s) => s.components);
   return (
     <div className="relative bg-gray-900 overflow-hidden">
       {tree.map((n) => (
-        <NodeView key={n.id} node={n} />
+        <NodeView key={n.id} node={n} components={components} />
       ))}
       {selected.length === 1 && <SelectionBox />}
       {selected.length === 1 && <ResizeHandles />}

--- a/web/components/editor/LeftPanel.tsx
+++ b/web/components/editor/LeftPanel.tsx
@@ -3,7 +3,9 @@ import { useEditorStore } from '@/store/editorStore';
 
 export default function LeftPanel() {
   const tree = useEditorStore((s) => s.tree);
+  const components = useEditorStore((s) => Object.values(s.components));
   const reorder = useEditorStore((s) => s.reorderChild);
+  const createInstance = useEditorStore((s) => s.createInstance);
 
   const handleDragStart = (e: React.DragEvent<HTMLLIElement>, idx: number) => {
     e.dataTransfer.setData('text/plain', String(idx));
@@ -14,22 +16,38 @@ export default function LeftPanel() {
   };
 
   return (
-    <div className="bg-gray-800 p-2 overflow-y-auto">
-      <h2 className="text-sm mb-2">Layers</h2>
-      <ul className="space-y-1">
-        {tree.map((n, i) => (
-          <li
-            key={n.id}
-            className="text-xs"
-            draggable
-            onDragStart={(e) => handleDragStart(e, i)}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(e) => handleDrop(e, i)}
-          >
-            {n.name || n.type}
-          </li>
-        ))}
-      </ul>
+    <div className="bg-gray-800 p-2 overflow-y-auto space-y-4">
+      <div>
+        <h2 className="text-sm mb-2">Layers</h2>
+        <ul className="space-y-1">
+          {tree.map((n, i) => (
+            <li
+              key={n.id}
+              className="text-xs"
+              draggable
+              onDragStart={(e) => handleDragStart(e, i)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => handleDrop(e, i)}
+            >
+              {n.name || n.type}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2 className="text-sm mb-2">Components</h2>
+        <ul className="space-y-1">
+          {components.map((c) => (
+            <li
+              key={c.id}
+              className="text-xs cursor-pointer"
+              onClick={() => createInstance(c.id)}
+            >
+              {c.name}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -7,8 +7,10 @@ export default function RightInspector() {
   const node = useEditorStore((s) =>
     s.tree.find((n) => n.id === s.selectedIds[0])
   );
+  const components = useEditorStore((s) => s.components);
   const update = useEditorStore((s) => s.updateNode);
   const setLayout = useEditorStore((s) => s.setLayoutProps);
+  const setVariant = useEditorStore((s) => s.setInstanceVariant);
   const [form, setForm] = useState({
     x: node?.props?.x || 0,
     y: node?.props?.y || 0,
@@ -25,6 +27,10 @@ export default function RightInspector() {
     update(selected, { props: next });
   };
 
+  const comp = node && (node as any).type === 'Instance'
+    ? components[(node as any).componentId]
+    : null;
+
   return (
     <div className="bg-gray-800 p-2 space-y-2 overflow-y-auto">
       {(['x', 'y', 'w', 'h', 'rotation'] as const).map((k) => (
@@ -38,6 +44,29 @@ export default function RightInspector() {
           />
         </label>
       ))}
+      {comp && comp.axes && (
+        <div className="mt-2 space-y-1">
+          <h3 className="text-xs font-bold">Variants</h3>
+          {Object.entries(comp.axes).map(([axis, vals]) => (
+            <label key={axis} className="block text-xs">
+              {axis}:
+              <select
+                className="w-full bg-gray-700 ml-1 p-1 text-white"
+                value={(node as any).variant?.[axis] || vals[0]}
+                onChange={(e) =>
+                  setVariant(selected, axis, e.target.value)
+                }
+              >
+                {vals.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ))}
+        </div>
+      )}
       <div className="mt-2 space-y-1">
         <label className="block text-xs">
           Layout:

--- a/web/lib/componentsRegistry.ts
+++ b/web/lib/componentsRegistry.ts
@@ -1,0 +1,16 @@
+import type { ComponentDefinition, EditorState } from '@/types/editor';
+
+export function addComponent(state: EditorState, def: ComponentDefinition) {
+  state.components[def.id] = def;
+}
+
+export function removeComponent(state: EditorState, id: string) {
+  delete state.components[id];
+}
+
+export function getComponent(
+  state: EditorState,
+  id: string
+): ComponentDefinition | undefined {
+  return state.components[id];
+}

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -8,7 +8,10 @@ export type Command =
   | 'undo'
   | 'redo'
   | 'makeAutoLayout'
-  | 'removeAutoLayout';
+  | 'removeAutoLayout'
+  | 'createComponent'
+  | 'detachInstance'
+  | 'swapInstance';
 
 const map: Record<string, Command> = {
   KeyV: 'select',
@@ -21,6 +24,11 @@ const map: Record<string, Command> = {
 
 export function getCommand(e: KeyboardEvent): Command | undefined {
   const mod = e.metaKey || e.ctrlKey;
+  if (mod && e.altKey) {
+    if (e.code === 'KeyK') return 'createComponent';
+    if (e.code === 'KeyB') return 'detachInstance';
+    if (e.code === 'KeyS') return 'swapInstance';
+  }
   if (mod) {
     if (e.code === 'KeyD') return 'duplicate';
     if (e.code === 'KeyZ' && e.shiftKey) return 'redo';

--- a/web/lib/overrideMerge.ts
+++ b/web/lib/overrideMerge.ts
@@ -1,0 +1,32 @@
+import type { ComponentNode } from '@/types/editor';
+
+function findNode(node: ComponentNode, id: string): ComponentNode | null {
+  if (node.id === id) return node;
+  if (node.children) {
+    for (const c of node.children) {
+      const r = findNode(c, id);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
+function applyPatch(target: ComponentNode, patch: Partial<ComponentNode>) {
+  if (patch.props) {
+    target.props = { ...(target.props || {}), ...patch.props };
+  }
+  if (patch.children) target.children = patch.children;
+  Object.assign(target, { ...patch, props: target.props });
+}
+
+export function applyOverrides(
+  root: ComponentNode,
+  overrides: Record<string, Partial<ComponentNode>>
+): ComponentNode {
+  const clone: ComponentNode = JSON.parse(JSON.stringify(root));
+  Object.entries(overrides).forEach(([id, patch]) => {
+    const target = findNode(clone, id);
+    if (target) applyPatch(target, patch);
+  });
+  return clone;
+}

--- a/web/lib/variantResolver.ts
+++ b/web/lib/variantResolver.ts
@@ -1,0 +1,38 @@
+import type { ComponentDefinition, ComponentNode } from '@/types/editor';
+
+function findNode(node: ComponentNode, id: string): ComponentNode | null {
+  if (node.id === id) return node;
+  if (node.children) {
+    for (const c of node.children) {
+      const r = findNode(c, id);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
+function applyPatch(target: ComponentNode, patch: Partial<ComponentNode>) {
+  if (patch.props) {
+    target.props = { ...(target.props || {}), ...patch.props };
+  }
+  if (patch.children) target.children = patch.children;
+  Object.assign(target, { ...patch, props: target.props });
+}
+
+export function resolveVariant(
+  def: ComponentDefinition,
+  variant?: Record<string, string>
+): ComponentNode {
+  const root: ComponentNode = JSON.parse(JSON.stringify(def.root));
+  if (!def.rules) return root;
+  def.rules.forEach((r) => {
+    const ok = Object.entries(r.when).every(
+      ([k, v]) => variant && variant[k] === v
+    );
+    if (ok) {
+      const target = findNode(root, r.node);
+      if (target) applyPatch(target, r.patch);
+    }
+  });
+  return root;
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -4,10 +4,14 @@ import { produceWithPatches } from 'immer';
 import type {
   EditorState,
   ComponentNode,
+  ComponentDefinition,
+  InstanceNode,
   SizeMode,
 } from '@/types/editor';
 import { idbStorage } from '@/lib/idb';
 import { push, undo as undoStack, redo as redoStack } from './undoRedo';
+import { resolveVariant } from '@/lib/variantResolver';
+import { applyOverrides } from '@/lib/overrideMerge';
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -32,6 +36,28 @@ interface EditorActions {
     mode: SizeMode,
     value?: number
   ) => void;
+  // Components
+  createComponentFromSelection: (name?: string) => void;
+  deleteComponent: (componentId: string) => void;
+  renameComponent: (componentId: string, name: string) => void;
+  createInstance: (componentId: string, pos?: { x: number; y: number }) => void;
+  detachInstance: (nodeId: string) => void;
+  swapInstance: (nodeId: string, nextComponentId: string) => void;
+  // Variants
+  defineVariantAxis: (componentId: string, axis: string, values: string[]) => void;
+  setVariantRule: (
+    componentId: string,
+    rule: { when: Record<string, string>; node: string; patch: Partial<ComponentNode> }
+  ) => void;
+  removeVariantRule: (componentId: string, index: number) => void;
+  setInstanceVariant: (nodeId: string, axis: string, value: string) => void;
+  // Overrides
+  setInstanceOverride: (
+    nodeId: string,
+    targetId: string,
+    patch: Partial<ComponentNode>
+  ) => void;
+  resetInstanceOverride: (nodeId: string, targetId?: string) => void;
 }
 
 function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
@@ -39,6 +65,22 @@ function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
     if (n.id === id) return n;
     if (n.children) {
       const c = findNode(n.children, id);
+      if (c) return c;
+    }
+  }
+  return null;
+}
+
+function findNodeWithParent(
+  nodes: ComponentNode[],
+  id: string,
+  parent: ComponentNode | null = null
+): { node: ComponentNode; parent: ComponentNode | null; index: number } | null {
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    if (n.id === id) return { node: n, parent, index: i };
+    if (n.children) {
+      const c = findNodeWithParent(n.children, id, n);
       if (c) return c;
     }
   }
@@ -60,6 +102,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         hoverId: null,
         camera: { x: 0, y: 0, zoom: 1 },
         meta: { version: 1, updatedAt: Date.now() },
+        components: {},
         select(ids) {
           set((state) => ({
             selectedIds: typeof ids === 'function' ? ids(state.selectedIds) : ids,
@@ -182,6 +225,138 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             }
           });
         },
+        createComponentFromSelection(name) {
+          apply((draft) => {
+            const sel = draft.selectedIds[0];
+            const res = findNodeWithParent(draft.tree, sel);
+            if (!res) return;
+            const { node, parent, index } = res;
+            const compId = Math.random().toString(36).slice(2);
+            draft.components[compId] = {
+              id: compId,
+              name: name || node.name || 'Component',
+              root: node,
+            } as ComponentDefinition;
+            const instId = Math.random().toString(36).slice(2);
+            const instance: InstanceNode = {
+              id: instId,
+              type: 'Instance',
+              componentId: compId,
+              props: { ...node.props },
+            };
+            if (parent && parent.children) parent.children[index] = instance;
+            else draft.tree[index] = instance;
+            draft.selectedIds = [instId];
+          });
+        },
+        deleteComponent(componentId) {
+          apply((draft) => {
+            delete draft.components[componentId];
+          });
+        },
+        renameComponent(componentId, name) {
+          apply((draft) => {
+            const c = draft.components[componentId];
+            if (c) c.name = name;
+          });
+        },
+        createInstance(componentId, pos) {
+          apply((draft) => {
+            if (!draft.components[componentId]) return;
+            const id = Math.random().toString(36).slice(2);
+            const inst: InstanceNode = {
+              id,
+              type: 'Instance',
+              componentId,
+              variant: {},
+              overrides: {},
+              props: { x: pos?.x || 0, y: pos?.y || 0 },
+            };
+            draft.tree.push(inst);
+            draft.selectedIds = [id];
+          });
+        },
+        detachInstance(nodeId) {
+          apply((draft) => {
+            const res = findNodeWithParent(draft.tree, nodeId);
+            if (!res) return;
+            const inst = res.node as InstanceNode;
+            const def = draft.components[inst.componentId];
+            if (!def) return;
+            let resolved = resolveVariant(def, inst.variant);
+            if (inst.overrides) {
+              resolved = applyOverrides(resolved, inst.overrides);
+            }
+            if (res.parent && res.parent.children)
+              res.parent.children[res.index] = resolved;
+            else draft.tree[res.index] = resolved;
+          });
+        },
+        swapInstance(nodeId, nextComponentId) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst) return;
+            inst.componentId = nextComponentId;
+            const def = draft.components[nextComponentId];
+            if (def?.axes) {
+              inst.variant = inst.variant || {};
+              // remove axes not in new component
+              Object.keys(inst.variant).forEach((k) => {
+                if (!def.axes || !def.axes[k]) delete inst.variant![k];
+              });
+              Object.entries(def.axes).forEach(([k, vals]) => {
+                if (!inst.variant![k]) inst.variant![k] = vals[0];
+              });
+            }
+          });
+        },
+        defineVariantAxis(componentId, axis, values) {
+          apply((draft) => {
+            const c = draft.components[componentId];
+            if (!c) return;
+            c.axes = c.axes || {};
+            c.axes[axis] = values;
+          });
+        },
+        setVariantRule(componentId, rule) {
+          apply((draft) => {
+            const c = draft.components[componentId];
+            if (!c) return;
+            c.rules = c.rules || [];
+            c.rules.push(rule);
+          });
+        },
+        removeVariantRule(componentId, index) {
+          apply((draft) => {
+            const c = draft.components[componentId];
+            if (c?.rules) c.rules.splice(index, 1);
+          });
+        },
+        setInstanceVariant(nodeId, axis, value) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst) return;
+            inst.variant = inst.variant || {};
+            inst.variant[axis] = value;
+          });
+        },
+        setInstanceOverride(nodeId, targetId, patch) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst) return;
+            inst.overrides = inst.overrides || {};
+            const prev = inst.overrides[targetId] || {};
+            inst.overrides[targetId] = { ...prev, ...patch };
+          });
+        },
+        resetInstanceOverride(nodeId, targetId) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst || !inst.overrides) return;
+            if (targetId) delete inst.overrides[targetId];
+            else inst.overrides = {};
+          });
+        },
         undo() {
           set((state) => undoStack(state));
         },
@@ -193,9 +368,11 @@ export const useEditorStore = create<EditorState & EditorActions>()(
     {
       name: 'uibuilder:editor',
       storage: createJSONStorage(() => idbStorage),
-      version: 4,
+      version: 5,
       migrate: (persisted, version) => {
-        if (version < 4 && persisted) {
+        if (!persisted) return persisted;
+        const state = persisted as EditorState;
+        if (version < 4) {
           const setLayout = (nodes: ComponentNode[]) => {
             nodes.forEach((n) => {
               n.props = n.props || {};
@@ -203,9 +380,20 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               if (n.children) setLayout(n.children);
             });
           };
-          setLayout((persisted as EditorState).tree);
+          setLayout(state.tree);
         }
-        return persisted;
+        if (version < 5) {
+          if (!state.components) state.components = {} as any;
+          const ensureVisible = (nodes: ComponentNode[]) => {
+            nodes.forEach((n) => {
+              if (!n.props) n.props = {};
+              if (n.props.visible === undefined) n.props.visible = true;
+              if (n.children) ensureVisible(n.children);
+            });
+          };
+          ensureVisible(state.tree);
+        }
+        return state;
       },
     }
   )

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -4,7 +4,7 @@ export type SizeMode = 'HUG' | 'FIXED' | 'FILL';
 
 export interface ComponentNode {
   id: string;
-  type: string; // 'Frame' | 'Rect' | 'Text' | 'Button' etc
+  type: string; // 'Frame' | 'Rect' | 'Text' | 'Instance' etc
   name?: string;
   props?: {
     x?: number;
@@ -31,6 +31,9 @@ export interface ComponentNode {
     minH?: number;
     maxW?: number;
     maxH?: number;
+    className?: string;
+    text?: string; // for Text nodes
+    visible?: boolean;
   };
   bindings?: Record<string, PropBinding>;
   variants?: {
@@ -56,4 +59,24 @@ export interface EditorState {
   hoverId: string | null;
   camera: { x: number; y: number; zoom: number };
   meta: { version: number; updatedAt: number };
+  components: Record<string, ComponentDefinition>;
+}
+
+export interface ComponentDefinition {
+  id: string;
+  name: string;
+  root: ComponentNode;
+  axes?: Record<string, string[]>;
+  rules?: Array<{
+    when: Record<string, string>;
+    node: string;
+    patch: Partial<ComponentNode>;
+  }>;
+}
+
+export interface InstanceNode extends ComponentNode {
+  type: 'Instance';
+  componentId: string;
+  variant?: Record<string, string>;
+  overrides?: Record<string, Partial<ComponentNode>>;
 }


### PR DESCRIPTION
## Summary
- expand editor types to support components, variants, overrides
- add store actions for creating components and instances
- render instances with variant resolution and overrides on canvas and preview

## Testing
- `npm test` (fails: reject is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68a8f3b7e400832cb2a9a1d7ffecba19