### PR TITLE
feat: add design tokens and basic ui kit

### DIFF
--- a/web/app/dev/tokens/page.tsx
+++ b/web/app/dev/tokens/page.tsx
@@ -1,0 +1,9 @@
+import { TokensPlayground } from '../../../components/dev/TokensPlayground'
+
+export default function TokensPage() {
+  return (
+    <div className="p-4">
+      <TokensPlayground />
+    </div>
+  )
+}

--- a/web/app/dev/ui/page.tsx
+++ b/web/app/dev/ui/page.tsx
@@ -1,0 +1,9 @@
+import { UIKitShowcase } from '../../../components/dev/UIKitShowcase'
+
+export default function UIPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <UIKitShowcase />
+    </div>
+  )
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,3 +1,4 @@
+@import '../styles/globals.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,15 +3,21 @@ import './globals.css'
 import React, { ReactNode } from 'react'
 import { HUDProvider } from '../components/hud/hudStore'
 import PerfHUD from '@/components/dev/PerfHUD'
+import { ThemeProvider, ThemeScript } from '../lib/theme/ThemeProvider'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <ThemeScript />
+      </head>
       <body>
-        <HUDProvider>
-          {children}
-          {process.env.NODE_ENV !== 'production' && <PerfHUD />}
-        </HUDProvider>
+        <ThemeProvider>
+          <HUDProvider>
+            {children}
+            {process.env.NODE_ENV !== 'production' && <PerfHUD />}
+          </HUDProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/web/components/dev/TokensPlayground.tsx
+++ b/web/components/dev/TokensPlayground.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { tokens } from '../../lib/tokens'
+
+export function TokensPlayground() {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {Object.entries(tokens.color.bg).map(([name]) => (
+        <div key={name} className="p-4 rounded-md border" style={{ background: `hsl(var(--color-bg-${name}))` }}>
+          <span className="text-xs">bg.{name}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/components/dev/UIKitShowcase.tsx
+++ b/web/components/dev/UIKitShowcase.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { Button } from '../ui/Button'
+
+export function UIKitShowcase() {
+  return (
+    <div className="flex gap-2">
+      <Button>Default</Button>
+      <Button tone="primary">Primary</Button>
+      <Button tone="success">Success</Button>
+      <Button tone="warn">Warn</Button>
+      <Button tone="danger">Danger</Button>
+    </div>
+  )
+}

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { ButtonHTMLAttributes } from 'react'
+import { cn } from '../../lib/ui/cn'
+import { variants } from '../../lib/ui/variants'
+
+const buttonVar = variants({
+  variant: {
+    solid: '',
+    outline: 'border border-border bg-transparent',
+    ghost: 'bg-transparent'
+  },
+  tone: {
+    neutral: 'bg-bg-panel text-fg',
+    primary: 'bg-accent-default text-accent-fg',
+    success: 'bg-state-success text-fg-inverted',
+    warn: 'bg-state-warn text-fg-inverted',
+    danger: 'bg-state-danger text-fg-inverted'
+  },
+  size: {
+    sm: 'text-sm px-3 py-1 rounded-sm',
+    md: 'text-base px-4 py-2 rounded-md',
+    lg: 'text-lg px-6 py-3 rounded-lg'
+  }
+})
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'solid' | 'outline' | 'ghost'
+  tone?: 'neutral' | 'primary' | 'success' | 'warn' | 'danger'
+  size?: 'sm' | 'md' | 'lg'
+  loading?: boolean
+}
+
+export function Button({ variant = 'solid', tone = 'neutral', size = 'md', className, children, ...props }: ButtonProps) {
+  const classes = cn(
+    'inline-flex items-center justify-center font-medium transition-colors focus-visible:outline-none disabled:opacity-50 disabled:pointer-events-none',
+    buttonVar({ variant, tone, size }),
+    className
+  )
+  return (
+    <button className={classes} {...props}>
+      {children}
+    </button>
+  )
+}

--- a/web/lib/theme/ThemeProvider.tsx
+++ b/web/lib/theme/ThemeProvider.tsx
@@ -1,0 +1,67 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+import type { Theme } from '../tokens'
+
+export type ThemeMode = Theme | 'system'
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (t: ThemeMode) => void
+  system: Theme
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  setTheme: () => {},
+  system: 'light'
+})
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light')
+  const system: Theme = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+
+  useEffect(() => {
+    const stored = (typeof window !== 'undefined' && localStorage.getItem('ui:theme')) as ThemeMode | null
+    const initial = stored === 'system' || !stored ? system : (stored as Theme)
+    setThemeState(initial)
+    document.documentElement.setAttribute('data-theme', initial)
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const listener = () => {
+      if (localStorage.getItem('ui:theme') === 'system' || !localStorage.getItem('ui:theme')) {
+        const next = mq.matches ? 'dark' : 'light'
+        document.documentElement.setAttribute('data-theme', next)
+        setThemeState(next)
+      }
+    }
+    mq.addEventListener('change', listener)
+    return () => mq.removeEventListener('change', listener)
+  }, [system])
+
+  const setTheme = (t: ThemeMode) => {
+    localStorage.setItem('ui:theme', t)
+    const applied: Theme = t === 'system' ? system : t
+    document.documentElement.setAttribute('data-theme', applied)
+    setThemeState(applied)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, system }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useThemeContext() {
+  return useContext(ThemeContext)
+}
+
+export function ThemeScript() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html:
+          "try{const t=localStorage.getItem('ui:theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t)}catch(e){}"
+      }}
+    />
+  )
+}

