### PR TITLE
feat: add basic perf metrics and HUD

### DIFF
--- a/web/app/dev/metrics/page.tsx
+++ b/web/app/dev/metrics/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import LogTable from '@/components/dev/LogTable';
+import { usePerfStore } from '@/store/perfStore';
+
+export default function MetricsPage() {
+  const logs = usePerfStore((s) => s.logs);
+  const exportJson = () => {
+    const data = JSON.stringify(logs, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'oplog.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <div className="p-4">
+      <h1 className="text-lg mb-2">Metrics</h1>
+      <button className="mb-2 px-2 py-1 border" onClick={exportJson}>
+        Download JSON
+      </button>
+      <LogTable />
+    </div>
+  );
+}

--- a/web/app/editor/page.tsx
+++ b/web/app/editor/page.tsx
@@ -1,4 +1,5 @@
 import EditorShell from '@/components/editor/EditorShell';
+import '@/styles/editor.css';
 
 export default function EditorPage() {
   return <EditorShell />;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,12 +2,16 @@
 import './globals.css'
 import React, { ReactNode } from 'react'
 import { HUDProvider } from '../components/hud/hudStore'
+import PerfHUD from '@/components/dev/PerfHUD'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <HUDProvider>{children}</HUDProvider>
+        <HUDProvider>
+          {children}
+          {process.env.NODE_ENV !== 'production' && <PerfHUD />}
+        </HUDProvider>
       </body>
     </html>
   )

--- a/web/components/dev/LogTable.tsx
+++ b/web/components/dev/LogTable.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { usePerfStore } from '@/store/perfStore';
+
+export default function LogTable() {
+  const logs = usePerfStore((s) => s.logs);
+  if (!logs.length) return <p>No logs</p>;
+  return (
+    <table className="text-xs">
+      <thead>
+        <tr>
+          <th className="px-1">time</th>
+          <th className="px-1">kind</th>
+          <th className="px-1">dur(ms)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {logs.map((l) => (
+          <tr key={l.id}>
+            <td className="px-1">{new Date(l.t).toLocaleTimeString()}</td>
+            <td className="px-1">{l.kind}</td>
+            <td className="px-1">{l.durMs?.toFixed(1)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/web/components/dev/PerfHUD.tsx
+++ b/web/components/dev/PerfHUD.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect } from 'react';
+import { usePerfStore } from '@/store/perfStore';
+
+export default function PerfHUD() {
+  const fps = usePerfStore((s) => s.fps);
+  const commit = usePerfStore((s) => s.commitMs[s.commitMs.length - 1] || 0);
+  const setFPS = usePerfStore((s) => s.setFPS);
+
+  useEffect(() => {
+    let frames = 0;
+    let last = performance.now();
+    let raf: number;
+    const loop = () => {
+      frames++;
+      const now = performance.now();
+      if (now - last >= 1000) {
+        setFPS(Math.round((frames * 1000) / (now - last)));
+        frames = 0;
+        last = now;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [setFPS]);
+
+  if (process.env.NODE_ENV === 'production') return null;
+  return (
+    <div className="perf-hud">
+      {fps.toFixed(0)} fps | {commit.toFixed(1)} ms
+    </div>
+  );
+}

--- a/web/lib/profiler.ts
+++ b/web/lib/profiler.ts
@@ -1,0 +1,14 @@
+export async function withMeasure<T>(name: string, fn: () => Promise<T> | T): Promise<T> {
+  const start = performance.now();
+  const result = await fn();
+  const dur = performance.now() - start;
+  try {
+    performance.measure(name, {
+      start: start,
+      duration: dur,
+    });
+  } catch {
+    // noop
+  }
+  return result;
+}

--- a/web/lib/scheduler.ts
+++ b/web/lib/scheduler.ts
@@ -1,0 +1,13 @@
+export function rafBatch<T extends (...args: any[]) => void>(fn: T): T {
+  let queued = false;
+  let lastArgs: any[];
+  return ((...args: any[]) => {
+    lastArgs = args;
+    if (queued) return;
+    queued = true;
+    requestAnimationFrame(() => {
+      queued = false;
+      fn(...lastArgs);
+    });
+  }) as T;
+}

--- a/web/store/perfStore.ts
+++ b/web/store/perfStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+
+export type OpKind =
+  | 'select'
+  | 'drag'
+  | 'resize'
+  | 'rotate'
+  | 'reorder'
+  | 'undo'
+  | 'redo'
+  | 'autosave'
+  | 'render';
+
+export interface OpLogEntry {
+  id: string;
+  t: number;
+  kind: OpKind;
+  detail?: any;
+  durMs?: number;
+  frameMs?: number;
+  patches?: number;
+  nodesAffected?: number;
+}
+
+interface PerfState {
+  fps: number;
+  commitMs: number[];
+  logs: OpLogEntry[];
+  setFPS: (fps: number) => void;
+  addCommit: (ms: number) => void;
+  addLog: (entry: OpLogEntry) => void;
+}
+
+export const usePerfStore = create<PerfState>()((set) => ({
+  fps: 0,
+  commitMs: [],
+  logs: [],
+  setFPS: (fps) => set({ fps }),
+  addCommit: (ms) =>
+    set((s) => ({ commitMs: [...s.commitMs.slice(-59), ms] })),
+  addLog: (entry) => set((s) => ({ logs: [...s.logs, entry] })),
+}));

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -22,3 +22,16 @@
   border: 1px solid #ff0;
   background: rgba(255, 255, 0, 0.2);
 }
+
+.perf-hud {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #0f0;
+  padding: 2px 6px;
+  font-family: monospace;
+  font-size: 12px;
+  z-index: 1000;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add rafBatch scheduler and performance measure helper
- track FPS and op logs with a new perf store
- render simple dev PerfHUD and metrics page

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fa8c8108832ca309b9ac899eaf3c