### PR TITLE
feat: add path boolean operations

### DIFF
--- a/web/components/editor/SVGLayer.tsx
+++ b/web/components/editor/SVGLayer.tsx
@@ -23,19 +23,21 @@ function segToCmd(prev: PathPoint, curr: PathPoint, prevSmooth: boolean) {
 }
 
 function pathToD(node: PathNode) {
-  const pts = node.points;
-  if (!pts.length) return "";
-  const cmds = [`M${pts[0].x} ${pts[0].y}`];
-  for (let i = 1; i < pts.length; i++) {
-    cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
-  }
-  if (node.closed) {
+  const paths = node.subpaths && node.subpaths.length ? node.subpaths : [node.points];
+  const parts: string[] = [];
+  paths.forEach((pts) => {
+    if (!pts.length) return;
+    const cmds = [`M${pts[0].x} ${pts[0].y}`];
+    for (let i = 1; i < pts.length; i++) {
+      cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
+    }
     const last = pts[pts.length - 1];
     const first = pts[0];
     cmds.push(segToCmd(last, first, areMirrored(last)));
     cmds.push("Z");
-  }
-  return cmds.join(" ");
+    parts.push(cmds.join(" "));
+  });
+  return parts.join(" ");
 }
 
 export default function SVGLayer() {
@@ -64,22 +66,26 @@ export default function SVGLayer() {
                 strokeOpacity: props.strokeOpacity ?? 1,
               }
             : {};
-        return (
-          <path
-            key={p.id}
-            d={pathToD(p)}
-            fill={props.fill || "none"}
-            fillOpacity={props.fillOpacity ?? 1}
-            fillRule={props.fillRule || "nonzero"}
-            className="pointer-events-auto"
-            onPointerDown={(e) => {
-              selectPath(p.id);
-              e.stopPropagation();
-            }}
-            {...strokeProps}
-          />
-        );
-      })}
+          return (
+            <path
+              key={p.id}
+              d={pathToD(p)}
+              fill={props.fill || "none"}
+              fillOpacity={props.fillOpacity ?? 1}
+              fillRule={
+                p.subpaths && p.subpaths.length
+                  ? props.fillRule || "evenodd"
+                  : props.fillRule || "nonzero"
+              }
+              className="pointer-events-auto"
+              onPointerDown={(e) => {
+                selectPath(p.id);
+                e.stopPropagation();
+              }}
+              {...strokeProps}
+            />
+          );
+        })}
     </svg>
   );
 }

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -1,56 +1,107 @@
 'use client';
 import { TOP_BAR_HEIGHT } from '@/lib/layout/constants';
 import { useEditorStore } from '@/store/editorStore';
