### PR TITLE
feat: add initial editor shell layout

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -6,6 +6,7 @@ import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
+import ZoomControls from './ZoomControls';
 
 function NodeView({
   node,
@@ -108,6 +109,7 @@ export default function CanvasStage() {
       ))}
       {selected.length === 1 && <SelectionBox />}
       {selected.length === 1 && <ResizeHandles />}
+      <div className="absolute top-2 right-2"><ZoomControls /></div>
     </div>
   );
 }

--- a/web/components/editor/ZoomControls.tsx
+++ b/web/components/editor/ZoomControls.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useState } from 'react';
+import { ZOOM_BUTTON_SIZE, ZOOM_PERCENT_WIDTH } from '@/lib/layout/constants';
+
+export default function ZoomControls() {
+  const [zoom, setZoom] = useState(100);
+  const inc = () => setZoom((z) => Math.min(z + 10, 800));
+  const dec = () => setZoom((z) => Math.max(z - 10, 10));
+  const fit = () => setZoom(100);
+  const reset = () => setZoom(100);
+  return (
+    <div className="flex items-center gap-1 bg-gray-800/70 rounded" style={{height: ZOOM_BUTTON_SIZE}}>
+      <button className="w-7 h-7" onClick={dec}>-</button>
+      <input
+        className="text-center bg-transparent"
+        style={{width: ZOOM_PERCENT_WIDTH}}
+        value={`${zoom}%`}
+        onChange={(e) => setZoom(parseInt(e.target.value) || 0)}
+      />
+      <button className="w-7 h-7" onClick={inc}>+</button>
+      <button className="w-7 h-7" onClick={fit}>Fit</button>
+      <button className="w-7 h-7" onClick={reset}>1:1</button>
+    </div>
+  );
+}

--- a/web/components/shell/AppShell.tsx
+++ b/web/components/shell/AppShell.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { useState, useEffect } from 'react';
+import TopBar from './TopBar';
+import LeftPane from './LeftPane';
+import RightPane from './RightPane';
+import StatusBar from './StatusBar';
+import Splitter from './Splitter';
+import CanvasStage from '../editor/CanvasStage';
+import {
+  LEFT_PANE_DEFAULT_WIDTH,
+  LEFT_PANE_MIN_WIDTH,
+  LEFT_PANE_MAX_WIDTH,
+  RIGHT_PANE_DEFAULT_WIDTH,
+  RIGHT_PANE_MIN_WIDTH,
+  RIGHT_PANE_MAX_WIDTH,
+} from '@/lib/layout/constants';
+import { loadLayout, saveLayout, LayoutState } from '@/lib/layout/persist';
+import '@/styles/shell.css';
+
+export default function AppShell() {
+  const [layout, setLayout] = useState<LayoutState>(() => loadLayout());
+
+  useEffect(() => {
+    saveLayout(layout);
+  }, [layout]);
+
+  const setLeftWidth = (w: number) =>
+    setLayout((l) => ({ ...l, left: { ...l.left, width: Math.min(Math.max(w, LEFT_PANE_MIN_WIDTH), LEFT_PANE_MAX_WIDTH) } }));
+  const setRightWidth = (w: number) =>
+    setLayout((l) => ({ ...l, right: { ...l.right, width: Math.min(Math.max(w, RIGHT_PANE_MIN_WIDTH), RIGHT_PANE_MAX_WIDTH) } }));
+
+  const toggleLeft = () => setLayout((l) => ({ ...l, left: { ...l.left, collapsed: !l.left.collapsed } }));
+  const toggleRight = () => setLayout((l) => ({ ...l, right: { ...l.right, collapsed: !l.right.collapsed } }));
+
+  const resetLeft = () => setLayout((l) => ({ ...l, left: { ...l.left, collapsed: false, width: LEFT_PANE_DEFAULT_WIDTH } }));
+  const resetRight = () => setLayout((l) => ({ ...l, right: { ...l.right, collapsed: false, width: RIGHT_PANE_DEFAULT_WIDTH } }));
+
+  return (
+    <div className="flex flex-col h-screen">
+      <TopBar />
+      <div className="flex flex-1 min-h-0">
+        {!layout.left.collapsed && (
+          <div style={{ width: layout.left.width }} className="h-full">
+            <LeftPane />
+          </div>
+        )}
+        <Splitter
+          onDrag={(d) => setLeftWidth(layout.left.width + d)}
+          onReset={resetLeft}
+          onToggleCollapse={toggleLeft}
+        />
+        <div className="flex-1 relative bg-black">
+          <CanvasStage />
+        </div>
+        <Splitter
+          onDrag={(d) => setRightWidth(layout.right.width - d)}
+          onReset={resetRight}
+          onToggleCollapse={toggleRight}
+        />
+        {!layout.right.collapsed && (
+          <div style={{ width: layout.right.width }} className="h-full">
+            <RightPane />
+          </div>
+        )}
+      </div>
+      <StatusBar />
+    </div>
+  );
+}

