### PR TITLE
feat(vector): add bezier pen support

### DIFF
--- a/web/components/editor/PathEditorOverlay.tsx
+++ b/web/components/editor/PathEditorOverlay.tsx
@@ -1,6 +1,42 @@
 'use client';
 import { useEditorStore } from '@/store/editorStore';
-import type { PathNode } from '@/types/editor';
+import type { PathNode, PathPoint } from '@/types/editor';
+import { useRef } from 'react';
+
+function areMirrored(pt: PathPoint) {
+  return (
+    pt.in &&
+    pt.out &&
+    Math.abs(pt.x * 2 - pt.in.x - pt.out.x) < 1e-6 &&
+    Math.abs(pt.y * 2 - pt.in.y - pt.out.y) < 1e-6
+  );
+}
+
+function segToCmd(prev: PathPoint, curr: PathPoint, prevSmooth: boolean) {
+  const c1 = prev.out || prev;
+  const c2 = curr.in || curr;
+  const useS = prevSmooth;
+  if (prev.out || curr.in) {
+    if (useS) return `S${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+    return `C${c1.x} ${c1.y} ${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+  }
+  return `L${curr.x} ${curr.y}`;
+}
+
+function pathToD(pts: PathPoint[], closed?: boolean) {
+  if (!pts.length) return '';
+  const cmds = [`M${pts[0].x} ${pts[0].y}`];
+  for (let i = 1; i < pts.length; i++) {
+    cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
+  }
+  if (closed) {
+    const last = pts[pts.length - 1];
+    const first = pts[0];
+    cmds.push(segToCmd(last, first, areMirrored(last)));
+    cmds.push('Z');
+  }
+  return cmds.join(' ');
+}
 
 export default function PathEditorOverlay() {
   const selection = useEditorStore((s) => s.vector?.selection);
@@ -8,25 +44,151 @@ export default function PathEditorOverlay() {
     s.tree.find((n): n is PathNode => n.id === selection?.pathId && n.type === 'Path')
   );
   const selectPath = useEditorStore((s) => s.selectPath);
+  const movePoint = useEditorStore((s) => s.movePoint);
+  const moveHandle = useEditorStore((s) => s.moveHandle);
+  const toggleCorner = useEditorStore((s) => s.toggleCorner);
+  const addPointOnSegment = useEditorStore((s) => s.addPointOnSegment);
+  const camera = useEditorStore((s) => s.camera);
   if (!path) return null;
   const selectedPts = selection?.pointIds || [];
+  const r = 4 / camera.zoom;
+
+  const drag = useRef<{ kind: 'point' | 'handle'; id: string; handle?: 'in' | 'out' } | null>(
+    null
+  );
+
+  const onPointerDownAnchor = (e: React.PointerEvent, pt: PathPoint) => {
+    selectPath(path.id, [pt.id]);
+    drag.current = { kind: 'point', id: pt.id };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    e.stopPropagation();
+  };
+
+  const onPointerDownHandle = (
+    e: React.PointerEvent,
+    pt: PathPoint,
+    kind: 'in' | 'out'
+  ) => {
+    drag.current = { kind: 'handle', id: pt.id, handle: kind };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    e.stopPropagation();
+  };
+
+  const toCanvas = (e: React.PointerEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) / camera.zoom + camera.x,
+      y: (e.clientY - rect.top) / camera.zoom + camera.y,
+    };
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    const pt = toCanvas(e);
+    if (drag.current.kind === 'point') movePoint(drag.current.id, pt);
+    else moveHandle(drag.current.id, drag.current.handle!, pt, { break: e.altKey });
+  };
+
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+
+  const onDoubleClick = (e: React.MouseEvent, id: string) => {
+    toggleCorner(id);
+    e.stopPropagation();
+  };
+
+  const onAltClick = (e: React.PointerEvent) => {
+    if (!e.altKey) return;
+    const p = toCanvas(e);
+    let best = { dist: Infinity, idx: 0, t: 0 };
+    const pts = path.points;
+    const count = path.closed ? pts.length : pts.length - 1;
+    for (let i = 0; i < count; i++) {
+      const a = pts[i];
+      const b = pts[(i + 1) % pts.length];
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const len2 = dx * dx + dy * dy;
+      let t = len2 ? ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2 : 0;
+      t = Math.max(0, Math.min(1, t));
+      const px = a.x + dx * t;
+      const py = a.y + dy * t;
+      const dist = Math.hypot(p.x - px, p.y - py);
+      if (dist < best.dist) best = { dist, idx: i, t };
+    }
+    addPointOnSegment(path.id, best.idx, best.t);
+    e.stopPropagation();
+  };
+
   return (
-    <svg className="absolute inset-0 pointer-events-none">
+    <svg
+      className="absolute inset-0 pointer-events-none"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerDown={onAltClick}
+    >
+      <path
+        d={pathToD(path.points, path.closed)}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={8 / camera.zoom}
+        className="pointer-events-auto"
+      />
       {path.points.map((pt) => (
-        <circle
-          key={pt.id}
-          cx={pt.x}
-          cy={pt.y}
-          r={4}
-          fill={selectedPts.includes(pt.id) ? '#ffa500' : '#ffffff'}
-          stroke="#000000"
-          strokeWidth={1}
-          className="pointer-events-auto"
-          onPointerDown={(e) => {
-            selectPath(path.id, [pt.id]);
-            e.stopPropagation();
-          }}
-        />
+        <g key={pt.id} className="pointer-events-none">
+          {pt.in && (
+            <>
+              <line
+                x1={pt.x}
+                y1={pt.y}
+                x2={pt.in.x}
+                y2={pt.in.y}
+                strokeWidth={1 / camera.zoom}
+                className="path-handle-line pointer-events-none"
+              />
+              <circle
+                cx={pt.in.x}
+                cy={pt.in.y}
+                r={r}
+                strokeWidth={1 / camera.zoom}
+                className="path-handle pointer-events-auto"
+                onPointerDown={(e) => onPointerDownHandle(e, pt, 'in')}
+              />
+            </>
+          )}
+          {pt.out && (
+            <>
+              <line
+                x1={pt.x}
+                y1={pt.y}
+                x2={pt.out.x}
+                y2={pt.out.y}
+                strokeWidth={1 / camera.zoom}
+                className="path-handle-line pointer-events-none"
+              />
+              <circle
+                cx={pt.out.x}
+                cy={pt.out.y}
+                r={r}
+                strokeWidth={1 / camera.zoom}
+                className="path-handle pointer-events-auto"
+                onPointerDown={(e) => onPointerDownHandle(e, pt, 'out')}
+              />
+            </>
+          )}
+          <rect
+            x={pt.x - r}
+            y={pt.y - r}
+            width={r * 2}
+            height={r * 2}
+            strokeWidth={1 / camera.zoom}
+            transform={`rotate(45 ${pt.x} ${pt.y})`}
+            className={`path-anchor${selectedPts.includes(pt.id) ? ' selected' : ''} pointer-events-auto`}
+            onPointerDown={(e) => onPointerDownAnchor(e, pt)}
+            onDoubleClick={(e) => onDoubleClick(e, pt.id)}
+          />
+        </g>
       ))}
     </svg>
   );