+import { useState } from 'react';
+import type { BooleanOp } from '@/lib/vector/boolean';
 
 export default function TopBar() {
-  const prefs = useEditorStore((s) => s.prefs || {});
-  const toggleLayoutGrid = useEditorStore((s) => s.toggleLayoutGrid);
-  const togglePixelGrid = useEditorStore((s) => s.togglePixelGrid);
-  const toggleSnapToPixel = useEditorStore((s) => s.toggleSnapToPixel);
+    const prefs = useEditorStore((s) => s.prefs || {});
+    const toggleLayoutGrid = useEditorStore((s) => s.toggleLayoutGrid);
+    const togglePixelGrid = useEditorStore((s) => s.togglePixelGrid);
+    const toggleSnapToPixel = useEditorStore((s) => s.toggleSnapToPixel);
+    const selection = useEditorStore((s) => s.selectedIds);
+    const combine = useEditorStore((s) => s.booleanCombine);
+    const [replace, setReplace] = useState(false);
+    const [toast, setToast] = useState(false);
+
+    const run = (op: BooleanOp) => {
+      const id = combine(op, selection, { replace });
+      if (id) {
+        setToast(true);
+        setTimeout(() => setToast(false), 1500);
+      }
+    };
   return (
-    <div
-      className="flex items-center justify-between px-3 gap-2 bg-gray-800 text-white"
-      style={{ height: TOP_BAR_HEIGHT }}
-    >
+      <div
+        className="flex items-center justify-between px-3 gap-2 bg-gray-800 text-white relative"
+        style={{ height: TOP_BAR_HEIGHT }}
+      >
       <div className="flex items-center gap-2">
         <button>Back</button>
         <span>Untitled</span>
       </div>
-      <div className="flex items-center gap-4">
-        <button>Group</button>
-        <button>Align</button>
-        <div className="flex items-center gap-2 text-xs">
-          <label className="flex items-center gap-1">
+        <div className="flex items-center gap-4">
+          <button>Group</button>
+          <button>Align</button>
+          <button
+            disabled={selection.length < 2}
+            onClick={() => run('UNION')}
+          >
+            Union
+          </button>
+          <button
+            disabled={selection.length < 2}
+            onClick={() => run('SUBTRACT')}
+          >
+            Subtract
+          </button>
+          <button
+            disabled={selection.length < 2}
+            onClick={() => run('INTERSECT')}
+          >
+            Intersect
+          </button>
+          <button
+            disabled={selection.length < 2}
+            onClick={() => run('EXCLUDE')}
+          >
+            Exclude
+          </button>
+          <label className="flex items-center gap-1 text-xs">
             <input
               type="checkbox"
-              checked={prefs.showLayoutGrid || false}
-              onChange={toggleLayoutGrid}
+              checked={replace}
+              onChange={() => setReplace(!replace)}
             />
-            Layout Grid
+            Replace originals
           </label>
-          <label className="flex items-center gap-1">
-            <input
-              type="checkbox"
-              checked={prefs.showPixelGrid || false}
-              onChange={togglePixelGrid}
-            />
-            Pixel Grid
-          </label>
-          <label className="flex items-center gap-1">
-            <input
-              type="checkbox"
-              checked={prefs.snapToPixel !== false}
-              onChange={toggleSnapToPixel}
-            />
-            Snap
-          </label>
+          <div className="flex items-center gap-2 text-xs">
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={prefs.showLayoutGrid || false}
+                onChange={toggleLayoutGrid}
+              />
+              Layout Grid
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={prefs.showPixelGrid || false}
+                onChange={togglePixelGrid}
+              />
+              Pixel Grid
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={prefs.snapToPixel !== false}
+                onChange={toggleSnapToPixel}
+              />
+              Snap
+            </label>
+          </div>
         </div>
+        <div className="flex items-center gap-2">
+          <button>Share</button>
+          <button>Present</button>
+          <div className="w-6 h-6 bg-gray-500 rounded-full" />
+        </div>
+        {toast && (
+          <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 bg-green-600 text-white px-2 py-1 rounded">
+            Created boolean result (evenodd)
+          </div>
+        )}
       </div>
-      <div className="flex items-center gap-2">
-        <button>Share</button>
-        <button>Present</button>
-        <div className="w-6 h-6 bg-gray-500 rounded-full" />
-      </div>
-    </div>
-  );
-}
+    );
+  }