--- a/web/lib/theme/useTheme.ts
+++ b/web/lib/theme/useTheme.ts
@@ -1,0 +1,8 @@
+'use client'
+import { useThemeContext, ThemeMode } from './ThemeProvider'
+
+export function useTheme() {
+  return useThemeContext()
+}
+
+export type { ThemeMode }

--- a/web/lib/tokens/index.ts
+++ b/web/lib/tokens/index.ts
@@ -1,0 +1,24 @@
+import tokensJson from './tokens.json'
+import type { Tokens } from './schema'
+
+export const tokens = tokensJson as Tokens
+
+export type Theme = 'light' | 'dark'
+
+export function tokensToCSS(theme: Theme): Record<string, string> {
+  const vars: Record<string, string> = {}
+  const { color } = tokens
+  const walk = (obj: any, path: string[] = []) => {
+    for (const key in obj) {
+      const nextPath = [...path, key]
+      const value = obj[key]
+      if (value && typeof value === 'object' && 'light' in value) {
+        vars[`--${nextPath.join('-')}`] = value[theme]
+      } else {
+        walk(value, nextPath)
+      }
+    }
+  }
+  walk(color, ['color'])
+  return vars
+}

--- a/web/lib/tokens/schema.d.ts
+++ b/web/lib/tokens/schema.d.ts
@@ -1,0 +1,31 @@
+export interface ColorValue {
+  light: string
+  dark: string
+}
+
+export interface Tokens {
+  color: {
+    bg: Record<string, ColorValue>
+    fg: Record<string, ColorValue>
+    border: Record<string, ColorValue>
+    accent: Record<string, ColorValue>
+    state: Record<string, ColorValue>
+    overlay: {
+      scrim: ColorValue
+      focus: { ring: ColorValue }
+    }
+  }
+  space: Record<string, number>
+  radius: Record<string, number>
+  shadow: Record<string, string>
+  font: {
+    family: Record<string, string>
+    size: Record<string, number>
+    weight: Record<string, number>
+  }
+  motion: {
+    duration: Record<string, number>
+    easing: Record<string, string>
+  }
+  z: Record<string, number>
+}

