### PR TITLE
chore: scaffold input routing and zoom stubs

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -7,6 +7,8 @@ import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
 import ZoomControls from './ZoomControls';
+import { keyRouter } from '@/lib/input/keyRouter';
+import { wheelRouter } from '@/lib/input/wheelRouter';
 
 function NodeView({
   node,
@@ -103,7 +105,12 @@ export default function CanvasStage() {
   const selected = useEditorStore((s) => s.selectedIds);
   const components = useEditorStore((s) => s.components);
   return (
-    <div className="relative bg-gray-900 overflow-hidden">
+    <div
+      className="relative bg-gray-900 overflow-hidden"
+      tabIndex={0}
+      onKeyDown={keyRouter}
+      onWheel={wheelRouter}
+    >
       {tree.map((n) => (
         <NodeView key={n.id} node={n} components={components} />
       ))}

--- a/web/lib/commands.ts
+++ b/web/lib/commands.ts
@@ -7,6 +7,7 @@ export interface Command {
 }
 
 import { useEditorStore } from '@/store/editorStore';
+import * as zoom from '@/lib/zoom';
 
 export const COMMANDS: Command[] = [
   {
@@ -58,4 +59,42 @@ export const COMMANDS: Command[] = [
     shortcut: 'Ctrl+Shift+E',
     run: () => window.dispatchEvent(new CustomEvent('uibuilder:export')),
   },
+  {
+    id: 'zoom.in',
+    label: 'Zoom In',
+    shortcut: 'Ctrl++',
+    run: () => zoom.zoomBy(1.1),
+  },
+  {
+    id: 'zoom.out',
+    label: 'Zoom Out',
+    shortcut: 'Ctrl+-',
+    run: () => zoom.zoomBy(0.9),
+  },
+  {
+    id: 'zoom.fitAll',
+    label: 'Fit All',
+    shortcut: 'Shift+1',
+    run: () => zoom.fitAll(),
+  },
+  {
+    id: 'zoom.fitSelection',
+    label: 'Fit Selection',
+    shortcut: 'Shift+2',
+    run: () => zoom.fitSelection(),
+  },
+  {
+    id: 'zoom.to100',
+    label: 'Zoom to 100%',
+    shortcut: '1',
+    run: () => zoom.animateZoomTo(1),
+  },
 ];
+
+export function runCommand(id: string): boolean {
+  const cmd = COMMANDS.find((c) => c.id === id);
+  if (!cmd) return false;
+  cmd.run();
+  useEditorStore.getState().setLastCommand(id);
+  return true;
+}

--- a/web/lib/input/keyRouter.ts
+++ b/web/lib/input/keyRouter.ts
@@ -1,0 +1,14 @@
+import { getCommand } from '@/lib/keymap';
+import { runCommand } from '@/lib/commands';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+
+export function keyRouter(e: KeyboardEvent | ReactKeyboardEvent) {
+  const evt = 'nativeEvent' in e ? (e as ReactKeyboardEvent).nativeEvent : e;
+  const cmd = getCommand(evt);
+  if (cmd) {
+    if (runCommand(cmd)) {
+      evt.preventDefault();
+      evt.stopPropagation();
+    }
+  }
+}

--- a/web/lib/input/wheelRouter.ts
+++ b/web/lib/input/wheelRouter.ts
@@ -1,0 +1,18 @@
+import { zoomBy } from '@/lib/zoom';
+import { useEditorStore } from '@/store/editorStore';
+import type { WheelEvent as ReactWheelEvent } from 'react';
+
+export function wheelRouter(e: WheelEvent | ReactWheelEvent) {
+  const evt = 'nativeEvent' in e ? (e as ReactWheelEvent).nativeEvent : e;
+  const store = useEditorStore.getState();
+  if (evt.ctrlKey || evt.metaKey) {
+    const factor = evt.deltaY > 0 ? 0.9 : 1.1;
+    zoomBy(factor, { x: evt.clientX, y: evt.clientY });
+  } else {
+    store.setCamera({
+      x: store.camera.x - evt.deltaX,
+      y: store.camera.y - evt.deltaY,
+    });
+  }
+  evt.preventDefault();
+}

--- a/web/lib/zoom.ts
+++ b/web/lib/zoom.ts
@@ -1,0 +1,25 @@
+import { useEditorStore } from '@/store/editorStore';
+
+export function zoomBy(factor: number, origin?: { x: number; y: number }) {
+  const { camera, setCamera } = useEditorStore.getState();
+  setCamera({ zoom: camera.zoom * factor });
+}
+
+export function animateZoomTo(zoom: number, _opts?: { duration?: number }) {
+  const { setCamera } = useEditorStore.getState();
+  setCamera({ zoom });
+}
+
+export function fitAll() {
+  const { setCamera } = useEditorStore.getState();
+  setCamera({ x: 0, y: 0, zoom: 1 });
+}
+
+export function fitSelection() {
+  const { setCamera } = useEditorStore.getState();
+  setCamera({ x: 0, y: 0, zoom: 1 });
+}
+
+export function panWithInertia(_vx: number, _vy: number) {
+  // stub
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -11,6 +11,7 @@ import type {
   ReviewStatus,
   Anchor,
   CommentThread,
+  Camera,
 } from '@/types/editor';
 import { idbStorage } from '@/lib/idb';
 import { push, undo as undoStack, redo as redoStack } from './undoRedo';
@@ -58,6 +59,10 @@ interface EditorActions {
   toggleGuides: () => void;
   toggleOutline: () => void;
   setLastCommand: (id: string) => void;
+  setCamera: (cam: Partial<Camera>) => void;
+  tweenCamera: (cam: Camera, opts?: { duration?: number }) => void;
+  getViewportRect: () => { x: number; y: number; w: number; h: number };
+  getSelectionBounds: () => { x: number; y: number; w: number; h: number } | null;
   // Variants
   defineVariantAxis: (componentId: string, axis: string, values: string[]) => void;
   setVariantRule: (
@@ -396,6 +401,40 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         },
         setLastCommand(id) {
           set({ lastCommandId: id });
+        },
+        setCamera(cam) {
+          set((state) => ({ camera: { ...state.camera, ...cam } }));
+        },
+        tweenCamera(cam) {
+          set({ camera: cam });
+        },
+        getViewportRect() {
+          const { camera } = get();
+          const w = window.innerWidth;
+          const h = window.innerHeight;
+          return { x: camera.x, y: camera.y, w: w / camera.zoom, h: h / camera.zoom };
+        },
+        getSelectionBounds() {
+          const { selectedIds, tree } = get();
+          if (!selectedIds.length) return null;
+          const boxes = selectedIds
+            .map((id) => {
+              const n = findNode(tree, id);
+              if (n?.props)
+                return {
+                  x: n.props.x || 0,
+                  y: n.props.y || 0,
+                  w: n.props.w || 0,
+                  h: n.props.h || 0,
+                };
+              return null;
+            })
+            .filter(Boolean) as Array<{ x: number; y: number; w: number; h: number }>;
+          const x1 = Math.min(...boxes.map((b) => b.x));
+          const y1 = Math.min(...boxes.map((b) => b.y));
+          const x2 = Math.max(...boxes.map((b) => b.x + b.w));
+          const y2 = Math.max(...boxes.map((b) => b.y + b.h));
+          return { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
         },
         defineVariantAxis(componentId, axis, values) {
           apply((draft) => {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -2,6 +2,12 @@ export type LayoutMode = 'free' | 'auto';
 export type Axis = 'horizontal' | 'vertical';
 export type SizeMode = 'HUG' | 'FIXED' | 'FILL';
 
+export interface Camera {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 // v5 review & comments types
 export type ReviewStatus = 'DRAFT' | 'IN_REVIEW' | 'CHANGES_REQUESTED' | 'APPROVED';
 export type ThreadStatus = 'OPEN' | 'RESOLVED' | 'REOPENED' | 'DRAFT';
@@ -103,7 +109,7 @@ export interface EditorState {
   tree: ComponentNode[];
   selectedIds: string[];
   hoverId: string | null;
-  camera: { x: number; y: number; zoom: number };
+  camera: Camera;
   meta: { version: number; updatedAt: number };
   components: Record<string, ComponentDefinition>;
   guides: Guide[];


### PR DESCRIPTION
## Summary
- route canvas keyboard and wheel events through new keyRouter and wheelRouter
- add camera helpers and zoom command stubs

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a9011462f0832c9ba5036fa8a38985