### PR TITLE
feat: add basic pen tool for path drawing

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -4,6 +4,7 @@ import SelectionBox from './SelectionBox';
 import ResizeHandles from './ResizeHandles';
 import SVGLayer from './SVGLayer';
 import PathEditorOverlay from './PathEditorOverlay';
+import PenTool from './tools/PenTool';
 import type { ComponentNode, InstanceNode, PathNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
@@ -111,6 +112,7 @@ export default function CanvasStage() {
   const selected = useEditorStore((s) => s.selectedIds);
   const components = useEditorStore((s) => s.components);
   const prefs = useEditorStore((s) => s.prefs || {});
+  const activeTool = useEditorStore((s) => s.ui?.activeTool || 'select');
 
   const panning = useRef(false);
   const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
@@ -160,15 +162,16 @@ export default function CanvasStage() {
           });
         e.preventDefault();
       }}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
+      onPointerDown={activeTool === 'pen' ? undefined : onPointerDown}
+      onPointerMove={activeTool === 'pen' ? undefined : onPointerMove}
+      onPointerUp={activeTool === 'pen' ? undefined : onPointerUp}
     >
       {tree.map((n) => (
         <NodeView key={n.id} node={n} components={components} />
       ))}
       <SVGLayer />
       <PathEditorOverlay />
+      {activeTool === 'pen' && <PenTool />}
       {prefs.showLayoutGrid && (
         <div className="absolute inset-0 pointer-events-none layout-grid" />
       )}

--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -9,6 +9,7 @@ import ShareButton from './ShareButton';
 import { useState, useEffect } from 'react';
 import { getCommand } from '@/lib/keymap';
 import { COMMANDS } from '@/lib/commands';
