### PR TITLE
feat: add basic sync infrastructure

### DIFF
--- a/web/app/api/_docStore.ts
+++ b/web/app/api/_docStore.ts
@@ -1,0 +1,9 @@
+import type { Operation } from '@/types/sync';
+
+interface DocEntry {
+  rev: number;
+  ops: Operation[];
+  state: any;
+}
+
+export const store: Record<string, DocEntry> = {};

--- a/web/app/api/state/[docId]/route.ts
+++ b/web/app/api/state/[docId]/route.ts
@@ -1,0 +1,6 @@
+import { store } from '../../_docStore';
+
+export async function GET(_req: Request, { params }: { params: { docId: string } }) {
+  const entry = store[params.docId] || { rev: 0, state: {} };
+  return Response.json({ rev: entry.rev, state: entry.state });
+}

--- a/web/app/api/sync/route.ts
+++ b/web/app/api/sync/route.ts
@@ -1,0 +1,21 @@
+import { store } from '../_docStore';
+import type { Envelope, ServerReply, Operation } from '@/types/sync';
+
+export async function POST(req: Request) {
+  const envelope: Envelope = await req.json();
+  const doc = (store[envelope.docId] ||= { rev: 0, ops: [], state: {} });
+  const serverOpsSince =
+    envelope.lastAckRev < doc.rev ? doc.ops.slice(envelope.lastAckRev) : undefined;
+  const accepted: string[] = [];
+  envelope.ops.forEach((op: Operation) => {
+    doc.ops.push(op);
+    doc.rev++;
+    accepted.push(op.id);
+  });
+  const reply: ServerReply = {
+    headRev: doc.rev,
+    accepted,
+    serverOpsSince,
+  };
+  return Response.json(reply);
+}

--- a/web/components/hud/SyncIndicator.tsx
+++ b/web/components/hud/SyncIndicator.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useSyncStatus } from '@/lib/sync/SaveQueue';
+
+export default function SyncIndicator() {
+  const { status } = useSyncStatus();
+  let text = 'Saved';
+  if (status === 'syncing') text = 'Syncing…';
+  else if (status === 'offline') text = 'Offline';
+  return <div className="text-xs text-gray-500">{text}</div>;
+}