--- a/web/lib/vector/boolean.ts
+++ b/web/lib/vector/boolean.ts
@@ -1,0 +1,264 @@
+export type BooleanOp = 'UNION' | 'SUBTRACT' | 'INTERSECT' | 'EXCLUDE';
+export interface Ring {
+  points: { x: number; y: number }[];
+  outer: boolean;
+}
+export interface Polyline {
+  points: { x: number; y: number }[];
+  closed: boolean;
+}
+
+class Vertex {
+  x: number;
+  y: number;
+  next: Vertex | null = null;
+  prev: Vertex | null = null;
+  _corresponding: Vertex | null = null;
+  _distance = 0;
+  _isEntry = true;
+  _isIntersection = false;
+  _visited = false;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+  static from(p: { x: number; y: number }) {
+    return new Vertex(p.x, p.y);
+  }
+  static createIntersection(x: number, y: number, dist: number) {
+    const v = new Vertex(x, y);
+    v._distance = dist;
+    v._isIntersection = true;
+    v._isEntry = false;
+    return v;
+  }
+  equals(v: Vertex) {
+    return this.x === v.x && this.y === v.y;
+  }
+  visit() {
+    this._visited = true;
+    if (this._corresponding && !this._corresponding._visited) {
+      this._corresponding.visit();
+    }
+  }
+  isInside(poly: Polygon) {
+    let odd = false;
+    let v = poly.first!;
+    let n = v.next!;
+    const x = this.x;
+    const y = this.y;
+    do {
+      if (((v.y < y && n.y >= y) || (n.y < y && v.y >= y)) && (v.x <= x || n.x <= x)) {
+        odd ^= v.x + ((y - v.y) / (n.y - v.y)) * (n.x - v.x) < x;
+      }
+      v = n;
+      n = v.next!;
+    } while (!v.equals(poly.first!));
+    return odd;
+  }
+}
+
+class Intersection {
+  x = 0;
+  y = 0;
+  toSource = 0;
+  toClip = 0;
+  constructor(s1: Vertex, s2: Vertex, c1: Vertex, c2: Vertex) {
+    const d = (c2.y - c1.y) * (s2.x - s1.x) - (c2.x - c1.x) * (s2.y - s1.y);
+    if (d === 0) return;
+    this.toSource = ((c2.x - c1.x) * (s1.y - c1.y) - (c2.y - c1.y) * (s1.x - c1.x)) / d;
+    this.toClip = ((s2.x - s1.x) * (s1.y - c1.y) - (s2.y - s1.y) * (s1.x - c1.x)) / d;
+    if (this.valid()) {
+      this.x = s1.x + this.toSource * (s2.x - s1.x);
+      this.y = s1.y + this.toSource * (s2.y - s1.y);
+    }
+  }
+  valid() {
+    return this.toSource > 0 && this.toSource < 1 && this.toClip > 0 && this.toClip < 1;
+  }
+}
+
+class Polygon {
+  first: Vertex | null = null;
+  vertices = 0;
+  _firstIntersect: Vertex | null = null;
+  _lastUnprocessed: Vertex | null = null;
+  constructor(points: { x: number; y: number }[]) {
+    points.forEach((p) => this.addVertex(Vertex.from(p)));
+  }
+  addVertex(v: Vertex) {
+    if (!this.first) {
+      this.first = v;
+      v.next = v.prev = v;
+    } else {
+      const n = this.first;
+      const p = n.prev!;
+      n.prev = v;
+      v.next = n;
+      v.prev = p;
+      p.next = v;
+    }
+    this.vertices++;
+  }
+  insertVertex(v: Vertex, start: Vertex, end: Vertex) {
+    let c = start;
+    while (!c.equals(end) && c._distance < v._distance) c = c.next!;
+    v.next = c;
+    const p = c.prev!;
+    v.prev = p;
+    p.next = v;
+    c.prev = v;
+    this.vertices++;
+  }
+  getNext(v: Vertex) {
+    let c = v;
+    while (c._isIntersection) c = c.next!;
+    return c;
+  }
+  getFirstIntersect() {
+    let v = this._firstIntersect || this.first!;
+    do {
+      if (v._isIntersection && !v._visited) break;
+      v = v.next!;
+    } while (!v.equals(this.first!));
+    this._firstIntersect = v;
+    return v;
+  }
+  hasUnprocessed() {
+    let v = this._lastUnprocessed || this.first!;
+    do {
+      if (v._isIntersection && !v._visited) {
+        this._lastUnprocessed = v;
+        return true;
+      }
+      v = v.next!;
+    } while (!v.equals(this.first!));
+    return false;
+  }
+  getPoints() {
+    const pts: { x: number; y: number }[] = [];
+    let v = this.first!;
+    do {
+      pts.push({ x: v.x, y: v.y });
+      v = v.next!;
+    } while (!v.equals(this.first!));
+    return pts;
+  }
+  clip(clip: Polygon, sourceForwards: boolean, clipForwards: boolean) {
+    let s = this.first!;
+    let c = clip.first!;
+    do {
+      if (!s._isIntersection) {
+        do {
+          if (!c._isIntersection) {
+            const inter = new Intersection(s, this.getNext(s.next!), c, clip.getNext(c.next!));
+            if (inter.valid()) {
+              const si = Vertex.createIntersection(inter.x, inter.y, inter.toSource);
+              const ci = Vertex.createIntersection(inter.x, inter.y, inter.toClip);
+              si._corresponding = ci;
+              ci._corresponding = si;
+              this.insertVertex(si, s, this.getNext(s.next!));
+              clip.insertVertex(ci, c, clip.getNext(c.next!));
+            }
+          }
+          c = c.next!;
+        } while (!c.equals(clip.first!));
+      }
+      s = s.next!;
+    } while (!s.equals(this.first!));
+
+    s = this.first!;
+    c = clip.first!;
+    let sInC = s.isInside(clip);
+    let cInS = c.isInside(this);
+    sourceForwards = sourceForwards ? !sInC : sInC;
+    clipForwards = clipForwards ? !cInS : cInS;
+    do {
+      if (s._isIntersection) {
+        s._isEntry = sourceForwards;
+        sourceForwards = !sourceForwards;
+      }
+      s = s.next!;
+    } while (!s.equals(this.first!));
+    do {
+      if (c._isIntersection) {
+        c._isEntry = clipForwards;
+        clipForwards = !clipForwards;
+      }
+      c = c.next!;
+    } while (!c.equals(clip.first!));
+
+    const list: { x: number; y: number }[][] = [];
+    while (this.hasUnprocessed()) {
+      let current = this.getFirstIntersect();
+      const clipped = new Polygon([]);
+      clipped.addVertex(new Vertex(current.x, current.y));
+      do {
+        current.visit();
+        if (current._isEntry) {
+          do {
+            current = current.next!;
+            clipped.addVertex(new Vertex(current.x, current.y));
+          } while (!current._isIntersection);
+        } else {
+          do {
+            current = current.prev!;
+            clipped.addVertex(new Vertex(current.x, current.y));
+          } while (!current._isIntersection);
+        }
+        current = current._corresponding!;
+      } while (!current._visited);
+      list.push(clipped.getPoints());
+    }
+    if (list.length === 0) {
+      if (!sourceForwards && !clipForwards) {
+        if (sInC) list.push(clip.getPoints());
+        else if (cInS) list.push(this.getPoints());
+        else list.push(this.getPoints(), clip.getPoints());
+      } else if (sourceForwards && clipForwards) {
+        if (sInC) list.push(this.getPoints());
+        else if (cInS) list.push(clip.getPoints());
+      } else {
+        if (sInC) list.push(clip.getPoints(), this.getPoints());
+        else if (cInS) list.push(this.getPoints(), clip.getPoints());
+        else list.push(this.getPoints());
+      }
+      if (list.length === 0) return null;
+    }
+    return list;
+  }
+}
+
+function polyArea(pts: { x: number; y: number }[]) {
+  let a = 0;
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    a += (pts[j].x - pts[i].x) * (pts[j].y + pts[i].y);
+  }
+  return a / 2;
+}
+
+function clipBoolean(A: { x: number; y: number }[], B: { x: number; y: number }[], eA: boolean, eB: boolean) {
+  const source = new Polygon(A);
+  const clip = new Polygon(B);
+  return source.clip(clip, eA, eB);
+}
+
+export function booleanCombine(op: BooleanOp, A: Polyline[], B: Polyline[]): Ring[] {
+  if (!A.length || !B.length) return [];
+  const polyA = A[0].points;
+  const polyB = B[0].points;
+  let res: { x: number; y: number }[][] | null = null;
+  if (op === 'UNION') res = clipBoolean(polyA, polyB, false, false);
+  else if (op === 'SUBTRACT') res = clipBoolean(polyA, polyB, false, true);
+  else if (op === 'INTERSECT') res = clipBoolean(polyA, polyB, true, true);
+  else if (op === 'EXCLUDE') {
+    const ab = clipBoolean(polyA, polyB, false, true) || [];
+    const ba = clipBoolean(polyB, polyA, false, true) || [];
+    res = ab.concat(ba);
+  }
+  if (!res) return [];
+  return res.map((pts) => {
+    const area = polyArea(pts);
+    return { points: pts, outer: area > 0 };
+  });
+}

