### PR TITLE
feat(vector): add stroke style controls and fill rule

### DIFF
--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,24 +1,33 @@
-'use client';
-import { useEditorStore } from '@/store/editorStore';
-import type { PathNode } from '@/types/editor';
+"use client";
+import { useEditorStore } from "@/store/editorStore";
+import type { PathNode } from "@/types/editor";
 
 export default function RightPane() {
   const selected = useEditorStore((s) => s.vector?.selection?.pathId);
   const path = useEditorStore((s) =>
-    s.tree.find((n): n is PathNode => n.id === selected && n.type === 'Path')
+    s.tree.find((n): n is PathNode => n.id === selected && n.type === "Path"),
   );
-  const update = useEditorStore((s) => s.updatePathProps);
+  const setProps = useEditorStore((s) => s.setPathProps);
   if (!path) return <div className="bg-gray-800" />;
   const props = path.props || {};
+  const parseDash = (v: string) => {
+    const nums = v
+      .trim()
+      .split(/[\s,]+/)
+      .map(Number)
+      .filter((n) => !isNaN(n) && n > 0);
+    return nums.length ? nums : undefined;
+  };
   return (
     <div className="bg-gray-800 p-2 space-y-2 text-xs">
+      <div className="font-bold">Vector › Style</div>
       <label className="block">
         Fill:
         <input
           type="text"
           className="w-full bg-gray-700 ml-1 p-1 text-white"
-          value={props.fill || ''}
-          onChange={(e) => update(path.id, { fill: e.target.value })}
+          value={props.fill || ""}
+          onChange={(e) => setProps(path.id, { fill: e.target.value })}
         />
       </label>
       <label className="block">
@@ -26,8 +35,8 @@ export default function RightPane() {
         <input
           type="text"
           className="w-full bg-gray-700 ml-1 p-1 text-white"
-          value={props.stroke || ''}
-          onChange={(e) => update(path.id, { stroke: e.target.value })}
+          value={props.stroke || ""}
+          onChange={(e) => setProps(path.id, { stroke: e.target.value })}
         />
       </label>
       <label className="block">
@@ -37,10 +46,138 @@ export default function RightPane() {
           className="w-full bg-gray-700 ml-1 p-1 text-white"
           value={props.strokeWidth ?? 1}
           onChange={(e) =>
-            update(path.id, { strokeWidth: Number(e.target.value) })
+            setProps(path.id, { strokeWidth: Number(e.target.value) })
           }
         />
       </label>
+      <div>
+        <div className="mb-1">Cap:</div>
+        <div className="flex gap-1">
+          {(["butt", "round", "square"] as const).map((cap) => (
+            <button
+              key={cap}
+              className={`flex-1 p-1 ${
+                props.strokeCap === cap ? "bg-blue-600" : "bg-gray-700"
+              }`}
+              onClick={() => setProps(path.id, { strokeCap: cap })}
+            >
+              {cap}
+            </button>
+          ))}
+          <button
+            className="p-1 bg-gray-700"
+            onClick={() => setProps(path.id, { strokeCap: undefined })}
+          >
+            ↺
+          </button>
+        </div>
+      </div>
+      <div>
+        <div className="mb-1">Join:</div>
+        <div className="flex gap-1">
+          {(["miter", "round", "bevel"] as const).map((join) => (
+            <button
+              key={join}
+              className={`flex-1 p-1 ${
+                props.strokeJoin === join ? "bg-blue-600" : "bg-gray-700"
+              }`}
+              onClick={() => setProps(path.id, { strokeJoin: join })}
+            >
+              {join}
+            </button>
+          ))}
+          <button
+            className="p-1 bg-gray-700"
+            onClick={() => setProps(path.id, { strokeJoin: undefined })}
+          >
+            ↺
+          </button>
+        </div>
+      </div>
+      <div className="flex items-center">
+        <label className="flex-1">
+          Miter Limit:
+          <input
+            type="number"
+            min={1}
+            step={0.5}
+            disabled={props.strokeJoin !== "miter"}
+            className="w-full bg-gray-700 ml-1 p-1 text-white"
+            value={props.miterLimit ?? 4}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              if (!isNaN(v) && v >= 1) setProps(path.id, { miterLimit: v });
+            }}
+          />
+        </label>
+        <button
+          className="ml-1 p-1 bg-gray-700"
+          onClick={() => setProps(path.id, { miterLimit: undefined })}
+        >
+          ↺
+        </button>
+      </div>
+      <div className="flex items-center">
+        <label className="flex-1">
+          Dash:
+          <input
+            type="text"
+            className="w-full bg-gray-700 ml-1 p-1 text-white"
+            value={props.dash?.join(" ") || ""}
+            onChange={(e) =>
+              setProps(path.id, { dash: parseDash(e.target.value) })
+            }
+          />
+        </label>
+        <button
+          className="ml-1 p-1 bg-gray-700"
+          onClick={() => setProps(path.id, { dash: undefined })}
+        >
+          ↺
+        </button>
+      </div>
+      <div className="flex items-center">
+        <label className="flex-1">
+          Offset:
+          <input
+            type="number"
+            className="w-full bg-gray-700 ml-1 p-1 text-white"
+            value={props.dashOffset ?? 0}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              if (!isNaN(v)) setProps(path.id, { dashOffset: v });
+            }}
+          />
+        </label>
+        <button
+          className="ml-1 p-1 bg-gray-700"
+          onClick={() => setProps(path.id, { dashOffset: undefined })}
+        >
+          ↺
+        </button>
+      </div>
+      <div>
+        <div className="mb-1">Fill Rule:</div>
+        <div className="flex items-center gap-2">
+          {(["nonzero", "evenodd"] as const).map((rule) => (
+            <label key={rule} className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="fillRule"
+                checked={(props.fillRule || "nonzero") === rule}
+                onChange={() => setProps(path.id, { fillRule: rule })}
+              />
+              {rule}
+            </label>
+          ))}
+          <button
+            className="p-1 bg-gray-700"
+            onClick={() => setProps(path.id, { fillRule: undefined })}
+          >
+            ↺
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/components/editor/SVGLayer.tsx
+++ b/web/components/editor/SVGLayer.tsx
@@ -1,6 +1,6 @@
-'use client';
-import { useEditorStore } from '@/store/editorStore';
-import type { PathNode, PathPoint } from '@/types/editor';
+"use client";
+import { useEditorStore } from "@/store/editorStore";
+import type { PathNode, PathPoint } from "@/types/editor";
 
 function areMirrored(pt: PathPoint) {
   return (
@@ -24,7 +24,7 @@ function segToCmd(prev: PathPoint, curr: PathPoint, prevSmooth: boolean) {
 
 function pathToD(node: PathNode) {
   const pts = node.points;
-  if (!pts.length) return '';
+  if (!pts.length) return "";
   const cmds = [`M${pts[0].x} ${pts[0].y}`];
   for (let i = 1; i < pts.length; i++) {
     cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
@@ -33,32 +33,53 @@ function pathToD(node: PathNode) {
     const last = pts[pts.length - 1];
     const first = pts[0];
     cmds.push(segToCmd(last, first, areMirrored(last)));
-    cmds.push('Z');
+    cmds.push("Z");
   }
-  return cmds.join(' ');
+  return cmds.join(" ");
 }
 
 export default function SVGLayer() {
   const paths = useEditorStore((s) =>
-    s.tree.filter((n): n is PathNode => n.type === 'Path')
+    s.tree.filter((n): n is PathNode => n.type === "Path"),
   );
   const selectPath = useEditorStore((s) => s.selectPath);
   return (
     <svg className="absolute inset-0 pointer-events-none">
-      {paths.map((p) => (
-        <path
-          key={p.id}
-          d={pathToD(p)}
-          fill={p.props?.fill || 'none'}
-          stroke={p.props?.stroke || 'none'}
-          strokeWidth={p.props?.strokeWidth || 1}
-          className="pointer-events-auto"
-          onPointerDown={(e) => {
-            selectPath(p.id);
-            e.stopPropagation();
-          }}
-        />
-      ))}
+      {paths.map((p) => {
+        const props = p.props || {};
+        const strokeWidth = props.strokeWidth ?? 0;
+        const strokeProps =
+          strokeWidth > 0
+            ? {
+                stroke: props.stroke || "none",
+                strokeWidth,
+                strokeLinecap: props.strokeCap || "butt",
+                strokeLinejoin: props.strokeJoin || "miter",
+                strokeMiterlimit: props.miterLimit ?? 4,
+                strokeDasharray:
+                  props.dash && props.dash.length
+                    ? props.dash.join(" ")
+                    : undefined,
+                strokeDashoffset: props.dashOffset ?? 0,
+                strokeOpacity: props.strokeOpacity ?? 1,
+              }
+            : {};
+        return (
+          <path
+            key={p.id}
+            d={pathToD(p)}
+            fill={props.fill || "none"}
+            fillOpacity={props.fillOpacity ?? 1}
+            fillRule={props.fillRule || "nonzero"}
+            className="pointer-events-auto"
+            onPointerDown={(e) => {
+              selectPath(p.id);
+              e.stopPropagation();
+            }}
+            {...strokeProps}
+          />
+        );
+      })}
     </svg>
   );
 }

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -1,6 +1,6 @@
-import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import { produceWithPatches } from 'immer';
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { produceWithPatches } from "immer";
 import type {
   EditorState,
   ComponentNode,
@@ -15,18 +15,23 @@ import type {
   PathNode,
   PathPoint,
   PathProps,
-} from '@/types/editor';
-import { idbStorage } from '@/lib/idb';
-import { push, undo as undoStack, redo as redoStack } from './undoRedo';
-import { resolveVariant } from '@/lib/variantResolver';
-import { applyOverrides } from '@/lib/overrideMerge';
-import { MIN_ZOOM, MAX_ZOOM } from '@/lib/layout/constants';
-import { reflectHandle } from '@/lib/vector/bezier';
+} from "@/types/editor";
+import { idbStorage } from "@/lib/idb";
+import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
+import { resolveVariant } from "@/lib/variantResolver";
+import { applyOverrides } from "@/lib/overrideMerge";
+import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
+import { reflectHandle } from "@/lib/vector/bezier";
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
   updateNode: (id: string, patch: Partial<ComponentNode>) => void;
-  moveNode: (id: string, dx: number, dy: number, opts?: { snap?: boolean }) => void;
+  moveNode: (
+    id: string,
+    dx: number,
+    dy: number,
+    opts?: { snap?: boolean },
+  ) => void;
   resizeNode: (id: string, next: { w?: number; h?: number }) => void;
   rotateNode: (id: string, deg: number) => void;
   duplicate: (ids?: string[]) => void;
@@ -38,13 +43,13 @@ interface EditorActions {
   reorderChild: (parentId: string, from: number, to: number) => void;
   setLayoutProps: (
     id: string,
-    patch: Partial<NonNullable<ComponentNode['props']>>
+    patch: Partial<NonNullable<ComponentNode["props"]>>,
   ) => void;
   setSizeMode: (
     id: string,
-    axis: 'w' | 'h',
+    axis: "w" | "h",
     mode: SizeMode,
-    value?: number
+    value?: number,
   ) => void;
   // Components
   createComponentFromSelection: (name?: string) => void;
@@ -54,10 +59,12 @@ interface EditorActions {
   detachInstance: (nodeId: string) => void;
   swapInstance: (nodeId: string, nextComponentId: string) => void;
   // v3 additions
-  align: (kind: 'left' | 'right' | 'top' | 'bottom' | 'centerH' | 'centerV') => void;
-  distribute: (kind: 'h' | 'v', space?: number) => void;
-  reorder: (kind: 'front' | 'back' | 'forward' | 'backward') => void;
-  addGuide: (g: Omit<Guide, 'id'>) => void;
+  align: (
+    kind: "left" | "right" | "top" | "bottom" | "centerH" | "centerV",
+  ) => void;
+  distribute: (kind: "h" | "v", space?: number) => void;
+  reorder: (kind: "front" | "back" | "forward" | "backward") => void;
+  addGuide: (g: Omit<Guide, "id">) => void;
   moveGuide: (id: string, pos: number) => void;
   removeGuide: (id: string) => void;
   toggleRulers: () => void;
@@ -68,14 +75,30 @@ interface EditorActions {
   toggleSnapToPixel: () => void;
   setLastCommand: (id: string) => void;
   setCamera: (cam: Partial<Camera>) => void;
-  tweenCamera: (cam: Camera | Partial<Camera>, opts?: { duration?: number }) => void;
+  tweenCamera: (
+    cam: Camera | Partial<Camera>,
+    opts?: { duration?: number },
+  ) => void;
   getViewportRect: () => { x: number; y: number; w: number; h: number };
-  getSelectionBounds: () => { x: number; y: number; w: number; h: number } | null;
+  getSelectionBounds: () => {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  } | null;
   // Variants
-  defineVariantAxis: (componentId: string, axis: string, values: string[]) => void;
+  defineVariantAxis: (
+    componentId: string,
+    axis: string,
+    values: string[],
+  ) => void;
   setVariantRule: (
     componentId: string,
-    rule: { when: Record<string, string>; node: string; patch: Partial<ComponentNode> }
+    rule: {
+      when: Record<string, string>;
+      node: string;
+      patch: Partial<ComponentNode>;
+    },
   ) => void;
   removeVariantRule: (componentId: string, index: number) => void;
   setInstanceVariant: (nodeId: string, axis: string, value: string) => void;
@@ -83,7 +106,7 @@ interface EditorActions {
   setInstanceOverride: (
     nodeId: string,
     targetId: string,
-    patch: Partial<ComponentNode>
+    patch: Partial<ComponentNode>,
   ) => void;
   resetInstanceOverride: (nodeId: string, targetId?: string) => void;
   // v5 comments and review
@@ -95,34 +118,40 @@ interface EditorActions {
   replyThread: (threadId: string, text: string) => void;
   resolveThread: (threadId: string, byUserId: string) => void;
   reopenThread: (threadId: string) => void;
-  addReaction: (threadId: string, msgId: string, kind: '+1' | 'heart') => void;
+  addReaction: (threadId: string, msgId: string, kind: "+1" | "heart") => void;
   removeReaction: (
     threadId: string,
     msgId: string,
-    kind: '+1' | 'heart',
-    userId: string
+    kind: "+1" | "heart",
+    userId: string,
   ) => void;
   setCommentsFilter: (
-    filter: Partial<EditorState['comments']['filter']>
+    filter: Partial<EditorState["comments"]["filter"]>,
   ) => void;
   setReviewStatus: (s: ReviewStatus) => void;
   toggleRequireApprovedToShare: () => void;
   // Vector
   addPath: (path: PathNode) => void;
-  updatePathProps: (id: string, patch: Partial<PathProps>) => void;
+  setPathProps: (id: string, patch: Partial<PathProps>) => void;
   selectPath: (id: string | null, pointIds?: string[]) => void;
   setPoints: (id: string, pts: PathPoint[]) => void;
   startPen: () => void;
-  placePoint: (pt: { x: number; y: number; in?: { x: number; y: number }; out?: { x: number; y: number }; corner?: boolean }) => void;
+  placePoint: (pt: {
+    x: number;
+    y: number;
+    in?: { x: number; y: number };
+    out?: { x: number; y: number };
+    corner?: boolean;
+  }) => void;
   deleteLast: () => void;
   closePath: () => void;
   cancelPen: () => void;
   movePoint: (id: string, to: { x: number; y: number }) => void;
   moveHandle: (
     id: string,
-    kind: 'in' | 'out',
+    kind: "in" | "out",
     to: { x: number; y: number },
-    opts?: { break?: boolean }
+    opts?: { break?: boolean },
   ) => void;
   addPointOnSegment: (pathId: string, segIndex: number, t: number) => void;
   toggleCorner: (id: string) => void;
@@ -142,7 +171,7 @@ function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
 function findNodeWithParent(
   nodes: ComponentNode[],
   id: string,
-  parent: ComponentNode | null = null
+  parent: ComponentNode | null = null,
 ): { node: ComponentNode; parent: ComponentNode | null; index: number } | null {
   for (let i = 0; i < nodes.length; i++) {
     const n = nodes[i];
@@ -156,12 +185,16 @@ function findNodeWithParent(
 }
 
 function uuid() {
-  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
     ? crypto.randomUUID()
     : Math.random().toString(36).slice(2);
 }
 
-function lerp(a: { x: number; y: number }, b: { x: number; y: number }, t: number) {
+function lerp(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+  t: number,
+) {
   return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
 }
 
@@ -188,15 +221,20 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           showGuides: true,
           showSmartGuides: true,
           showOutline: false,
-          activeTool: 'select',
+          activeTool: "select",
         },
-        prefs: { showLayoutGrid: false, showPixelGrid: false, snapToPixel: true },
+        prefs: {
+          showLayoutGrid: false,
+          showPixelGrid: false,
+          snapToPixel: true,
+        },
         lastCommandId: undefined,
-        review: { status: 'DRAFT', requireApprovedToShare: false },
+        review: { status: "DRAFT", requireApprovedToShare: false },
         comments: { threads: {}, users: {} },
         select(ids) {
           set((state) => ({
-            selectedIds: typeof ids === 'function' ? ids(state.selectedIds) : ids,
+            selectedIds:
+              typeof ids === "function" ? ids(state.selectedIds) : ids,
           }));
         },
         updateNode(id, patch) {
@@ -268,8 +306,8 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               : findNode(draft.tree, draft.selectedIds[0]);
             if (target) {
               target.props = target.props || {};
-              target.props.layout = 'auto';
-              if (!target.props.axis) target.props.axis = 'vertical';
+              target.props.layout = "auto";
+              if (!target.props.axis) target.props.axis = "vertical";
             }
           });
         },
@@ -279,7 +317,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               ? findNode(draft.tree, frameId)
               : findNode(draft.tree, draft.selectedIds[0]);
             if (target && target.props) {
-              target.props.layout = 'free';
+              target.props.layout = "free";
             }
           });
         },
@@ -307,12 +345,12 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             const node = findNode(draft.tree, id);
             if (!node) return;
             node.props = node.props || {};
-            if (axis === 'w') {
+            if (axis === "w") {
               node.props.widthMode = mode;
-              if (mode === 'FIXED' && value !== undefined) node.props.w = value;
+              if (mode === "FIXED" && value !== undefined) node.props.w = value;
             } else {
               node.props.heightMode = mode;
-              if (mode === 'FIXED' && value !== undefined) node.props.h = value;
+              if (mode === "FIXED" && value !== undefined) node.props.h = value;
             }
           });
         },
@@ -325,13 +363,13 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             const compId = Math.random().toString(36).slice(2);
             draft.components[compId] = {
               id: compId,
-              name: name || node.name || 'Component',
+              name: name || node.name || "Component",
               root: node,
             } as ComponentDefinition;
             const instId = Math.random().toString(36).slice(2);
             const instance: InstanceNode = {
               id: instId,
-              type: 'Instance',
+              type: "Instance",
               componentId: compId,
               props: { ...node.props },
             };
@@ -357,7 +395,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             const id = Math.random().toString(36).slice(2);
             const inst: InstanceNode = {
               id,
-              type: 'Instance',
+              type: "Instance",
               componentId,
               variant: {},
               overrides: {},
@@ -412,7 +450,10 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         },
         addGuide(g) {
           apply((draft) => {
-            draft.guides.push({ id: Math.random().toString(36).slice(2), ...g });
+            draft.guides.push({
+              id: Math.random().toString(36).slice(2),
+              ...g,
+            });
           });
         },
         moveGuide(id, pos) {
@@ -486,7 +527,12 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           const { camera } = get();
           const w = window.innerWidth;
           const h = window.innerHeight;
-          return { x: camera.x, y: camera.y, w: w / camera.zoom, h: h / camera.zoom };
+          return {
+            x: camera.x,
+            y: camera.y,
+            w: w / camera.zoom,
+            h: h / camera.zoom,
+          };
         },
         getSelectionBounds() {
           const { selectedIds, tree } = get();
@@ -503,7 +549,12 @@ export const useEditorStore = create<EditorState & EditorActions>()(
                 };
               return null;
             })
-            .filter(Boolean) as Array<{ x: number; y: number; w: number; h: number }>;
+            .filter(Boolean) as Array<{
+            x: number;
+            y: number;
+            w: number;
+            h: number;
+          }>;
           const x1 = Math.min(...boxes.map((b) => b.x));
           const y1 = Math.min(...boxes.map((b) => b.y));
           const x2 = Math.max(...boxes.map((b) => b.x + b.w));
@@ -560,12 +611,17 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         // --- v5 comments & review ---
         startPinAnnotation() {
           set((state) => ({
-            comments: { ...state.comments, draft: { anchor: { kind: 'PIN' } } },
+            comments: { ...state.comments, draft: { anchor: { kind: "PIN" } } },
           }));
         },
         startRectAnnotation() {
           set((state) => ({
-            comments: { ...state.comments, draft: { anchor: { kind: 'RECT', rect: { x: 0, y: 0, w: 0, h: 0 } } } },
+            comments: {
+              ...state.comments,
+              draft: {
+                anchor: { kind: "RECT", rect: { x: 0, y: 0, w: 0, h: 0 } },
+              },
+            },
           }));
         },
         placeAnnotationAt(pt) {
@@ -579,7 +635,9 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           });
         },
         cancelAnnotation() {
-          set((state) => ({ comments: { ...state.comments, draft: undefined } }));
+          set((state) => ({
+            comments: { ...state.comments, draft: undefined },
+          }));
         },
         createThread(anchor, text) {
           set((state) => {
@@ -587,10 +645,10 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             const msgId = Math.random().toString(36).slice(2);
             const thread: CommentThread = {
               id,
-              status: 'OPEN',
+              status: "OPEN",
               anchor,
               messages: [
-                { id: msgId, userId: 'local', createdAt: Date.now(), text },
+                { id: msgId, userId: "local", createdAt: Date.now(), text },
               ],
             };
             return {
@@ -609,7 +667,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             const msgId = Math.random().toString(36).slice(2);
             thread.messages.push({
               id: msgId,
-              userId: 'local',
+              userId: "local",
               createdAt: Date.now(),
               text,
             });
@@ -620,7 +678,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           set((state) => {
             const thread = state.comments.threads[threadId];
             if (thread) {
-              thread.status = 'RESOLVED';
+              thread.status = "RESOLVED";
               thread.resolvedBy = byUserId;
               thread.resolvedAt = Date.now();
             }
@@ -630,19 +688,19 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         reopenThread(threadId) {
           set((state) => {
             const thread = state.comments.threads[threadId];
-            if (thread) thread.status = 'REOPENED';
+            if (thread) thread.status = "REOPENED";
             return { comments: { ...state.comments } };
           });
         },
         addReaction(threadId, msgId, kind) {
           set((state) => {
             const msg = state.comments.threads[threadId]?.messages.find(
-              (m) => m.id === msgId
+              (m) => m.id === msgId,
             );
             if (msg) {
-              msg.reactions = msg.reactions || { '+1': [], heart: [] };
+              msg.reactions = msg.reactions || { "+1": [], heart: [] };
               const arr = msg.reactions[kind];
-              if (!arr.includes('local')) arr.push('local');
+              if (!arr.includes("local")) arr.push("local");
             }
             return { comments: { ...state.comments } };
           });
@@ -650,17 +708,22 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         removeReaction(threadId, msgId, kind, userId) {
           set((state) => {
             const msg = state.comments.threads[threadId]?.messages.find(
-              (m) => m.id === msgId
+              (m) => m.id === msgId,
             );
             if (msg?.reactions?.[kind]) {
-              msg.reactions[kind] = msg.reactions[kind].filter((u) => u !== userId);
+              msg.reactions[kind] = msg.reactions[kind].filter(
+                (u) => u !== userId,
+              );
             }
             return { comments: { ...state.comments } };
           });
         },
         setCommentsFilter(filter) {
           set((state) => ({
-            comments: { ...state.comments, filter: { ...state.comments.filter, ...filter } },
+            comments: {
+              ...state.comments,
+              filter: { ...state.comments.filter, ...filter },
+            },
           }));
         },
         setReviewStatus(s) {
@@ -676,15 +739,42 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         },
         addPath(path) {
           apply((draft) => {
+            path.props = {
+              strokeCap: "butt",
+              strokeJoin: "miter",
+              miterLimit: 4,
+              fillRule: "nonzero",
+              ...path.props,
+            };
+            if (path.props.dash && path.props.dash.length === 0)
+              path.props.dash = undefined;
             draft.tree.push(path);
           });
         },
-        updatePathProps(id, patch) {
+        setPathProps(id, patch) {
           apply((draft) => {
             const node = findNode(draft.tree, id) as PathNode | null;
-            if (node && node.type === 'Path') {
-              node.props = { ...(node.props || {}), ...patch };
+            if (!node || node.type !== "Path") return;
+            node.props = { ...(node.props || {}) };
+            for (const key of Object.keys(patch) as (keyof PathProps)[]) {
+              const val = patch[key];
+              if (key === "dash") {
+                const arr =
+                  val && val.length ? val.filter((n) => n > 0) : undefined;
+                if (arr && arr.length) node.props[key] = arr as any;
+                else delete node.props[key];
+                continue;
+              }
+              if (val === undefined || val === null) delete node.props[key];
+              else node.props[key] = val as any;
             }
+            if (node.props.miterLimit === undefined) node.props.miterLimit = 4;
+            if (node.props.fillRule === undefined)
+              node.props.fillRule = "nonzero";
+            if (node.props.strokeCap === undefined)
+              node.props.strokeCap = "butt";
+            if (node.props.strokeJoin === undefined)
+              node.props.strokeJoin = "miter";
           });
         },
         selectPath(id, pointIds) {
@@ -696,14 +786,14 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         setPoints(id, pts) {
           apply((draft) => {
             const node = findNode(draft.tree, id) as PathNode | null;
-            if (node && node.type === 'Path') {
+            if (node && node.type === "Path") {
               node.points = pts;
             }
           });
         },
         startPen() {
           set((state) => ({
-            ui: { ...(state.ui || {}), activeTool: 'pen' },
+            ui: { ...(state.ui || {}), activeTool: "pen" },
             vector: { ...(state.vector || {}), draft: undefined },
           }));
         },
@@ -742,7 +832,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             if (!d) return;
             if (d.points.length < 2) {
               draft.vector!.draft = undefined;
-              draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
+              draft.ui = { ...(draft.ui || {}), activeTool: "select" };
               return;
             }
             const pts = d.points;
@@ -760,19 +850,19 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             }
             draft.tree.push({
               id: d.pathId,
-              type: 'Path',
+              type: "Path",
               closed,
               points: pts,
-              props: { stroke: '#ffffff', fill: 'none', strokeWidth: 1 },
+              props: { stroke: "#ffffff", fill: "none", strokeWidth: 1 },
             });
             draft.selectedIds = [d.pathId];
             draft.vector = { selection: { pathId: d.pathId } };
-            draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
+            draft.ui = { ...(draft.ui || {}), activeTool: "select" };
           });
         },
         cancelPen() {
           set((state) => ({
-            ui: { ...(state.ui || {}), activeTool: 'select' },
+            ui: { ...(state.ui || {}), activeTool: "select" },
             vector: { ...(state.vector || {}), draft: undefined },
           }));
         },
@@ -796,7 +886,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               }
             };
             draft.tree.forEach((n) => {
-              if (n.type === 'Path') update(n.points);
+              if (n.type === "Path") update(n.points);
             });
             draft.vector?.draft && update(draft.vector.draft.points);
           });
@@ -809,13 +899,16 @@ export const useEditorStore = create<EditorState & EditorActions>()(
                 (p as any)[kind] = { x: to.x, y: to.y };
                 if (opts?.break) p.corner = true;
                 if (!opts?.break && !p.corner) {
-                  const other = kind === 'in' ? 'out' : 'in';
-                  (p as any)[other] = reflectHandle({ x: p.x, y: p.y }, { x: to.x, y: to.y });
+                  const other = kind === "in" ? "out" : "in";
+                  (p as any)[other] = reflectHandle(
+                    { x: p.x, y: p.y },
+                    { x: to.x, y: to.y },
+                  );
                 }
               }
             };
             draft.tree.forEach((n) => {
-              if (n.type === 'Path') update(n.points);
+              if (n.type === "Path") update(n.points);
             });
             draft.vector?.draft && update(draft.vector.draft.points);
           });
@@ -823,7 +916,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         addPointOnSegment(pathId, segIndex, t) {
           apply((draft) => {
             const node = findNode(draft.tree, pathId) as PathNode | null;
-            if (!node || node.type !== 'Path') return;
+            if (!node || node.type !== "Path") return;
             const pts = node.points;
             const a = pts[segIndex];
             const b = pts[(segIndex + 1) % pts.length];
@@ -865,7 +958,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               }
             };
             draft.tree.forEach((n) => {
-              if (n.type === 'Path') update(n.points);
+              if (n.type === "Path") update(n.points);
             });
             draft.vector?.draft && update(draft.vector.draft.points);
           });