+import { useEditorStore } from '@/store/editorStore';
 
 export default function EditorShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -18,6 +19,31 @@ export default function EditorShell() {
     const handler = (e: KeyboardEvent) => {
       const cmd = getCommand(e);
       if (!cmd) return;
+      if (cmd === 'tool.pen') {
+        e.preventDefault();
+        useEditorStore.getState().startPen();
+        return;
+      }
+      if (cmd === 'tool.select') {
+        e.preventDefault();
+        useEditorStore.getState().cancelPen();
+        return;
+      }
+      if (cmd === 'path.confirm') {
+        e.preventDefault();
+        useEditorStore.getState().closePath();
+        return;
+      }
+      if (cmd === 'path.cancel') {
+        e.preventDefault();
+        useEditorStore.getState().cancelPen();
+        return;
+      }
+      if (cmd === 'path.deleteLast') {
+        e.preventDefault();
+        useEditorStore.getState().deleteLast();
+        return;
+      }
       if (cmd === 'commandPalette') {
         e.preventDefault();
         setPaletteOpen(true);

--- a/web/components/editor/tools/PenTool.tsx
+++ b/web/components/editor/tools/PenTool.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { useEditorStore } from '@/store/editorStore';
+import { useState, useRef } from 'react';
+import type { PathPoint } from '@/types/editor';
+
+function pathToD(pts: PathPoint[]) {
+  if (!pts.length) return '';
+  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x} ${p.y}`).join(' ');
+}
+
+export default function PenTool() {
+  const draft = useEditorStore((s) => s.vector?.draft);
+  const placePoint = useEditorStore((s) => s.placePoint);
+  const closePath = useEditorStore((s) => s.closePath);
+  const camera = useEditorStore((s) => s.camera);
+
+  const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
+  const pending = useRef<{ x: number; y: number } | null>(null);
+  const raf = useRef<number>();
+
+  const updateCursor = () => {
+    raf.current = undefined;
+    if (pending.current) setCursor(pending.current);
+  };
+
+  const toCanvas = (e: React.PointerEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) / camera.zoom + camera.x,
+      y: (e.clientY - rect.top) / camera.zoom + camera.y,
+    };
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    const pt = toCanvas(e);
+    if (draft && draft.points.length) {
+      const first = draft.points[0];
+      const dx = pt.x - first.x;
+      const dy = pt.y - first.y;
+      if (Math.hypot(dx, dy) * camera.zoom <= 6) {
+        placePoint({ x: first.x, y: first.y });
+        closePath();
+        return;
+      }
+    }
+    placePoint(pt);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    e.stopPropagation();
+    const pt = toCanvas(e);
+    pending.current = pt;
+    if (!raf.current) {
+      raf.current = requestAnimationFrame(updateCursor);
+    }
+  };
+
+  const previewD =
+    draft && cursor && draft.points.length
+      ? `M${draft.points[draft.points.length - 1].x} ${draft.points[draft.points.length - 1].y} L${cursor.x} ${cursor.y}`
+      : '';
+
+  return (
+    <div
+      className="absolute inset-0 cursor-crosshair"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+    >
+      {draft && (
+        <svg className="absolute inset-0 pointer-events-none">
+          <path
+            d={pathToD(draft.points)}
+            fill="none"
+            stroke="#ffffff"
+            strokeWidth={1}
+            opacity={0.5}
+          />
+          {previewD && (
+            <path
+              d={previewD}
+              fill="none"
+              stroke="#ffffff"
+              strokeWidth={1}
+              strokeDasharray="4 4"
+              opacity={0.5}
+            />
+          )}
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -1,5 +1,10 @@
 export type Command =
   | 'select'
+  | 'tool.pen'
+  | 'tool.select'
+  | 'path.confirm'
+  | 'path.cancel'
+  | 'path.deleteLast'
   | 'frame'
   | 'rect'
   | 'text'
@@ -38,12 +43,15 @@ export type Command =
   | 'nudge.big.right';
 
 const map: Record<string, Command> = {
-  KeyV: 'select',
+  KeyP: 'tool.pen',
+  KeyV: 'tool.select',
+  Enter: 'path.confirm',
+  Escape: 'path.cancel',
+  Backspace: 'path.deleteLast',
   KeyF: 'frame',
   KeyR: 'rect',
   KeyT: 'text',
   Delete: 'delete',
-  Backspace: 'delete',
 };
 
 export function getCommand(e: KeyboardEvent): Command | undefined {

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -111,6 +111,11 @@ interface EditorActions {
   updatePathProps: (id: string, patch: Partial<PathProps>) => void;
   selectPath: (id: string | null, pointIds?: string[]) => void;
   setPoints: (id: string, pts: PathPoint[]) => void;
+  startPen: () => void;
+  placePoint: (pt: { x: number; y: number }) => void;
+  deleteLast: () => void;
+  closePath: () => void;
+  cancelPen: () => void;
 }
 
 function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
@@ -140,6 +145,12 @@ function findNodeWithParent(
   return null;
 }
 
+function uuid() {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+}
+
 export const useEditorStore = create<EditorState & EditorActions>()(
   persist(
     (set, get) => {
@@ -158,7 +169,13 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         components: {},
         guides: [],
         vector: { selection: {} },
-        ui: { showRulers: false, showGuides: true, showSmartGuides: true, showOutline: false },
+        ui: {
+          showRulers: false,
+          showGuides: true,
+          showSmartGuides: true,
+          showOutline: false,
+          activeTool: 'select',
+        },
         prefs: { showLayoutGrid: false, showPixelGrid: false, snapToPixel: true },
         lastCommandId: undefined,
         review: { status: 'DRAFT', requireApprovedToShare: false },
@@ -669,6 +686,74 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               node.points = pts;
             }
           });
+        },
+        startPen() {
+          set((state) => ({
+            ui: { ...(state.ui || {}), activeTool: 'pen' },
+            vector: { ...(state.vector || {}), draft: undefined },
+          }));
+        },
+        placePoint(pt) {
+          apply((draft) => {
+            draft.vector = draft.vector || {};
+            if (!draft.vector.draft) {
+              draft.vector.draft = { pathId: uuid(), points: [] };
+            }
+            const d = draft.vector.draft;
+            const last = d.points[d.points.length - 1];
+            if (!last || last.x !== pt.x || last.y !== pt.y) {
+              d.points.push({ id: uuid(), x: pt.x, y: pt.y });
+            }
+          });
+        },
+        deleteLast() {
+          apply((draft) => {
+            const d = draft.vector?.draft;
+            if (d) {
+              d.points.pop();
+              if (d.points.length === 0) draft.vector!.draft = undefined;
+            }
+          });
+        },
+        closePath() {
+          apply((draft) => {
+            const d = draft.vector?.draft;
+            if (!d) return;
+            if (d.points.length < 2) {
+              draft.vector!.draft = undefined;
+              draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
+              return;
+            }
+            const pts = d.points;
+            const first = pts[0];
+            const last = pts[pts.length - 1];
+            const threshold = 6 / draft.camera.zoom;
+            const dist = Math.hypot(last.x - first.x, last.y - first.y);
+            const closed = dist <= threshold;
+            if (closed) {
+              last.x = first.x;
+              last.y = first.y;
+              if (pts.length > 1 && pts[pts.length - 1].id !== first.id) {
+                pts.pop();
+              }
+            }
+            draft.tree.push({
+              id: d.pathId,
+              type: 'Path',
+              closed,
+              points: pts,
+              props: { stroke: '#ffffff', fill: 'none', strokeWidth: 1 },
+            });
+            draft.selectedIds = [d.pathId];
+            draft.vector = { selection: { pathId: d.pathId } };
+            draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
+          });
+        },
+        cancelPen() {
+          set((state) => ({
+            ui: { ...(state.ui || {}), activeTool: 'select' },
+            vector: { ...(state.vector || {}), draft: undefined },
+          }));
         },
         undo() {
           set((state) => undoStack(state));

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -190,12 +190,14 @@ export interface EditorState {
   guides: Guide[];
   vector?: {
     selection?: { pathId?: string; pointIds?: string[] };
+    draft?: { pathId: string; points: PathPoint[] };
   };
   ui?: {
     showRulers?: boolean;
     showGuides?: boolean;
     showSmartGuides?: boolean;
     showOutline?: boolean;
+    activeTool?: 'select' | 'pen';
   };
   prefs?: {
     showLayoutGrid?: boolean;


### PR DESCRIPTION
## Summary
- implement pen tool with preview line and close-on-first-point
- wire keyboard shortcuts P/V/Enter/Esc/Backspace to pen actions
- add store actions for path drafting and confirmation

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 1 passed, 2 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a90b907da8832cb1ed6f8e02157108