--- a/web/lib/vector/flatten.ts
+++ b/web/lib/vector/flatten.ts
@@ -1,0 +1,93 @@
+import type { PathNode, PathPoint } from "@/types/editor";
+import { flattenCubic } from "./bezier";
+
+export interface Polyline {
+  points: { x: number; y: number }[];
+  closed: boolean;
+}
+
+const EPS = 1e-3;
+
+function distToSeg(p: { x: number; y: number }, a: { x: number; y: number }, b: { x: number; y: number }) {
+  const l2 = (b.x - a.x) ** 2 + (b.y - a.y) ** 2;
+  if (l2 === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * (b.x - a.x) + (p.y - a.y) * (b.y - a.y)) / l2;
+  t = Math.max(0, Math.min(1, t));
+  const x = a.x + t * (b.x - a.x);
+  const y = a.y + t * (b.y - a.y);
+  return Math.hypot(p.x - x, p.y - y);
+}
+
+function rdp(points: { x: number; y: number }[], eps: number): { x: number; y: number }[] {
+  if (points.length <= 2) return points.slice();
+  let dmax = 0;
+  let index = 0;
+  for (let i = 1; i < points.length - 1; i++) {
+    const d = distToSeg(points[i], points[0], points[points.length - 1]);
+    if (d > dmax) {
+      index = i;
+      dmax = d;
+    }
+  }
+  if (dmax > eps) {
+    const rec1 = rdp(points.slice(0, index + 1), eps);
+    const rec2 = rdp(points.slice(index), eps);
+    return rec1.slice(0, -1).concat(rec2);
+  } else {
+    return [points[0], points[points.length - 1]];
+  }
+}
+
+function area(pts: { x: number; y: number }[]) {
+  let a = 0;
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    a += (pts[j].x - pts[i].x) * (pts[j].y + pts[i].y);
+  }
+  return a / 2;
+}
+
+function toPoint(p: PathPoint) {
+  return { x: p.x, y: p.y };
+}
+
+export function flattenPath(path: PathNode, flatness = 0.5): Polyline[] {
+  const src = path.subpaths && path.subpaths.length ? path.subpaths : [path.points];
+  const result: Polyline[] = [];
+  for (const sub of src) {
+    if (!sub.length) continue;
+    const poly: { x: number; y: number }[] = [];
+    const push = (pt: { x: number; y: number }) => {
+      const last = poly[poly.length - 1];
+      if (!last || Math.hypot(last.x - pt.x, last.y - pt.y) > EPS) poly.push(pt);
+    };
+    let prev = sub[0];
+    push(toPoint(prev));
+    for (let i = 1; i < sub.length; i++) {
+      const curr = sub[i];
+      if (prev.out || curr.in) {
+        const seg = flattenCubic(toPoint(prev), toPoint(prev.out || prev), toPoint(curr.in || curr), toPoint(curr), flatness);
+        seg.slice(1).forEach(push);
+      } else {
+        push(toPoint(curr));
+      }
+      prev = curr;
+    }
+    if (path.closed) {
+      const first = sub[0];
+      const last = sub[sub.length - 1];
+      if (last.out || first.in) {
+        const seg = flattenCubic(toPoint(last), toPoint(last.out || last), toPoint(first.in || first), toPoint(first), flatness);
+        seg.slice(1).forEach(push);
+      } else {
+        push(toPoint(first));
+      }
+    }
+    if (poly.length < 3) continue;
+    // simplify and orient
+    const simplified = rdp(poly, Math.min(flatness, 0.5));
+    const ar = area(simplified);
+    if (ar < 0) simplified.reverse();
+    result.push({ points: simplified, closed: true });
+  }
+  return result;
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -22,6 +22,11 @@ import { resolveVariant } from "@/lib/variantResolver";
 import { applyOverrides } from "@/lib/overrideMerge";
 import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
 import { reflectHandle } from "@/lib/vector/bezier";
+import { flattenPath } from "@/lib/vector/flatten";
+import {
+  booleanCombine as combinePolys,
+  BooleanOp,
+} from "@/lib/vector/boolean";
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -73,6 +78,11 @@ interface EditorActions {
   toggleLayoutGrid: () => void;
   togglePixelGrid: () => void;
   toggleSnapToPixel: () => void;
+  booleanCombine: (
+    op: BooleanOp,
+    ids: string[],
+    opts?: { replace?: boolean; flatness?: number; simplify?: number },
+  ) => string;
   setLastCommand: (id: string) => void;
   setCamera: (cam: Partial<Camera>) => void;
   tweenCamera: (
@@ -502,6 +512,46 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             draft.prefs = draft.prefs || {};
             draft.prefs.snapToPixel = !draft.prefs.snapToPixel;
           });
+        },
+        booleanCombine(op, ids, opts) {
+          const flat = opts?.flatness ?? 0.5;
+          const replace = opts?.replace ?? false;
+          const list = ids.length ? ids : get().selectedIds;
+          if (list.length < 2) return "";
+          let acc = flattenPath(
+            findNode(get().tree, list[0]) as PathNode,
+            flat,
+          );
+          let rings: ReturnType<typeof combinePolys> = acc.map((pl) => ({
+            points: pl.points,
+            outer: true,
+          }));
+          for (let i = 1; i < list.length; i++) {
+            const nodeB = findNode(get().tree, list[i]) as PathNode;
+            if (!nodeB) continue;
+            const polyB = flattenPath(nodeB, flat);
+            rings = combinePolys(op, acc, polyB);
+            acc = rings.map((r) => ({ points: r.points, closed: true }));
+          }
+          if (!rings.length) return "";
+          const newId = uuid();
+          const subpaths = rings.map((r) =>
+            r.points.map((pt) => ({ id: uuid(), x: pt.x, y: pt.y, corner: true })),
+          );
+          apply((draft) => {
+            draft.tree.push({
+              id: newId,
+              type: "Path",
+              closed: true,
+              points: subpaths[0] || [],
+              subpaths,
+              props: { fillRule: "evenodd" },
+            });
+            if (replace) {
+              draft.tree = draft.tree.filter((n) => !list.includes(n.id));
+            }
+          });
+          return newId;
         },
         setLastCommand(id) {
           set({ lastCommandId: id });

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -133,6 +133,7 @@ export interface PathNode extends ComponentNode {
   type: "Path";
   closed: boolean;
   points: PathPoint[];
+  subpaths?: PathPoint[][];
   props?: ComponentNode["props"] & PathProps;
 }
 


### PR DESCRIPTION
## Summary
- support multi-subpath PathNode
- add flatten and boolean combine utilities
- enable boolean ops in editor UI

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a9129959a4832cb215d83dcc205298