@@ -879,9 +972,9 @@ export const useEditorStore = create<EditorState & EditorActions>()(
       };
     },
     {
-      name: 'uibuilder:editor',
+      name: "uibuilder:editor",
       storage: createJSONStorage(() => idbStorage),
-      version: 5,
+      version: 6,
       migrate: (persisted, version) => {
         if (!persisted) return persisted;
         const state = persisted as EditorState;
@@ -889,7 +982,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           const setLayout = (nodes: ComponentNode[]) => {
             nodes.forEach((n) => {
               n.props = n.props || {};
-              if (!n.props.layout) n.props.layout = 'free';
+              if (!n.props.layout) n.props.layout = "free";
               if (n.children) setLayout(n.children);
             });
           };
@@ -906,8 +999,29 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           };
           ensureVisible(state.tree);
         }
+        if (version < 6) {
+          const migratePath = (nodes: ComponentNode[]) => {
+            nodes.forEach((n) => {
+              if (n.type === "Path") {
+                n.props = n.props || {};
+                if (n.props.miterLimit === undefined) n.props.miterLimit = 4;
+                if (n.props.fillRule === undefined)
+                  n.props.fillRule = "nonzero";
+                if (n.props.strokeCap === undefined) n.props.strokeCap = "butt";
+                if (n.props.strokeJoin === undefined)
+                  n.props.strokeJoin = "miter";
+                if (n.props.dash && n.props.dash.length) {
+                  n.props.dash = n.props.dash.filter((d) => d > 0);
+                  if (n.props.dash.length === 0) n.props.dash = undefined;
+                }
+              }
+              if (n.children) migratePath(n.children);
+            });
+          };
+          migratePath(state.tree);
+        }
         return state;
       },