--- a/web/components/editor/SVGLayer.tsx
+++ b/web/components/editor/SVGLayer.tsx
@@ -1,11 +1,40 @@
 'use client';
 import { useEditorStore } from '@/store/editorStore';
-import type { PathNode } from '@/types/editor';
+import type { PathNode, PathPoint } from '@/types/editor';
+
+function areMirrored(pt: PathPoint) {
+  return (
+    pt.in &&
+    pt.out &&
+    Math.abs(pt.x * 2 - pt.in.x - pt.out.x) < 1e-6 &&
+    Math.abs(pt.y * 2 - pt.in.y - pt.out.y) < 1e-6
+  );
+}
+
+function segToCmd(prev: PathPoint, curr: PathPoint, prevSmooth: boolean) {
+  const c1 = prev.out || prev;
+  const c2 = curr.in || curr;
+  const useS = prevSmooth;
+  if (prev.out || curr.in) {
+    if (useS) return `S${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+    return `C${c1.x} ${c1.y} ${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+  }
+  return `L${curr.x} ${curr.y}`;
+}
 
 function pathToD(node: PathNode) {
-  if (!node.points.length) return '';
-  const cmds = node.points.map((pt, i) => `${i === 0 ? 'M' : 'L'}${pt.x} ${pt.y}`);
-  if (node.closed) cmds.push('Z');
+  const pts = node.points;
+  if (!pts.length) return '';
+  const cmds = [`M${pts[0].x} ${pts[0].y}`];
+  for (let i = 1; i < pts.length; i++) {
+    cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
+  }
+  if (node.closed) {
+    const last = pts[pts.length - 1];
+    const first = pts[0];
+    cmds.push(segToCmd(last, first, areMirrored(last)));
+    cmds.push('Z');
+  }
   return cmds.join(' ');
 }
 

--- a/web/components/editor/tools/PenTool.tsx
+++ b/web/components/editor/tools/PenTool.tsx
@@ -2,21 +2,56 @@
 import { useEditorStore } from '@/store/editorStore';
 import { useState, useRef } from 'react';
 import type { PathPoint } from '@/types/editor';
+import { angleSnap } from '@/lib/vector/bezier';
 
-function pathToD(pts: PathPoint[]) {
+function areMirrored(pt: PathPoint) {
+  return (
+    pt.in &&
+    pt.out &&
+    Math.abs(pt.x * 2 - pt.in.x - pt.out.x) < 1e-6 &&
+    Math.abs(pt.y * 2 - pt.in.y - pt.out.y) < 1e-6
+  );
+}
+
+function segToCmd(prev: PathPoint, curr: PathPoint, prevSmooth: boolean) {
+  const c1 = prev.out || prev;
+  const c2 = curr.in || curr;
+  const useS = prevSmooth;
+  if (prev.out || curr.in) {
+    if (useS) {
+      return `S${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+    }
+    return `C${c1.x} ${c1.y} ${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+  }
+  return `L${curr.x} ${curr.y}`;
+}
+
+function pathToD(pts: PathPoint[], closed?: boolean) {
   if (!pts.length) return '';
-  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x} ${p.y}`).join(' ');
+  const cmds = [`M${pts[0].x} ${pts[0].y}`];
+  for (let i = 1; i < pts.length; i++) {
+    cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
+  }
+  if (closed) {
+    const last = pts[pts.length - 1];
+    const first = pts[0];
+    cmds.push(segToCmd(last, first, areMirrored(last)));
+    cmds.push('Z');
+  }
+  return cmds.join(' ');
 }
 
 export default function PenTool() {
   const draft = useEditorStore((s) => s.vector?.draft);
   const placePoint = useEditorStore((s) => s.placePoint);
+  const moveHandle = useEditorStore((s) => s.moveHandle);
   const closePath = useEditorStore((s) => s.closePath);
   const camera = useEditorStore((s) => s.camera);
 
   const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
   const pending = useRef<{ x: number; y: number } | null>(null);
   const raf = useRef<number>();
+  const dragId = useRef<string | null>(null);
 
   const updateCursor = () => {
     raf.current = undefined;
@@ -45,39 +80,60 @@ export default function PenTool() {
         return;
       }
     }
-    placePoint(pt);
+    placePoint({ x: pt.x, y: pt.y });
+    const d = useEditorStore.getState().vector!.draft!;
+    dragId.current = d.points[d.points.length - 1].id;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
     e.stopPropagation();
     const pt = toCanvas(e);
     pending.current = pt;
-    if (!raf.current) {
-      raf.current = requestAnimationFrame(updateCursor);
+    if (dragId.current) {
+      const d = useEditorStore.getState().vector?.draft;
+      const p = d?.points.find((q) => q.id === dragId.current);
+      if (p) {
+        let h = pt;
+        if (e.shiftKey) {
+          const snap = angleSnap(pt.x - p.x, pt.y - p.y);
+          h = { x: p.x + snap.x, y: p.y + snap.y };
+        }
+        moveHandle(p.id, 'out', h, { break: e.altKey });
+      }
+    } else {
+      if (!raf.current) {
+        raf.current = requestAnimationFrame(updateCursor);
+      }
     }
   };
 
+  const onPointerUp = () => {
+    dragId.current = null;
+  };
+
   const previewD =
-    draft && cursor && draft.points.length
-      ? `M${draft.points[draft.points.length - 1].x} ${draft.points[draft.points.length - 1].y} L${cursor.x} ${cursor.y}`
-      : '';
+    draft && cursor && draft.points.length && !dragId.current
+      ? pathToD([...draft.points, { id: 'p', x: cursor.x, y: cursor.y }])
+      : pathToD(draft?.points || [], draft?.closed);
 
   return (
     <div
       className="absolute inset-0 cursor-crosshair"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
     >
       {draft && (
         <svg className="absolute inset-0 pointer-events-none">
           <path
-            d={pathToD(draft.points)}
+            d={pathToD(draft.points, draft.closed)}
             fill="none"
             stroke="#ffffff"
             strokeWidth={1}
             opacity={0.5}
           />
-          {previewD && (
+          {previewD && previewD !== pathToD(draft.points, draft.closed) && (
             <path
               d={previewD}
               fill="none"

--- a/web/lib/vector/bezier.ts
+++ b/web/lib/vector/bezier.ts
@@ -1,0 +1,70 @@
+export interface Point { x: number; y: number }
+
+export function evalCubic(
+  p0: Point,
+  p1: Point,
+  p2: Point,
+  p3: Point,
+  t: number
+): Point {
+  const mt = 1 - t;
+  const mt2 = mt * mt;
+  const t2 = t * t;
+  return {
+    x:
+      mt2 * mt * p0.x +
+      3 * mt2 * t * p1.x +
+      3 * mt * t2 * p2.x +
+      t2 * t * p3.x,
+    y:
+      mt2 * mt * p0.y +
+      3 * mt2 * t * p1.y +
+      3 * mt * t2 * p2.y +
+      t2 * t * p3.y,
+  };
+}
+
+export function reflectHandle(anchor: Point, h: Point): Point {
+  return { x: 2 * anchor.x - h.x, y: 2 * anchor.y - h.y };
+}
+
+export function angleSnap(dx: number, dy: number): Point {
+  const len = Math.hypot(dx, dy);
+  if (len === 0) return { x: 0, y: 0 };
+  const step = Math.PI / 4;
+  const ang = Math.atan2(dy, dx);
+  const snap = Math.round(ang / step) * step;
+  return { x: len * Math.cos(snap), y: len * Math.sin(snap) };
+}
+
+function flatEnough(p0: Point, p1: Point, p2: Point, p3: Point, f: number) {
+  const ux = 3 * p1.x - 2 * p0.x - p3.x;
+  const uy = 3 * p1.y - 2 * p0.y - p3.y;
+  const vx = 3 * p2.x - 2 * p3.x - p0.x;
+  const vy = 3 * p2.y - 2 * p3.y - p0.y;
+  return Math.max(ux * ux + uy * uy, vx * vx + vy * vy) <= f * f;
+}
+
+export function flattenCubic(
+  p0: Point,
+  p1: Point,
+  p2: Point,
+  p3: Point,
+  flatness = 0.5
+): Point[] {
+  if (flatEnough(p0, p1, p2, p3, flatness)) return [p0, p3];
+  const a = lerpPoint(p0, p1, 0.5);
+  const b = lerpPoint(p1, p2, 0.5);
+  const c = lerpPoint(p2, p3, 0.5);
+  const d = lerpPoint(a, b, 0.5);
+  const e = lerpPoint(b, c, 0.5);
+  const f = lerpPoint(d, e, 0.5);
+  return [
+    ...flattenCubic(p0, a, d, f, flatness),
+    ...flattenCubic(f, e, c, p3, flatness).slice(1),
+  ];
+}
+
+function lerpPoint(a: Point, b: Point, t: number): Point {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -21,6 +21,7 @@ import { push, undo as undoStack, redo as redoStack } from './undoRedo';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
 import { MIN_ZOOM, MAX_ZOOM } from '@/lib/layout/constants';
+import { reflectHandle } from '@/lib/vector/bezier';
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -112,10 +113,19 @@ interface EditorActions {
   selectPath: (id: string | null, pointIds?: string[]) => void;
   setPoints: (id: string, pts: PathPoint[]) => void;
   startPen: () => void;
-  placePoint: (pt: { x: number; y: number }) => void;
+  placePoint: (pt: { x: number; y: number; in?: { x: number; y: number }; out?: { x: number; y: number }; corner?: boolean }) => void;
   deleteLast: () => void;
   closePath: () => void;
   cancelPen: () => void;
+  movePoint: (id: string, to: { x: number; y: number }) => void;
+  moveHandle: (
+    id: string,
+    kind: 'in' | 'out',
+    to: { x: number; y: number },
+    opts?: { break?: boolean }
+  ) => void;
+  addPointOnSegment: (pathId: string, segIndex: number, t: number) => void;
+  toggleCorner: (id: string) => void;
 }
 
 function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
@@ -149,6 +159,10 @@ function uuid() {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
     : Math.random().toString(36).slice(2);
+}
+
+function lerp(a: { x: number; y: number }, b: { x: number; y: number }, t: number) {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
 }
 
 export const useEditorStore = create<EditorState & EditorActions>()(
@@ -702,7 +716,14 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             const d = draft.vector.draft;
             const last = d.points[d.points.length - 1];
             if (!last || last.x !== pt.x || last.y !== pt.y) {
-              d.points.push({ id: uuid(), x: pt.x, y: pt.y });
+              d.points.push({
+                id: uuid(),
+                x: pt.x,
+                y: pt.y,
+                in: pt.in,
+                out: pt.out,
+                corner: pt.corner,
+              });
             }
           });
         },
@@ -754,6 +775,100 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             ui: { ...(state.ui || {}), activeTool: 'select' },
             vector: { ...(state.vector || {}), draft: undefined },
           }));
+        },
+        movePoint(id, to) {
+          apply((draft) => {
+            const update = (pts: PathPoint[]) => {
+              const p = pts.find((q) => q.id === id);
+              if (p) {
+                const dx = to.x - p.x;
+                const dy = to.y - p.y;
+                p.x = to.x;
+                p.y = to.y;
+                if (p.in) {
+                  p.in.x += dx;
+                  p.in.y += dy;
+                }
+                if (p.out) {
+                  p.out.x += dx;
+                  p.out.y += dy;
+                }
+              }
+            };
+            draft.tree.forEach((n) => {
+              if (n.type === 'Path') update(n.points);
+            });
+            draft.vector?.draft && update(draft.vector.draft.points);
+          });
+        },
+        moveHandle(id, kind, to, opts) {
+          apply((draft) => {
+            const update = (pts: PathPoint[]) => {
+              const p = pts.find((q) => q.id === id);
+              if (p) {
+                (p as any)[kind] = { x: to.x, y: to.y };
+                if (opts?.break) p.corner = true;
+                if (!opts?.break && !p.corner) {
+                  const other = kind === 'in' ? 'out' : 'in';
+                  (p as any)[other] = reflectHandle({ x: p.x, y: p.y }, { x: to.x, y: to.y });
+                }
+              }
+            };
+            draft.tree.forEach((n) => {
+              if (n.type === 'Path') update(n.points);
+            });
+            draft.vector?.draft && update(draft.vector.draft.points);
+          });
+        },
+        addPointOnSegment(pathId, segIndex, t) {
+          apply((draft) => {
+            const node = findNode(draft.tree, pathId) as PathNode | null;
+            if (!node || node.type !== 'Path') return;
+            const pts = node.points;
+            const a = pts[segIndex];
+            const b = pts[(segIndex + 1) % pts.length];
+            const p0 = a;
+            const p1 = a.out || a;
+            const p2 = b.in || b;
+            const p3 = b;
+            const a1 = lerp(p0, p1, t);
+            const b1 = lerp(p1, p2, t);
+            const c1 = lerp(p2, p3, t);
+            const d1 = lerp(a1, b1, t);
+            const e1 = lerp(b1, c1, t);
+            const f1 = lerp(d1, e1, t);
+            a.out = a1;
+            b.in = c1;
+            const newPt: PathPoint = {
+              id: uuid(),
+              x: f1.x,
+              y: f1.y,
+              in: d1,
+              out: e1,
+            };
+            pts.splice(segIndex + 1, 0, newPt);
+          });
+        },
+        toggleCorner(id) {
+          apply((draft) => {
+            const update = (pts: PathPoint[]) => {
+              const p = pts.find((q) => q.id === id);
+              if (p) {
+                p.corner = !p.corner;
+                if (!p.corner) {
+                  if (p.out && !p.in) p.in = reflectHandle(p, p.out);
+                  else if (p.in && !p.out) p.out = reflectHandle(p, p.in);
+                  else if (p.in && p.out) {
+                    p.in = reflectHandle(p, p.out);
+                  }
+                }
+              }
+            };
+            draft.tree.forEach((n) => {
+              if (n.type === 'Path') update(n.points);
+            });
+            draft.vector?.draft && update(draft.vector.draft.points);
+          });
         },
         undo() {
           set((state) => undoStack(state));

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -65,3 +65,23 @@
   background-size: 1px 1px;
   z-index: 6;
 }
+
+/* vector editing */
+.path-handle-line {
+  stroke: #999;
+  stroke-dasharray: 4 4;
+}
+
+.path-handle {
+  fill: #000;
+  stroke: #fff;
+}
+
+.path-anchor {
+  fill: #fff;
+  stroke: #000;
+}
+
+.path-anchor.selected {
+  fill: #ffa500;
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -112,6 +112,9 @@ export interface PathPoint {
   id: string;
   x: number;
   y: number;
+  in?: { x: number; y: number };
+  out?: { x: number; y: number };
+  corner?: boolean;
 }
 
 export interface PathProps {


### PR DESCRIPTION
## Summary
- extend PathPoint with Bezier handles and corner flag
- implement cubic Bezier helpers and PenTool curve drawing with Shift/Alt modifiers
- add overlay for handle editing and update SVG output

## Testing
- `npm test --prefix web` (fails: Missing script: "test")
- `npm run build --prefix web` (fails: Nullish coalescing operator requires parens)


------
https://chatgpt.com/codex/tasks/task_e_68a90fa9ffb0832cadd2ae6e67e43f66