--- a/web/components/shell/LeftPane.tsx
+++ b/web/components/shell/LeftPane.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { LEFT_PANE_DEFAULT_WIDTH } from '@/lib/layout/constants';
+import { useState } from 'react';
+
+const TABS = ['Layers', 'Assets', 'Pages'];
+
+export default function LeftPane() {
+  const [tab, setTab] = useState('Layers');
+  return (
+    <div className="flex flex-col h-full bg-gray-800 text-white" style={{width: LEFT_PANE_DEFAULT_WIDTH}}>
+      <div role="tablist" className="flex">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            onClick={() => setTab(t)}
+            className={`flex-1 px-2 py-1 border-b ${tab===t? 'border-white':'border-transparent'}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="p-2">
+        <input
+          className="w-full px-2 py-1 bg-gray-700"
+          placeholder="Search layers"
+        />
+      </div>
+      <div className="flex-1 overflow-auto text-sm p-2">
+        <p>{tab} content</p>
+      </div>
+    </div>
+  );
+}

--- a/web/components/shell/RightPane.tsx
+++ b/web/components/shell/RightPane.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { RIGHT_PANE_DEFAULT_WIDTH } from '@/lib/layout/constants';
+import { useState } from 'react';
+
+const TABS = ['Properties', 'Prototype', 'Code'];
+
+export default function RightPane() {
+  const [tab, setTab] = useState('Properties');
+  return (
+    <div className="flex flex-col h-full bg-gray-800 text-white" style={{width: RIGHT_PANE_DEFAULT_WIDTH}}>
+      <div role="tablist" className="flex">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            onClick={() => setTab(t)}
+            className={`flex-1 px-2 py-1 border-b ${tab===t? 'border-white':'border-transparent'}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="flex-1 overflow-auto p-2 text-sm">
+        <p>{tab} panel</p>
+      </div>
+    </div>
+  );
+}

--- a/web/components/shell/Splitter.tsx
+++ b/web/components/shell/Splitter.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { SPLITTER_WIDTH } from '@/lib/layout/constants';
+
+interface Props {
+  onDrag: (delta: number) => void;
+  onReset: () => void;
+  onToggleCollapse: () => void;
+}
+
+export default function Splitter({ onDrag, onReset, onToggleCollapse }: Props) {
+  const handleMouseDown = (e: React.MouseEvent) => {
+    const startX = e.clientX;
+    const onMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startX;
+      onDrag(delta);
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const handleDouble = (e: React.MouseEvent) => {
+    if (e.altKey) onToggleCollapse();
+    else onReset();
+  };
+
+  return (
+    <div
+      className="splitter"
+      style={{ width: SPLITTER_WIDTH }}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDouble}
+    />
+  );
+}

--- a/web/components/shell/StatusBar.tsx
+++ b/web/components/shell/StatusBar.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { STATUS_BAR_HEIGHT } from '@/lib/layout/constants';
+
+export default function StatusBar() {
+  return (
+    <div
+      className="flex items-center justify-between px-3 bg-gray-800 text-white text-xs"
+      style={{ height: STATUS_BAR_HEIGHT }}
+    >
+      <div>Selection</div>
+      <div>Error messages</div>
+      <div className="flex items-center gap-2">
+        <span>100%</span>
+        <span>0,0</span>
+        <span>Snap</span>
+      </div>
+    </div>
+  );
+}

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { TOP_BAR_HEIGHT } from '@/lib/layout/constants';
+
+export default function TopBar() {
+  return (
+    <div
+      className="flex items-center justify-between px-3 gap-2 bg-gray-800 text-white"
+      style={{ height: TOP_BAR_HEIGHT }}
+    >
+      <div className="flex items-center gap-2">
+        <button>Back</button>
+        <span>Untitled</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button>Group</button>
+        <button>Align</button>
+      </div>
+      <div className="flex items-center gap-2">
+        <button>Share</button>
+        <button>Present</button>
+        <div className="w-6 h-6 bg-gray-500 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/web/lib/layout/constants.ts
+++ b/web/lib/layout/constants.ts
@@ -1,0 +1,11 @@
+export const TOP_BAR_HEIGHT = 48;
+export const LEFT_PANE_DEFAULT_WIDTH = 240;
+export const LEFT_PANE_MIN_WIDTH = 200;
+export const LEFT_PANE_MAX_WIDTH = 420;
+export const RIGHT_PANE_DEFAULT_WIDTH = 320;
+export const RIGHT_PANE_MIN_WIDTH = 260;
+export const RIGHT_PANE_MAX_WIDTH = 520;
+export const STATUS_BAR_HEIGHT = 28;
+export const SPLITTER_WIDTH = 6;
+export const ZOOM_BUTTON_SIZE = 28;
+export const ZOOM_PERCENT_WIDTH = 56;

--- a/web/lib/layout/persist.ts
+++ b/web/lib/layout/persist.ts
@@ -1,0 +1,44 @@
+export interface LayoutState {
+  left: { width: number; collapsed: boolean };
+  right: { width: number; collapsed: boolean };
+  status: { height: number; visible: boolean };
+  lastResetAt?: number;
+}
+
+import {
+  LEFT_PANE_DEFAULT_WIDTH,
+  RIGHT_PANE_DEFAULT_WIDTH,
+  STATUS_BAR_HEIGHT,
+} from './constants';
+
+const KEY = 'uibuilder:layout';
+
+const DEFAULT_STATE: LayoutState = {
+  left: { width: LEFT_PANE_DEFAULT_WIDTH, collapsed: false },
+  right: { width: RIGHT_PANE_DEFAULT_WIDTH, collapsed: false },
+  status: { height: STATUS_BAR_HEIGHT, visible: true },
+};
+
+export function loadLayout(): LayoutState {
+  if (typeof window === 'undefined') return DEFAULT_STATE;
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return DEFAULT_STATE;
+    const parsed = JSON.parse(raw);
+    return { ...DEFAULT_STATE, ...parsed } as LayoutState;
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+export function saveLayout(patch: Partial<LayoutState>): void {
+  if (typeof window === 'undefined') return;
+  const current = loadLayout();
+  const next = { ...current, ...patch };
+  window.localStorage.setItem(KEY, JSON.stringify(next));
+}
+
+export function resetLayout(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_STATE, lastResetAt: Date.now() }));
+}

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -1,0 +1,4 @@
+.splitter {
+  cursor: col-resize;
+  user-select: none;
+}


### PR DESCRIPTION
## Summary
- add top/left/right/status panes and splitters with persistent layout
- introduce zoom controls and overlay in canvas stage
- define layout constants and persistence helpers

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a8feddcad4832ca18a09054ba963ec