### PR TITLE
feat: improve zoom and shortcut routing

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -7,8 +7,9 @@ import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
 import ZoomControls from './ZoomControls';
-import { keyRouter } from '@/lib/input/keyRouter';
 import { wheelRouter } from '@/lib/input/wheelRouter';
+import * as zoom from '@/lib/zoom';
+import { useRef } from 'react';
 
 function NodeView({
   node,
@@ -104,12 +105,58 @@ export default function CanvasStage() {
   const tree = useEditorStore((s) => s.tree);
   const selected = useEditorStore((s) => s.selectedIds);
   const components = useEditorStore((s) => s.components);
+
+  const panning = useRef(false);
+  const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    panning.current = true;
+    last.current = { x: e.clientX, y: e.clientY, t: performance.now(), vx: 0, vy: 0 };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!panning.current) return;
+    const now = performance.now();
+    const state = useEditorStore.getState();
+    const dx = e.clientX - last.current.x;
+    const dy = e.clientY - last.current.y;
+    state.setCamera({
+      x: state.camera.x - dx / state.camera.zoom,
+      y: state.camera.y - dy / state.camera.zoom,
+    });
+    last.current.vx = dx / (now - last.current.t);
+    last.current.vy = dy / (now - last.current.t);
+    last.current.x = e.clientX;
+    last.current.y = e.clientY;
+    last.current.t = now;
+  };
+
+  const onPointerUp = () => {
+    if (panning.current) {
+      panning.current = false;
+      zoom.panWithInertia(last.current.vx, last.current.vy);
+    }
+  };
+
   return (
     <div
       className="relative bg-gray-900 overflow-hidden"
       tabIndex={0}
-      onKeyDown={keyRouter}
-      onWheel={wheelRouter}
+      onWheel={(e) => {
+        const act = wheelRouter(e);
+        const state = useEditorStore.getState();
+        if (act.type === 'zoom') zoom.zoomBy(act.factor, act.anchor);
+        else
+          state.setCamera({
+            x: state.camera.x - act.dx,
+            y: state.camera.y - act.dy,
+          });
+        e.preventDefault();
+      }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
     >
       {tree.map((n) => (
         <NodeView key={n.id} node={n} components={components} />

--- a/web/components/editor/ZoomControls.tsx
+++ b/web/components/editor/ZoomControls.tsx
@@ -1,25 +1,31 @@
 'use client';
-import { useState } from 'react';
-import { ZOOM_BUTTON_SIZE, ZOOM_PERCENT_WIDTH } from '@/lib/layout/constants';
+import { ZOOM_BUTTON_SIZE } from '@/lib/layout/constants';
+import * as zoom from '@/lib/zoom';
+import { useEditorStore } from '@/store/editorStore';
 
 export default function ZoomControls() {
-  const [zoom, setZoom] = useState(100);
-  const inc = () => setZoom((z) => Math.min(z + 10, 800));
-  const dec = () => setZoom((z) => Math.max(z - 10, 10));
-  const fit = () => setZoom(100);
-  const reset = () => setZoom(100);
+  const z = useEditorStore((s) => s.camera.zoom);
   return (
-    <div className="flex items-center gap-1 bg-gray-800/70 rounded" style={{height: ZOOM_BUTTON_SIZE}}>
-      <button className="w-7 h-7" onClick={dec}>-</button>
-      <input
-        className="text-center bg-transparent"
-        style={{width: ZOOM_PERCENT_WIDTH}}
-        value={`${zoom}%`}
-        onChange={(e) => setZoom(parseInt(e.target.value) || 0)}
-      />
-      <button className="w-7 h-7" onClick={inc}>+</button>
-      <button className="w-7 h-7" onClick={fit}>Fit</button>
-      <button className="w-7 h-7" onClick={reset}>1:1</button>
+    <div
+      className="flex items-center gap-1 bg-gray-800/70 rounded px-1"
+      style={{ height: ZOOM_BUTTON_SIZE }}
+    >
+      <button className="w-7 h-7" onClick={() => zoom.zoomBy(1.1)}>
+        +
+      </button>
+      <button className="w-7 h-7" onClick={() => zoom.zoomBy(0.9)}>
+        -
+      </button>
+      <span className="text-xs w-12 text-center">{Math.round(z * 100)}%</span>
+      <button className="w-12 h-7" onClick={() => zoom.animateZoomTo(1)}>
+        100%
+      </button>
+      <button className="w-7 h-7" onClick={() => zoom.fitAll()}>
+        Fit
+      </button>
+      <button className="w-7 h-7" onClick={() => zoom.fitSelection()}>
+        Sel
+      </button>
     </div>
   );
 }

--- a/web/components/hud/ShortcutHelp.tsx
+++ b/web/components/hud/ShortcutHelp.tsx
@@ -1,24 +1,15 @@
 'use client';
-import { Command } from '@/lib/keymap';
-
-const shortcuts: [string, string][] = [
-  ['V', 'Select'],
-  ['F', 'Frame'],
-  ['R', 'Rect'],
-  ['T', 'Text'],
-  ['Cmd/Ctrl + D', 'Duplicate'],
-  ['Delete', 'Remove'],
-  ['Cmd/Ctrl + Shift + E', 'Export'],
-];
+import { COMMANDS } from '@/lib/commands';
 
 export default function ShortcutHelp() {
+  const list = COMMANDS.filter((c) => c.shortcut);
   return (
     <div className="fixed bottom-2 right-2 bg-gray-800 text-xs text-white p-2 rounded pointer-events-auto">
       <ul>
-        {shortcuts.map(([k, d]) => (
-          <li key={k}>
-            <span className="font-mono mr-2">{k}</span>
-            {d}
+        {list.map((c) => (
+          <li key={c.id} className="whitespace-nowrap">
+            <span className="font-mono mr-2">{c.shortcut}</span>
+            {c.label}
           </li>
         ))}
       </ul>

--- a/web/components/shell/AppShell.tsx
+++ b/web/components/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import RightPane from './RightPane';
 import StatusBar from './StatusBar';
 import Splitter from './Splitter';
 import CanvasStage from '../editor/CanvasStage';
+import KeyboardHandler from './KeyboardHandler';
 import {
   LEFT_PANE_DEFAULT_WIDTH,
   LEFT_PANE_MIN_WIDTH,
@@ -37,6 +38,7 @@ export default function AppShell() {
 
   return (
     <div className="flex flex-col h-screen">
+      <KeyboardHandler />
       <TopBar />
       <div className="flex flex-1 min-h-0">
         {!layout.left.collapsed && (

--- a/web/components/shell/KeyboardHandler.tsx
+++ b/web/components/shell/KeyboardHandler.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useEffect } from 'react';
+import { keyRouter } from '@/lib/input/keyRouter';
+
+export default function KeyboardHandler() {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => keyRouter(e);
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, []);
+  return null;
+}

--- a/web/components/shell/LeftPane.tsx
+++ b/web/components/shell/LeftPane.tsx
@@ -22,6 +22,7 @@ export default function LeftPane() {
       </div>
       <div className="p-2">
         <input
+          id="leftpane-search"
           className="w-full px-2 py-1 bg-gray-700"
           placeholder="Search layers"
         />

--- a/web/lib/input/keyRouter.ts
+++ b/web/lib/input/keyRouter.ts
@@ -2,13 +2,40 @@ import { getCommand } from '@/lib/keymap';
 import { runCommand } from '@/lib/commands';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
+function isEditingContext(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable) return true;
+  if (el.closest('[data-ignore-shortcuts]')) return true;
+  return false;
+}
+
 export function keyRouter(e: KeyboardEvent | ReactKeyboardEvent) {
   const evt = 'nativeEvent' in e ? (e as ReactKeyboardEvent).nativeEvent : e;
-  const cmd = getCommand(evt);
-  if (cmd) {
-    if (runCommand(cmd)) {
+  if (evt.isComposing) return;
+  if (isEditingContext(evt.target)) return;
+
+  if (evt.key === '/') {
+    const input = document.getElementById('leftpane-search') as HTMLInputElement | null;
+    if (input) {
+      input.focus();
       evt.preventDefault();
-      evt.stopPropagation();
+      return;
     }
+  }
+  if (evt.key === 'Escape') {
+    const active = document.activeElement as HTMLElement | null;
+    if (active && active.id === 'leftpane-search') {
+      active.blur();
+      evt.preventDefault();
+      return;
+    }
+  }
+
+  const cmd = getCommand(evt);
+  if (cmd && runCommand(cmd)) {
+    evt.preventDefault();
+    evt.stopPropagation();
   }
 }

--- a/web/lib/input/wheelRouter.ts
+++ b/web/lib/input/wheelRouter.ts
@@ -1,18 +1,16 @@
-import { zoomBy } from '@/lib/zoom';
-import { useEditorStore } from '@/store/editorStore';
 import type { WheelEvent as ReactWheelEvent } from 'react';
 
-export function wheelRouter(e: WheelEvent | ReactWheelEvent) {
+export type WheelAction =
+  | { type: 'zoom'; factor: number; anchor: { x: number; y: number } }
+  | { type: 'pan'; dx: number; dy: number };
+
+export function wheelRouter(e: WheelEvent | ReactWheelEvent): WheelAction {
   const evt = 'nativeEvent' in e ? (e as ReactWheelEvent).nativeEvent : e;
-  const store = useEditorStore.getState();
+  const dx = evt.deltaMode === WheelEvent.DOM_DELTA_LINE ? evt.deltaX * 16 : evt.deltaX;
+  const dy = evt.deltaMode === WheelEvent.DOM_DELTA_LINE ? evt.deltaY * 16 : evt.deltaY;
   if (evt.ctrlKey || evt.metaKey) {
-    const factor = evt.deltaY > 0 ? 0.9 : 1.1;
-    zoomBy(factor, { x: evt.clientX, y: evt.clientY });
-  } else {
-    store.setCamera({
-      x: store.camera.x - evt.deltaX,
-      y: store.camera.y - evt.deltaY,
-    });
+    const factor = dy > 0 ? 0.9 : 1.1;
+    return { type: 'zoom', factor, anchor: { x: evt.clientX, y: evt.clientY } };
   }
-  evt.preventDefault();
+  return { type: 'pan', dx, dy };
 }

--- a/web/lib/layout/constants.ts
+++ b/web/lib/layout/constants.ts
@@ -9,3 +9,7 @@ export const STATUS_BAR_HEIGHT = 28;
 export const SPLITTER_WIDTH = 6;
 export const ZOOM_BUTTON_SIZE = 28;
 export const ZOOM_PERCENT_WIDTH = 56;
+export const MIN_ZOOM = 0.05;
+export const MAX_ZOOM = 16;
+export const FIT_PADDING = 0.08;
+export const PAN_INERTIA = 0.92;

--- a/web/lib/zoom.ts
+++ b/web/lib/zoom.ts
@@ -1,25 +1,105 @@
 import { useEditorStore } from '@/store/editorStore';
+import { MIN_ZOOM, MAX_ZOOM, FIT_PADDING, PAN_INERTIA } from '@/lib/layout/constants';
 
-export function zoomBy(factor: number, origin?: { x: number; y: number }) {
+function clampZoom(z: number) {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z));
+}
+
+export function zoomBy(factor: number, anchor?: { x: number; y: number }) {
   const { camera, setCamera } = useEditorStore.getState();
-  setCamera({ zoom: camera.zoom * factor });
+  const nextZoom = clampZoom(camera.zoom * factor);
+  let x = camera.x;
+  let y = camera.y;
+  if (anchor) {
+    const wx = (anchor.x - camera.x) / camera.zoom;
+    const wy = (anchor.y - camera.y) / camera.zoom;
+    x = anchor.x - wx * nextZoom;
+    y = anchor.y - wy * nextZoom;
+  }
+  setCamera({ x, y, zoom: nextZoom });
 }
 
-export function animateZoomTo(zoom: number, _opts?: { duration?: number }) {
-  const { setCamera } = useEditorStore.getState();
-  setCamera({ zoom });
+export function animateZoomTo(
+  targetZoom: number,
+  anchor?: { x: number; y: number },
+  opts?: { duration?: number }
+): Promise<void> {
+  const store = useEditorStore.getState();
+  const start = performance.now();
+  const duration = opts?.duration ?? parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--motion-base')) || 200;
+  const from = store.camera;
+  const toZoom = clampZoom(targetZoom);
+  let toX = from.x;
+  let toY = from.y;
+  if (anchor) {
+    const wx = (anchor.x - from.x) / from.zoom;
+    const wy = (anchor.y - from.y) / from.zoom;
+    toX = anchor.x - wx * toZoom;
+    toY = anchor.y - wy * toZoom;
+  }
+  return new Promise((resolve) => {
+    function frame(now: number) {
+      const t = Math.min((now - start) / duration, 1);
+      const eased = t * (2 - t); // ease-out
+      const z = from.zoom + (toZoom - from.zoom) * eased;
+      const x = from.x + (toX - from.x) * eased;
+      const y = from.y + (toY - from.y) * eased;
+      store.setCamera({ x, y, zoom: z });
+      if (t < 1) requestAnimationFrame(frame);
+      else resolve();
+    }
+    requestAnimationFrame(frame);
+  });
 }
 
-export function fitAll() {
-  const { setCamera } = useEditorStore.getState();
-  setCamera({ x: 0, y: 0, zoom: 1 });
+export function fitAll(): void {
+  const store = useEditorStore.getState();
+  const nodes = store.tree;
+  if (!nodes.length) return;
+  const boxes = nodes
+    .map((n) => ({ x: n.props?.x || 0, y: n.props?.y || 0, w: n.props?.w || 0, h: n.props?.h || 0 }));
+  const x1 = Math.min(...boxes.map((b) => b.x));
+  const y1 = Math.min(...boxes.map((b) => b.y));
+  const x2 = Math.max(...boxes.map((b) => b.x + b.w));
+  const y2 = Math.max(...boxes.map((b) => b.y + b.h));
+  const bounds = { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
+  fitBounds(bounds);
 }
 
-export function fitSelection() {
-  const { setCamera } = useEditorStore.getState();
-  setCamera({ x: 0, y: 0, zoom: 1 });
+export function fitSelection(): void {
+  const store = useEditorStore.getState();
+  const bounds = store.getSelectionBounds();
+  if (bounds) fitBounds(bounds);
+  else fitAll();
 }
 
-export function panWithInertia(_vx: number, _vy: number) {
-  // stub
+function fitBounds(bounds: { x: number; y: number; w: number; h: number }) {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const padW = bounds.w * FIT_PADDING;
+  const padH = bounds.h * FIT_PADDING;
+  const zoom = clampZoom(Math.min(vw / (bounds.w + padW * 2), vh / (bounds.h + padH * 2)));
+  const cx = bounds.x + bounds.w / 2;
+  const cy = bounds.y + bounds.h / 2;
+  const x = cx - vw / (2 * zoom);
+  const y = cy - vh / (2 * zoom);
+  useEditorStore.getState().setCamera({ x, y, zoom });
+}
+
+export function panWithInertia(vx: number, vy: number) {
+  let { camera } = useEditorStore.getState();
+  let x = camera.x;
+  let y = camera.y;
+  let last = performance.now();
+  function step(now: number) {
+    const dt = now - last;
+    last = now;
+    x -= vx * dt;
+    y -= vy * dt;
+    useEditorStore.getState().setCamera({ x, y });
+    vx *= PAN_INERTIA;
+    vy *= PAN_INERTIA;
+    if (Math.abs(vx) > 0.01 || Math.abs(vy) > 0.01) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
 }

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -17,6 +17,7 @@ import { idbStorage } from '@/lib/idb';
 import { push, undo as undoStack, redo as redoStack } from './undoRedo';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
+import { MIN_ZOOM, MAX_ZOOM } from '@/lib/layout/constants';
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -60,7 +61,7 @@ interface EditorActions {
   toggleOutline: () => void;
   setLastCommand: (id: string) => void;
   setCamera: (cam: Partial<Camera>) => void;
-  tweenCamera: (cam: Camera, opts?: { duration?: number }) => void;
+  tweenCamera: (cam: Camera | Partial<Camera>, opts?: { duration?: number }) => void;
   getViewportRect: () => { x: number; y: number; w: number; h: number };
   getSelectionBounds: () => { x: number; y: number; w: number; h: number } | null;
   // Variants
@@ -403,10 +404,21 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           set({ lastCommandId: id });
         },
         setCamera(cam) {
-          set((state) => ({ camera: { ...state.camera, ...cam } }));
+          set((state) => {
+            const next = { ...state.camera, ...cam };
+            if (next.zoom !== undefined) {
+              next.zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next.zoom));
+            }
+            return { camera: next };
+          });
         },
         tweenCamera(cam) {
-          set({ camera: cam });
+          const state = get();
+          const next = { ...state.camera, ...cam } as Camera;
+          if (next.zoom !== undefined) {
+            next.zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next.zoom));
+          }
+          set({ camera: next });
         },
         getViewportRect() {
           const { camera } = get();


### PR DESCRIPTION
## Summary
- add global keyboard handler and context-aware shortcuts
- implement wheel and pointer routing with zoom/pan inertia
- expand zoom utilities and controls

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a9037eca9c832c947da3550420dac8