--- a/web/lib/tokens/tokens.json
+++ b/web/lib/tokens/tokens.json
@@ -1,0 +1,59 @@
+{
+  "color": {
+    "bg": {
+      "canvas": {"light": "220 7% 10%", "dark": "220 7% 10%"},
+      "panel": {"light": "220 7% 12%", "dark": "220 7% 12%"},
+      "muted": {"light": "220 6% 16%", "dark": "220 6% 16%"},
+      "elevated": {"light": "220 6% 18%", "dark": "220 6% 18%"}
+    },
+    "fg": {
+      "default": {"light": "220 15% 92%", "dark": "220 15% 92%"},
+      "muted": {"light": "220 10% 70%", "dark": "220 10% 70%"},
+      "inverted": {"light": "220 10% 8%", "dark": "220 10% 8%"}
+    },
+    "border": {
+      "default": {"light": "220 10% 20%", "dark": "220 10% 20%"},
+      "muted": {"light": "220 8% 18%", "dark": "220 8% 18%"}
+    },
+    "accent": {
+      "default": {"light": "210 90% 60%", "dark": "210 90% 60%"},
+      "fg": {"light": "0 0% 100%", "dark": "0 0% 100%"}
+    },
+    "state": {
+      "success": {"light": "150 60% 40%", "dark": "150 60% 40%"},
+      "warn": {"light": "40 90% 55%", "dark": "40 90% 55%"},
+      "danger": {"light": "4 85% 58%", "dark": "4 85% 58%"},
+      "info": {"light": "210 90% 60%", "dark": "210 90% 60%"}
+    },
+    "overlay": {
+      "scrim": {"light": "0 0% 0% / 0.5", "dark": "0 0% 0% / 0.5"},
+      "focus": {
+        "ring": {"light": "210 90% 60% / 0.6", "dark": "210 90% 60% / 0.6"}
+      }
+    }
+  },
+  "space": {"xxs": 4, "xs": 8, "sm": 12, "md": 16, "lg": 24, "xl": 32, "2xl": 48},
+  "radius": {"sm": 4, "md": 8, "lg": 12, "xl": 16, "pill": 9999},
+  "shadow": {
+    "sm": "0 1px 2px 0 hsl(0 0% 0% / 0.2)",
+    "md": "0 4px 10px 0 hsl(0 0% 0% / 0.25)",
+    "lg": "0 8px 24px 0 hsl(0 0% 0% / 0.3)"
+  },
+  "font": {
+    "family": {
+      "ui": "Inter, system-ui, sans-serif",
+      "mono": "ui-monospace, SFMono-Regular, Menlo, monospace"
+    },
+    "size": {"xs": 11, "sm": 12, "md": 14, "lg": 16, "xl": 18, "2xl": 20, "3xl": 24},
+    "weight": {"normal": 400, "medium": 500, "semibold": 600}
+  },
+  "motion": {
+    "duration": {"fast": 100, "base": 200, "slow": 300},
+    "easing": {
+      "standard": "cubic-bezier(.2,0,.2,1)",
+      "decelerate": "cubic-bezier(0,0,.2,1)",
+      "accelerate": "cubic-bezier(.4,0,1,1)"
+    }
+  },
+  "z": {"tooltip": 60, "dropdown": 70, "modal": 80, "toast": 90, "hud": 95}
+}

--- a/web/lib/ui/cn.ts
+++ b/web/lib/ui/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}

