### PR TITLE
Add motion tokens and RightPane accordion

### DIFF
--- a/web/components/shell/RightPane.tsx
+++ b/web/components/shell/RightPane.tsx
@@ -1,28 +1,91 @@
 'use client';
 import { RIGHT_PANE_DEFAULT_WIDTH } from '@/lib/layout/constants';
-import { useState } from 'react';
+import { loadLayout, saveLayout } from '@/lib/layout/persist';
+import { useEffect, useRef, useState } from 'react';
 
-const TABS = ['Properties', 'Prototype', 'Code'];
+interface Section {
+  id: string;
+  title: string;
+  content: JSX.Element;
+}
+
+const SECTIONS: Section[] = [
+  { id: 'layout', title: 'Layout', content: <p>Layout content</p> },
+  { id: 'style', title: 'Style', content: <p>Style content</p> },
+  { id: 'code', title: 'Code', content: <p>Code content</p> },
+];
 
 export default function RightPane() {
-  const [tab, setTab] = useState('Properties');
+  const persisted = loadLayout().rightSections || {};
+  const [open, setOpen] = useState<Record<string, boolean>>({ ...persisted });
+
+  useEffect(() => {
+    saveLayout({ rightSections: open });
+  }, [open]);
+
   return (
-    <div className="flex flex-col h-full bg-gray-800 text-white" style={{width: RIGHT_PANE_DEFAULT_WIDTH}}>
-      <div role="tablist" className="flex">
-        {TABS.map((t) => (
-          <button
-            key={t}
-            role="tab"
-            onClick={() => setTab(t)}
-            className={`flex-1 px-2 py-1 border-b ${tab===t? 'border-white':'border-transparent'}`}
+    <div
+      className="flex flex-col h-full bg-gray-800 text-white"
+      style={{ width: RIGHT_PANE_DEFAULT_WIDTH }}
+    >
+      <div className="flex-1 overflow-auto text-sm">
+        {SECTIONS.map((sec) => (
+          <Accordion
+            key={sec.id}
+            title={sec.title}
+            open={open[sec.id] ?? true}
+            onToggle={() =>
+              setOpen((s) => ({ ...s, [sec.id]: !(s[sec.id] ?? true) }))
+            }
           >
-            {t}
-          </button>
+            {sec.content}
+          </Accordion>
         ))}
       </div>
-      <div className="flex-1 overflow-auto p-2 text-sm">
-        <p>{tab} panel</p>
-      </div>
     </div>
+  );
+}
+
+interface AccordionProps {
+  title: string;
+  open: boolean;
+  onToggle(): void;
+  children: React.ReactNode;
+}
+
+function Accordion({ title, open, onToggle, children }: AccordionProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const update = () => setHeight(ref.current!.scrollHeight);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(ref.current);
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <section className="border-b border-gray-700">
+      <button
+        className="w-full text-left px-2 py-1 hover:bg-gray-700 transition-colors"
+        onClick={onToggle}
+      >
+        {title}
+      </button>
+      <div
+        style={{
+          maxHeight: open ? height : 0,
+          opacity: open ? 1 : 0,
+          transition: `max-height var(--motion-base) var(--easing-standard), opacity var(--motion-base) var(--easing-standard)`
+        }}
+        className="overflow-hidden"
+      >
+        <div ref={ref} className="p-2">
+          {children}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -24,7 +24,15 @@ export type Command =
   | 'annotation.pin'
   | 'annotation.rect'
   | 'comment.submit'
-  | 'review.inReview';
+  | 'review.inReview'
+  | 'nudge.up'
+  | 'nudge.down'
+  | 'nudge.left'
+  | 'nudge.right'
+  | 'nudge.big.up'
+  | 'nudge.big.down'
+  | 'nudge.big.left'
+  | 'nudge.big.right';
 
 const map: Record<string, Command> = {
   KeyV: 'select',
@@ -58,6 +66,12 @@ export function getCommand(e: KeyboardEvent): Command | undefined {
     if (e.code === 'KeyY') return 'view.toggleOutline';
     if (e.code === 'KeyE' && e.shiftKey) return 'export';
     if (e.code === 'Enter') return 'comment.submit';
+  }
+  if (!mod) {
+    if (e.code === 'ArrowUp') return e.shiftKey ? 'nudge.big.up' : 'nudge.up';
+    if (e.code === 'ArrowDown') return e.shiftKey ? 'nudge.big.down' : 'nudge.down';
+    if (e.code === 'ArrowLeft') return e.shiftKey ? 'nudge.big.left' : 'nudge.left';
+    if (e.code === 'ArrowRight') return e.shiftKey ? 'nudge.big.right' : 'nudge.right';
   }
   if (e.code === 'KeyA' && e.shiftKey) return 'makeAutoLayout';
   if (e.code === 'KeyC' && e.shiftKey) return 'annotation.rect';

--- a/web/lib/layout/persist.ts
+++ b/web/lib/layout/persist.ts
@@ -2,6 +2,7 @@ export interface LayoutState {
   left: { width: number; collapsed: boolean };
   right: { width: number; collapsed: boolean };
   status: { height: number; visible: boolean };
+  rightSections?: Record<string, boolean>;
   lastResetAt?: number;
 }
 
@@ -17,6 +18,7 @@ const DEFAULT_STATE: LayoutState = {
   left: { width: LEFT_PANE_DEFAULT_WIDTH, collapsed: false },
   right: { width: RIGHT_PANE_DEFAULT_WIDTH, collapsed: false },
   status: { height: STATUS_BAR_HEIGHT, visible: true },
+  rightSections: {},
 };
 
 export function loadLayout(): LayoutState {

--- a/web/lib/motion.ts
+++ b/web/lib/motion.ts
@@ -1,0 +1,27 @@
+export const MOTION = {
+  fast: 'var(--motion-fast)',
+  base: 'var(--motion-base)',
+  slow: 'var(--motion-slow)',
+  easing: {
+    standard: 'var(--easing-standard)',
+    decel: 'var(--easing-decel)',
+    accel: 'var(--easing-accel)',
+  },
+  pressScale: 'var(--press-scale)',
+};
+
+export function transition(
+  props: string,
+  duration: keyof typeof MOTION | string = 'base',
+  easing: keyof typeof MOTION['easing'] | string = 'standard'
+) {
+  const d =
+    typeof duration === 'string' && duration in MOTION
+      ? (MOTION as any)[duration]
+      : duration;
+  const e =
+    typeof easing === 'string' && easing in MOTION.easing
+      ? (MOTION.easing as any)[easing]
+      : easing;
+  return `${props} ${d} ${e}`;
+}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,3 +1,5 @@
+@import './motion.css';
+
 :root {
   --color-bg-canvas: 220 7% 10%;
   --color-bg-panel: 220 7% 12%;
@@ -37,6 +39,23 @@
 
   --font-ui: Inter, system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --motion-slow: 300ms;
+  --easing-standard: cubic-bezier(.2,0,.2,1);
+  --easing-decel: cubic-bezier(0,0,.2,1);
+  --easing-accel: cubic-bezier(.4,0,1,1);
+  --press-scale: .985;
+  --hover-lift: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-fast: 1ms;
+    --motion-base: 1ms;
+    --motion-slow: 1ms;
+  }
 }
 
 [data-theme='dark'] {

--- a/web/styles/motion.css
+++ b/web/styles/motion.css
@@ -1,0 +1,10 @@
+@layer utilities {
+  .u-fade-in   { opacity: 0; animation: fadeIn var(--motion-fast) var(--easing-standard) forwards; }
+  .u-fade-out  { opacity: 1; animation: fadeOut var(--motion-fast) var(--easing-standard) forwards; }
+  .u-press     { transform: scale(var(--press-scale)); transition: transform var(--motion-fast) var(--easing-standard); }
+  .u-hover     { transition: background var(--motion-fast) var(--easing-standard),
+                          box-shadow var(--motion-fast) var(--easing-standard),
+                          opacity var(--motion-fast) var(--easing-standard); }
+}
+@keyframes fadeIn { from{opacity:0} to{opacity:1} }
+@keyframes fadeOut{ from{opacity:1} to{opacity:0} }


### PR DESCRIPTION
## Summary
- add global motion tokens and utility classes for micro-interactions
- extend layout persistence and implement RightPane accordion with smooth open/close
- expose motion helpers and arrow key commands for nudging

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a900376e94832c9c413875e3c01f35