--- a/web/lib/sync/SaveQueue.ts
+++ b/web/lib/sync/SaveQueue.ts
@@ -1,0 +1,112 @@
+import { create } from 'zustand';
+import { db } from './idb';
+import type { Patch, Operation, Envelope, ServerReply } from '@/types/sync';
+
+export type SyncStatus = 'saved' | 'syncing' | 'offline';
+
+interface SyncState {
+  status: SyncStatus;
+  lastSync: number | null;
+}
+
+export const useSyncStatus = create<SyncState>(() => ({
+  status: typeof navigator !== 'undefined' && !navigator.onLine ? 'offline' : 'saved',
+  lastSync: null,
+}));
+
+function uuid() {
+  return (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+}
+
+export class SaveQueue {
+  private docId: string;
+  private clientId: string;
+  private sessionId: string;
+  private timer: any = null;
+  private sending = false;
+  private backoff = 1000;
+
+  constructor(docId: string) {
+    this.docId = docId;
+    this.clientId = localStorage.getItem('clientId') || uuid();
+    localStorage.setItem('clientId', this.clientId);
+    this.sessionId = uuid();
+    if (db) {
+      window.addEventListener('online', () => this.scheduleFlush());
+      window.addEventListener('offline', () => useSyncStatus.setState({ status: 'offline' }));
+    }
+  }
+
+  async record(patches: Patch[], state: any, baseRev: number) {
+    if (!db) return;
+    const op: Operation = {
+      id: uuid(),
+      docId: this.docId,
+      clientId: this.clientId,
+      sessionId: this.sessionId,
+      baseRev,
+      patches,
+      ts: Date.now(),
+    };
+    await db.transaction('rw', db.ops, db.draft, async () => {
+      await db.ops.put(op);
+      await db.draft.put({ docId: this.docId, state, updatedAt: Date.now() });
+    });
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush() {
+    if (!db || !navigator.onLine) {
+      useSyncStatus.setState({ status: 'offline' });
+      return;
+    }
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.flush(), 500);
+  }
+
+  private async flush() {
+    if (!db || this.sending) return;
+    const ops = await db.ops.orderBy('ts').toArray();
+    if (ops.length === 0) {
+      useSyncStatus.setState({ status: 'saved' });
+      return;
+    }
+    const meta = await db.meta.get(this.docId);
+    const envelope: Envelope = {
+      docId: this.docId,
+      clientId: this.clientId,
+      lastAckRev: meta?.lastAckRev || 0,
+      ops,
+    };
+    this.sending = true;
+    useSyncStatus.setState({ status: 'syncing' });
+    try {
+      const res = await fetch('/api/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(envelope),
+      });
+      if (!res.ok) throw new Error('sync failed');
+      const reply: ServerReply = await res.json();
+      await db.transaction('rw', db.ops, db.meta, async () => {
+        await Promise.all(reply.accepted.map((id) => db.ops.delete(id)));
+        await db.meta.put({
+          docId: this.docId,
+          clientId: this.clientId,
+          sessionId: this.sessionId,
+          lastAckRev: reply.headRev,
+        });
+      });
+      useSyncStatus.setState({ status: 'saved', lastSync: Date.now() });
+      this.backoff = 1000;
+    } catch (err) {
+      useSyncStatus.setState({ status: 'offline' });
+      this.backoff = Math.min(this.backoff * 2, 30000);
+      setTimeout(() => this.flush(), this.backoff);
+    } finally {
+      this.sending = false;
+    }
+  }
+}

--- a/web/lib/sync/idb.ts
+++ b/web/lib/sync/idb.ts
@@ -1,0 +1,26 @@
+import Dexie, { Table } from 'dexie';
+import type { Operation } from '@/types/sync';
+
+export interface Draft { docId: string; state: any; updatedAt: number }
+export interface Snapshot { docId: string; rev: number; state: any; at: number }
+export interface Meta { docId: string; lastAckRev: number; clientId: string; sessionId: string }
+
+class SyncDB extends Dexie {
+  draft!: Table<Draft, string>;
+  ops!: Table<Operation, string>;
+  snapshots!: Table<Snapshot, [string, number]>;
+  meta!: Table<Meta, string>;
+
+  constructor() {
+    super('uibuilder-sync');
+    this.version(1).stores({
+      draft: '&docId',
+      ops: '&id, docId, baseRev',
+      snapshots: '[docId+rev]',
+      meta: '&docId',
+    });
+  }
+}
+
+export const db: SyncDB | undefined =
+  typeof indexedDB !== 'undefined' ? new SyncDB() : undefined;

--- a/web/types/sync.ts
+++ b/web/types/sync.ts
@@ -1,0 +1,25 @@
+export type Patch = { op: 'replace' | 'add' | 'remove'; path: (string | number)[]; value?: any };
+
+export interface Operation {
+  id: string;
+  docId: string;
+  clientId: string;
+  sessionId: string;
+  baseRev: number;
+  patches: Patch[];
+  ts: number;
+}
+
+export interface Envelope {
+  docId: string;
+  clientId: string;
+  lastAckRev: number;
+  ops: Operation[];
+}
+
+export interface ServerReply {
+  headRev: number;
+  accepted: string[];
+  serverOpsSince?: Operation[];
+  conflict?: boolean;
+}


### PR DESCRIPTION
## Summary
- add sync types and Dexie-backed storage scaffolding
- implement SaveQueue with offline-aware status indicator
- add mock Next.js API routes for syncing and state retrieval

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*


------
https://chatgpt.com/codex/tasks/task_e_68a8fbbab8c0832c870fe004354fd8cc