--- a/web/lib/ui/variants.ts
+++ b/web/lib/ui/variants.ts
@@ -1,0 +1,8 @@
+export type VariantConfig = Record<string, Record<string, string>>
+
+export function variants(cfg: VariantConfig) {
+  return (opts: Record<string, string | undefined>) =>
+    Object.entries(opts)
+      .map(([k, v]) => (v && cfg[k] ? cfg[k][v] : ''))
+      .join(' ')
+}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,0 +1,72 @@
+:root {
+  --color-bg-canvas: 220 7% 10%;
+  --color-bg-panel: 220 7% 12%;
+  --color-bg-muted: 220 6% 16%;
+  --color-bg-elevated: 220 6% 18%;
+  --color-fg-default: 220 15% 92%;
+  --color-fg-muted: 220 10% 70%;
+  --color-fg-inverted: 220 10% 8%;
+  --color-border-default: 220 10% 20%;
+  --color-border-muted: 220 8% 18%;
+  --color-accent-default: 210 90% 60%;
+  --color-accent-fg: 0 0% 100%;
+  --color-state-success: 150 60% 40%;
+  --color-state-warn: 40 90% 55%;
+  --color-state-danger: 4 85% 58%;
+  --color-state-info: 210 90% 60%;
+  --color-overlay-scrim: 0 0% 0% / 0.5;
+  --color-overlay-focus-ring: 210 90% 60% / 0.6;
+
+  --space-xxs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 9999px;
+
+  --shadow-sm: 0 1px 2px 0 hsl(0 0% 0% / 0.2);
+  --shadow-md: 0 4px 10px 0 hsl(0 0% 0% / 0.25);
+  --shadow-lg: 0 8px 24px 0 hsl(0 0% 0% / 0.3);
+
+  --font-ui: Inter, system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+[data-theme='dark'] {
+  --color-bg-canvas: 220 7% 10%;
+  --color-bg-panel: 220 7% 12%;
+  --color-bg-muted: 220 6% 16%;
+  --color-bg-elevated: 220 6% 18%;
+  --color-fg-default: 220 15% 92%;
+  --color-fg-muted: 220 10% 70%;
+  --color-fg-inverted: 220 10% 8%;
+  --color-border-default: 220 10% 20%;
+  --color-border-muted: 220 8% 18%;
+  --color-accent-default: 210 90% 60%;
+  --color-accent-fg: 0 0% 100%;
+  --color-state-success: 150 60% 40%;
+  --color-state-warn: 40 90% 55%;
+  --color-state-danger: 4 85% 58%;
+  --color-state-info: 210 90% 60%;
+  --color-overlay-scrim: 0 0% 0% / 0.5;
+  --color-overlay-focus-ring: 210 90% 60% / 0.6;
+}
+
+@layer base {
+  body {
+    background: hsl(var(--color-bg-canvas));
+    color: hsl(var(--color-fg-default));
+    font-family: var(--font-ui);
+  }
+  :focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px hsl(var(--color-overlay-focus-ring));
+  }
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -7,7 +7,60 @@ const config: Config = {
     "./lib/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        bg: {
+          canvas: 'hsl(var(--color-bg-canvas) / <alpha-value>)',
+          panel: 'hsl(var(--color-bg-panel) / <alpha-value>)',
+          muted: 'hsl(var(--color-bg-muted) / <alpha-value>)',
+          elevated: 'hsl(var(--color-bg-elevated) / <alpha-value>)'
+        },
+        fg: {
+          DEFAULT: 'hsl(var(--color-fg-default) / <alpha-value>)',
+          muted: 'hsl(var(--color-fg-muted) / <alpha-value>)',
+          inverted: 'hsl(var(--color-fg-inverted) / <alpha-value>)'
+        },
+        border: {
+          DEFAULT: 'hsl(var(--color-border-default) / <alpha-value>)',
+          muted: 'hsl(var(--color-border-muted) / <alpha-value>)'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--color-accent-default) / <alpha-value>)',
+          fg: 'hsl(var(--color-accent-fg) / <alpha-value>)'
+        },
+        state: {
+          success: 'hsl(var(--color-state-success) / <alpha-value>)',
+          warn: 'hsl(var(--color-state-warn) / <alpha-value>)',
+          danger: 'hsl(var(--color-state-danger) / <alpha-value>)',
+          info: 'hsl(var(--color-state-info) / <alpha-value>)'
+        }
+      },
+      spacing: {
+        xxs: 'var(--space-xxs)',
+        xs: 'var(--space-xs)',
+        sm: 'var(--space-sm)',
+        md: 'var(--space-md)',
+        lg: 'var(--space-lg)',
+        xl: 'var(--space-xl)',
+        '2xl': 'var(--space-2xl)'
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+        pill: 'var(--radius-pill)'
+      },
+      boxShadow: {
+        sm: 'var(--shadow-sm)',
+        md: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)'
+      },
+      fontFamily: {
+        ui: ['var(--font-ui)'],
+        mono: ['var(--font-mono)']
+      }
+    }
   },
   plugins: []
 }

--- a/web/types/tokens.ts
+++ b/web/types/tokens.ts
@@ -1,0 +1,2 @@
+import type { Tokens } from '../lib/tokens/schema'
+export type { Tokens }


### PR DESCRIPTION
## Summary
- introduce design token system with CSS variables and Tailwind mapping
- add theme provider and utilities for light/dark switching
- create starter button component and dev playground pages

## Testing
- `npm test` *(fails: interrupted)*
- `cd web && npm run build` *(fails: module-not-found html-to-image)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fd5b56b4832c854597fb8abb4625