-    }
-  )
+    },
+  ),
 );

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -1,26 +1,16 @@
-export type LayoutMode = 'free' | 'auto';
-export type Axis = 'horizontal' | 'vertical';
-export type SizeMode = 'HUG' | 'FIXED' | 'FILL';
+export type LayoutMode = "free" | "auto";
+export type Axis = "horizontal" | "vertical";
+export type SizeMode = "HUG" | "FIXED" | "FILL";
 
-export type ConstraintH =
-  | 'LEFT'
-  | 'RIGHT'
-  | 'LEFT_RIGHT'
-  | 'CENTER'
-  | 'SCALE';
-export type ConstraintV =
-  | 'TOP'
-  | 'BOTTOM'
-  | 'TOP_BOTTOM'
-  | 'CENTER'
-  | 'SCALE';
+export type ConstraintH = "LEFT" | "RIGHT" | "LEFT_RIGHT" | "CENTER" | "SCALE";
+export type ConstraintV = "TOP" | "BOTTOM" | "TOP_BOTTOM" | "CENTER" | "SCALE";
 
 export interface Constraints {
   horizontal: ConstraintH;
   vertical: ConstraintV;
 }
 
-export type GridKind = 'COLUMNS' | 'ROWS' | 'GRID';
+export type GridKind = "COLUMNS" | "ROWS" | "GRID";
 
 export interface LayoutGridBase {
   id: string;
@@ -31,25 +21,25 @@ export interface LayoutGridBase {
 }
 
 export interface ColumnsGrid extends LayoutGridBase {
-  kind: 'COLUMNS';
+  kind: "COLUMNS";
   count: number;
-  type: 'stretch' | 'center' | 'left' | 'right';
+  type: "stretch" | "center" | "left" | "right";
   gutter: number;
   margin?: number;
   offset?: number;
 }
 
 export interface RowsGrid extends LayoutGridBase {
-  kind: 'ROWS';
+  kind: "ROWS";
   count: number;
-  type: 'stretch' | 'center' | 'top' | 'bottom';
+  type: "stretch" | "center" | "top" | "bottom";
   gutter: number;
   margin?: number;
   offset?: number;
 }
 
 export interface SquareGrid extends LayoutGridBase {
-  kind: 'GRID';
+  kind: "GRID";
   size: number;
   offset?: number;
 }
@@ -63,9 +53,13 @@ export interface Camera {
 }
 
 // v5 review & comments types
-export type ReviewStatus = 'DRAFT' | 'IN_REVIEW' | 'CHANGES_REQUESTED' | 'APPROVED';
-export type ThreadStatus = 'OPEN' | 'RESOLVED' | 'REOPENED' | 'DRAFT';
-export type AnchorKind = 'PIN' | 'RECT' | 'NODE';
+export type ReviewStatus =
+  | "DRAFT"
+  | "IN_REVIEW"
+  | "CHANGES_REQUESTED"
+  | "APPROVED";
+export type ThreadStatus = "OPEN" | "RESOLVED" | "REOPENED" | "DRAFT";
+export type AnchorKind = "PIN" | "RECT" | "NODE";
 
 export interface CommentUser {
   id: string;
@@ -79,7 +73,7 @@ export interface CommentMessage {
   createdAt: number;
   text: string;
   mentions?: string[];
-  reactions?: Record<'+1' | 'heart', string[]>;
+  reactions?: Record<"+1" | "heart", string[]>;
 }
 
 export interface Anchor {
@@ -102,7 +96,7 @@ export interface CommentThread {
 
 export interface Guide {
   id: string;
-  axis: 'x' | 'y';
+  axis: "x" | "y";
   pos: number;
   locked?: boolean;
   label?: string;
@@ -117,17 +111,29 @@ export interface PathPoint {
   corner?: boolean;
 }
 
+export type Cap = "butt" | "round" | "square";
+export type Join = "miter" | "round" | "bevel";
+export type FillRule = "nonzero" | "evenodd";
+
 export interface PathProps {
   fill?: string;
+  fillOpacity?: number;
+  fillRule?: FillRule;
   stroke?: string;
+  strokeOpacity?: number;
   strokeWidth?: number;
+  strokeCap?: Cap;
+  strokeJoin?: Join;
+  miterLimit?: number; // 1..∞, default 4
+  dash?: number[]; // e.g. [8,4,2]
+  dashOffset?: number; // px
 }
 
 export interface PathNode extends ComponentNode {
-  type: 'Path';
+  type: "Path";
   closed: boolean;
   points: PathPoint[];
-  props?: ComponentNode['props'] & PathProps;
+  props?: ComponentNode["props"] & PathProps;
 }
 
 export interface ComponentNode {
@@ -143,15 +149,17 @@ export interface ComponentNode {
     layout?: LayoutMode;
     axis?: Axis;
     gap?: number;
-    padding?: number | { top: number; right: number; bottom: number; left: number };
-    alignItems?: 'start' | 'center' | 'end' | 'stretch';
+    padding?:
+      | number
+      | { top: number; right: number; bottom: number; left: number };
+    alignItems?: "start" | "center" | "end" | "stretch";
     justifyContent?:
-      | 'start'
-      | 'center'
-      | 'end'
-      | 'space-between'
-      | 'space-around'
-      | 'space-evenly';
+      | "start"
+      | "center"
+      | "end"
+      | "space-between"
+      | "space-around"
+      | "space-evenly";
     wrap?: boolean;
     widthMode?: SizeMode;
     heightMode?: SizeMode;
@@ -200,7 +208,7 @@ export interface EditorState {
     showGuides?: boolean;
     showSmartGuides?: boolean;
     showOutline?: boolean;
-    activeTool?: 'select' | 'pen';
+    activeTool?: "select" | "pen";
   };
   prefs?: {
     showLayoutGrid?: boolean;
@@ -233,7 +241,7 @@ export interface ComponentDefinition {
 }
 
 export interface InstanceNode extends ComponentNode {
-  type: 'Instance';
+  type: "Instance";
   componentId: string;
   variant?: Record<string, string>;
   overrides?: Record<string, Partial<ComponentNode>>;
@@ -241,7 +249,7 @@ export interface InstanceNode extends ComponentNode {
 
 // v6 data binding and action types
 
-export type DataSourceKind = 'rest' | 'graphql' | 'mock';
+export type DataSourceKind = "rest" | "graphql" | "mock";
 
 export interface DataEndpoint {
   id: string;
@@ -249,11 +257,15 @@ export interface DataEndpoint {
   kind: DataSourceKind;
   baseUrl?: string;
   path?: string;
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   headers?: Record<string, string>;
   query?: Record<string, string | number | boolean>;
   body?: any;
-  graphQL?: { endpoint: string; query: string; variables?: Record<string, any> };
+  graphQL?: {
+    endpoint: string;
+    query: string;
+    variables?: Record<string, any>;
+  };
   mock?: { data: any };
   ttlSec?: number;
   transform?: string;
@@ -267,22 +279,22 @@ export interface BindingExpr {
 }
 
 export type EventName =
-  | 'onClick'
-  | 'onChange'
-  | 'onMount'
-  | 'onUnmount'
-  | 'onSubmit'
-  | 'onKeyDown'
-  | 'onKeyUp';
+  | "onClick"
+  | "onChange"
+  | "onMount"
+  | "onUnmount"
+  | "onSubmit"
+  | "onKeyDown"
+  | "onKeyUp";
 
 export type ActionKind =
-  | 'navigate'
-  | 'openUrl'
-  | 'setState'
-  | 'emit'
-  | 'callApi'
-  | 'showToast'
-  | 'openModal';
+  | "navigate"
+  | "openUrl"
+  | "setState"
+  | "emit"
+  | "callApi"
+  | "showToast"
+  | "openModal";
 
 export interface ActionSpec {
   id: string;


### PR DESCRIPTION
## Summary
- extend PathProps to include stroke caps, joins, dash, miter limit, dash offset and fill rules
- add SVG mapping and right pane controls for new stroke and fill options
- migrate persisted data and expose setPathProps for undo/redo

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a9111f8528832ca282c50d1f428fe4