### PR TITLE
feat: add layout grid and pixel snapping options

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -105,6 +105,7 @@ export default function CanvasStage() {
   const tree = useEditorStore((s) => s.tree);
   const selected = useEditorStore((s) => s.selectedIds);
   const components = useEditorStore((s) => s.components);
+  const prefs = useEditorStore((s) => s.prefs || {});
 
   const panning = useRef(false);
   const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
@@ -161,6 +162,12 @@ export default function CanvasStage() {
       {tree.map((n) => (
         <NodeView key={n.id} node={n} components={components} />
       ))}
+      {prefs.showLayoutGrid && (
+        <div className="absolute inset-0 pointer-events-none layout-grid" />
+      )}
+      {prefs.showPixelGrid && (
+        <div className="absolute inset-0 pointer-events-none pixel-grid" />
+      )}
       {selected.length === 1 && <SelectionBox />}
       {selected.length === 1 && <ResizeHandles />}
       <div className="absolute top-2 right-2"><ZoomControls /></div>

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -96,6 +96,57 @@ export default function RightInspector() {
             </select>
           </label>
         )}
+        <div className="mt-2 space-y-1">
+          <h3 className="text-xs font-bold">Constraints</h3>
+          <label className="block text-xs">
+            Horizontal:
+            <select
+              className="w-full bg-gray-700 ml-1 p-1 text-white"
+              value={node?.props?.constraints?.horizontal || 'LEFT'}
+              onChange={(e) =>
+                update(selected, {
+                  props: {
+                    ...(node?.props || {}),
+                    constraints: {
+                      ...(node?.props?.constraints || { vertical: 'TOP', horizontal: 'LEFT' }),
+                      horizontal: e.target.value as any,
+                    },
+                  },
+                })
+              }
+            >
+              {['LEFT', 'RIGHT', 'LEFT_RIGHT', 'CENTER', 'SCALE'].map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-xs">
+            Vertical:
+            <select
+              className="w-full bg-gray-700 ml-1 p-1 text-white"
+              value={node?.props?.constraints?.vertical || 'TOP'}
+              onChange={(e) =>
+                update(selected, {
+                  props: {
+                    ...(node?.props || {}),
+                    constraints: {
+                      ...(node?.props?.constraints || { vertical: 'TOP', horizontal: 'LEFT' }),
+                      vertical: e.target.value as any,
+                    },
+                  },
+                })
+              }
+            >
+              {['TOP', 'BOTTOM', 'TOP_BOTTOM', 'CENTER', 'SCALE'].map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
     </div>
   );

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -1,7 +1,12 @@
 'use client';
 import { TOP_BAR_HEIGHT } from '@/lib/layout/constants';
+import { useEditorStore } from '@/store/editorStore';
 
 export default function TopBar() {
+  const prefs = useEditorStore((s) => s.prefs || {});
+  const toggleLayoutGrid = useEditorStore((s) => s.toggleLayoutGrid);
+  const togglePixelGrid = useEditorStore((s) => s.togglePixelGrid);
+  const toggleSnapToPixel = useEditorStore((s) => s.toggleSnapToPixel);
   return (
     <div
       className="flex items-center justify-between px-3 gap-2 bg-gray-800 text-white"
@@ -11,9 +16,35 @@ export default function TopBar() {
         <button>Back</button>
         <span>Untitled</span>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-4">
         <button>Group</button>
         <button>Align</button>
+        <div className="flex items-center gap-2 text-xs">
+          <label className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={prefs.showLayoutGrid || false}
+              onChange={toggleLayoutGrid}
+            />
+            Layout Grid
+          </label>
+          <label className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={prefs.showPixelGrid || false}
+              onChange={togglePixelGrid}
+            />
+            Pixel Grid
+          </label>
+          <label className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={prefs.snapToPixel !== false}
+              onChange={toggleSnapToPixel}
+            />
+            Snap
+          </label>
+        </div>
       </div>
       <div className="flex items-center gap-2">
         <button>Share</button>

--- a/web/lib/commands.ts
+++ b/web/lib/commands.ts
@@ -54,6 +54,24 @@ export const COMMANDS: Command[] = [
     run: () => useEditorStore.getState().toggleOutline(),
   },
   {
+    id: 'view.toggleLayoutGrid',
+    label: 'Toggle Layout Grid',
+    shortcut: 'Ctrl+Shift+G',
+    run: () => useEditorStore.getState().toggleLayoutGrid(),
+  },
+  {
+    id: 'view.togglePixelGrid',
+    label: 'Toggle Pixel Grid',
+    shortcut: "Ctrl+'",
+    run: () => useEditorStore.getState().togglePixelGrid(),
+  },
+  {
+    id: 'view.toggleSnapToPixel',
+    label: 'Toggle Snap To Pixel',
+    shortcut: 'Ctrl+Shift+P',
+    run: () => useEditorStore.getState().toggleSnapToPixel(),
+  },
+  {
     id: 'export',
     label: 'Export',
     shortcut: 'Ctrl+Shift+E',

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -20,6 +20,9 @@ export type Command =
   | 'view.toggleRulers'
   | 'view.toggleGuides'
   | 'view.toggleOutline'
+  | 'view.toggleLayoutGrid'
+  | 'view.togglePixelGrid'
+  | 'view.toggleSnapToPixel'
   | 'export'
   | 'annotation.pin'
   | 'annotation.rect'
@@ -64,6 +67,9 @@ export function getCommand(e: KeyboardEvent): Command | undefined {
     if (e.code === 'KeyR') return 'view.toggleRulers';
     if (e.code === 'Semicolon') return 'view.toggleGuides';
     if (e.code === 'KeyY') return 'view.toggleOutline';
+    if (e.code === 'KeyG' && e.shiftKey) return 'view.toggleLayoutGrid';
+    if (e.code === 'Quote') return 'view.togglePixelGrid';
+    if (e.code === 'KeyP' && e.shiftKey) return 'view.toggleSnapToPixel';
     if (e.code === 'KeyE' && e.shiftKey) return 'export';
     if (e.code === 'Enter') return 'comment.submit';
   }

--- a/web/lib/layout/constraints.ts
+++ b/web/lib/layout/constraints.ts
@@ -1,0 +1,57 @@
+import { Constraints } from '@/types/editor';
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export function applyConstraints(
+  parentBefore: Rect,
+  parentAfter: Rect,
+  childBefore: Rect,
+  constraints: Constraints
+): Rect {
+  const dw = parentAfter.w - parentBefore.w;
+  const dh = parentAfter.h - parentBefore.h;
+  const result: Rect = { ...childBefore };
+
+  switch (constraints.horizontal) {
+    case 'LEFT':
+      break;
+    case 'RIGHT':
+      result.x += dw;
+      break;
+    case 'LEFT_RIGHT':
+      result.w += dw;
+      break;
+    case 'CENTER':
+      result.x += dw / 2;
+      break;
+    case 'SCALE':
+      result.x = (childBefore.x / parentBefore.w) * parentAfter.w;
+      result.w = (childBefore.w / parentBefore.w) * parentAfter.w;
+      break;
+  }
+
+  switch (constraints.vertical) {
+    case 'TOP':
+      break;
+    case 'BOTTOM':
+      result.y += dh;
+      break;
+    case 'TOP_BOTTOM':
+      result.h += dh;
+      break;
+    case 'CENTER':
+      result.y += dh / 2;
+      break;
+    case 'SCALE':
+      result.y = (childBefore.y / parentBefore.h) * parentAfter.h;
+      result.h = (childBefore.h / parentBefore.h) * parentAfter.h;
+      break;
+  }
+
+  return result;
+}

--- a/web/lib/layout/grids.ts
+++ b/web/lib/layout/grids.ts
@@ -1,0 +1,66 @@
+import type { ColumnsGrid, RowsGrid, SquareGrid } from '@/types/editor';
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+export function renderColumns(
+  ctx: CanvasRenderingContext2D,
+  rect: Rect,
+  grid: ColumnsGrid,
+  zoom: number
+) {
+  const { count, gutter, margin = 0, color = 'rgba(255,0,0,0.1)' } = grid;
+  const colWidth =
+    (rect.w - margin * 2 - gutter * (count - 1)) / Math.max(count, 1);
+  ctx.save();
+  ctx.fillStyle = color;
+  for (let i = 0; i < count; i++) {
+    const x = rect.x + margin + i * (colWidth + gutter);
+    ctx.fillRect(x, rect.y, colWidth, rect.h);
+  }
+  ctx.restore();
+}
+
+export function renderRows(
+  ctx: CanvasRenderingContext2D,
+  rect: Rect,
+  grid: RowsGrid,
+  zoom: number
+) {
+  const { count, gutter, margin = 0, color = 'rgba(255,0,0,0.1)' } = grid;
+  const rowHeight =
+    (rect.h - margin * 2 - gutter * (count - 1)) / Math.max(count, 1);
+  ctx.save();
+  ctx.fillStyle = color;
+  for (let i = 0; i < count; i++) {
+    const y = rect.y + margin + i * (rowHeight + gutter);
+    ctx.fillRect(rect.x, y, rect.w, rowHeight);
+  }
+  ctx.restore();
+}
+
+export function renderSquareGrid(
+  ctx: CanvasRenderingContext2D,
+  rect: Rect,
+  grid: SquareGrid,
+  zoom: number
+) {
+  const size = grid.size;
+  const offset = grid.offset || 0;
+  const color = grid.color || 'rgba(255,0,0,0.2)';
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1 / zoom;
+  for (let x = rect.x + offset; x < rect.x + rect.w; x += size) {
+    ctx.beginPath();
+    ctx.moveTo(x, rect.y);
+    ctx.lineTo(x, rect.y + rect.h);
+    ctx.stroke();
+  }
+  for (let y = rect.y + offset; y < rect.y + rect.h; y += size) {
+    ctx.beginPath();
+    ctx.moveTo(rect.x, y);
+    ctx.lineTo(rect.x + rect.w, y);
+    ctx.stroke();
+  }
+  ctx.restore();
+}

--- a/web/lib/layout/pixelSnap.ts
+++ b/web/lib/layout/pixelSnap.ts
@@ -1,0 +1,20 @@
+export function shouldShowPixelGrid(zoom: number): boolean {
+  return zoom >= 4;
+}
+
+export function snapRectToPixels(
+  rect: { x: number; y: number; w: number; h: number },
+  zoom: number,
+  devicePixelRatio: number,
+  enabled: boolean
+) {
+  if (!enabled) return rect;
+  const scale = zoom * devicePixelRatio;
+  const snap = (v: number) => Math.round(v * scale) / scale;
+  return {
+    x: snap(rect.x),
+    y: snap(rect.y),
+    w: snap(rect.w),
+    h: snap(rect.h),
+  };
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -59,6 +59,9 @@ interface EditorActions {
   toggleRulers: () => void;
   toggleGuides: () => void;
   toggleOutline: () => void;
+  toggleLayoutGrid: () => void;
+  togglePixelGrid: () => void;
+  toggleSnapToPixel: () => void;
   setLastCommand: (id: string) => void;
   setCamera: (cam: Partial<Camera>) => void;
   tweenCamera: (cam: Camera | Partial<Camera>, opts?: { duration?: number }) => void;
@@ -147,6 +150,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         components: {},
         guides: [],
         ui: { showRulers: false, showGuides: true, showSmartGuides: true, showOutline: false },
+        prefs: { showLayoutGrid: false, showPixelGrid: false, snapToPixel: true },
         lastCommandId: undefined,
         review: { status: 'DRAFT', requireApprovedToShare: false },
         comments: { threads: {}, users: {} },
@@ -398,6 +402,24 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           apply((draft) => {
             draft.ui = draft.ui || {};
             draft.ui.showOutline = !draft.ui.showOutline;
+          });
+        },
+        toggleLayoutGrid() {
+          apply((draft) => {
+            draft.prefs = draft.prefs || {};
+            draft.prefs.showLayoutGrid = !draft.prefs.showLayoutGrid;
+          });
+        },
+        togglePixelGrid() {
+          apply((draft) => {
+            draft.prefs = draft.prefs || {};
+            draft.prefs.showPixelGrid = !draft.prefs.showPixelGrid;
+          });
+        },
+        toggleSnapToPixel() {
+          apply((draft) => {
+            draft.prefs = draft.prefs || {};
+            draft.prefs.snapToPixel = !draft.prefs.snapToPixel;
           });
         },
         setLastCommand(id) {

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -35,3 +35,33 @@
   z-index: 1000;
   pointer-events: none;
 }
+
+.layout-grid {
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.1) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.1) 1px,
+      transparent 1px
+    );
+  background-size: 8px 8px;
+  z-index: 5;
+}
+
+.pixel-grid {
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    );
+  background-size: 1px 1px;
+  z-index: 6;
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -2,6 +2,60 @@ export type LayoutMode = 'free' | 'auto';
 export type Axis = 'horizontal' | 'vertical';
 export type SizeMode = 'HUG' | 'FIXED' | 'FILL';
 
+export type ConstraintH =
+  | 'LEFT'
+  | 'RIGHT'
+  | 'LEFT_RIGHT'
+  | 'CENTER'
+  | 'SCALE';
+export type ConstraintV =
+  | 'TOP'
+  | 'BOTTOM'
+  | 'TOP_BOTTOM'
+  | 'CENTER'
+  | 'SCALE';
+
+export interface Constraints {
+  horizontal: ConstraintH;
+  vertical: ConstraintV;
+}
+
+export type GridKind = 'COLUMNS' | 'ROWS' | 'GRID';
+
+export interface LayoutGridBase {
+  id: string;
+  kind: GridKind;
+  visible?: boolean;
+  color?: string;
+  opacity?: number;
+}
+
+export interface ColumnsGrid extends LayoutGridBase {
+  kind: 'COLUMNS';
+  count: number;
+  type: 'stretch' | 'center' | 'left' | 'right';
+  gutter: number;
+  margin?: number;
+  offset?: number;
+}
+
+export interface RowsGrid extends LayoutGridBase {
+  kind: 'ROWS';
+  count: number;
+  type: 'stretch' | 'center' | 'top' | 'bottom';
+  gutter: number;
+  margin?: number;
+  offset?: number;
+}
+
+export interface SquareGrid extends LayoutGridBase {
+  kind: 'GRID';
+  size: number;
+  offset?: number;
+}
+
+export type LayoutGrid = ColumnsGrid | RowsGrid | SquareGrid;
+
 export interface Camera {
   x: number;
   y: number;
@@ -86,6 +140,8 @@ export interface ComponentNode {
     className?: string;
     text?: string; // for Text nodes
     visible?: boolean;
+    constraints?: Constraints;
+    layoutGrids?: LayoutGrid[];
   };
   bindings?: Record<string, PropBinding>;
   variants?: {
@@ -118,6 +174,11 @@ export interface EditorState {
     showGuides?: boolean;
     showSmartGuides?: boolean;
     showOutline?: boolean;
+  };
+  prefs?: {
+    showLayoutGrid?: boolean;
+    showPixelGrid?: boolean;
+    snapToPixel?: boolean;
   };
   lastCommandId?: string;
   review: {


### PR DESCRIPTION
## Summary
- define constraint and grid types and editor preferences
- add UI toggles for layout grid, pixel grid, and pixel snapping
- include helpers for constraint application, grid rendering and pixel snapping

## Testing
- `npm test --prefix web` (fails: Missing script: "test")
- `npm run build --prefix web` (fails: Nullish coalescing operator requires parens)


------
https://chatgpt.com/codex/tasks/task_e_68a9057e3f84832ca77ca6e67950f729