### PR TITLE
feat: add mask rendering

### DIFF
--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -8,6 +8,7 @@ export default function RightPane() {
     s.tree.find((n): n is PathNode => n.id === selected && n.type === "Path"),
   );
   const setProps = useEditorStore((s) => s.setPathProps);
+  const toggleMask = useEditorStore((s) => s.toggleMask);
   if (!path) return <div className="bg-gray-800" />;
   const props = path.props || {};
   const parseDash = (v: string) => {
@@ -21,6 +22,17 @@ export default function RightPane() {
   return (
     <div className="bg-gray-800 p-2 space-y-2 text-xs">
       <div className="font-bold">Vector › Style</div>
+      <label className="flex items-center gap-1">
+        <input
+          type="checkbox"
+          checked={path.isMask || false}
+          onChange={() => toggleMask(path.id)}
+        />
+        Use as Mask
+      </label>
+      <div className="text-[10px] text-gray-400">
+        Applies to subsequent siblings until another mask appears.
+      </div>
       <label className="block">
         Fill:
         <input

--- a/web/components/editor/SVGLayer.tsx
+++ b/web/components/editor/SVGLayer.tsx
@@ -1,6 +1,18 @@
 "use client";
+import { useEffect, useRef } from "react";
 import { useEditorStore } from "@/store/editorStore";
-import type { PathNode, PathPoint } from "@/types/editor";
+import type {
+  ComponentNode,
+  FrameNode,
+  ImageNode,
+  PathNode,
+  PathPoint,
+} from "@/types/editor";
+import {
+  ensureMaskDefs,
+  buildMaskElement,
+  makeMaskId,
+} from "@/lib/vector/mask";
 
 function areMirrored(pt: PathPoint) {
   return (
@@ -41,13 +53,39 @@ function pathToD(node: PathNode) {
 }
 
 export default function SVGLayer() {
-  const paths = useEditorStore((s) =>
-    s.tree.filter((n): n is PathNode => n.type === "Path"),
-  );
+  const tree = useEditorStore((s) => s.tree);
   const selectPath = useEditorStore((s) => s.selectPath);
-  return (
-    <svg className="absolute inset-0 pointer-events-none">
-      {paths.map((p) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  // Build mask <defs> on every change to the tree
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const defs = ensureMaskDefs(svg);
+    defs.innerHTML = "";
+    const masks: Array<PathNode | FrameNode | ImageNode> = [];
+    const collect = (nodes: ComponentNode[]) => {
+      nodes.forEach((n) => {
+        if ((n as any).isMask) masks.push(n as any);
+        if (n.children) collect(n.children);
+      });
+    };
+    collect(tree);
+    masks.forEach((m) => {
+      defs.appendChild(buildMaskElement(svg.ownerDocument, m));
+    });
+  }, [tree]);
+
+  const renderNodes = (nodes: ComponentNode[]): JSX.Element[] => {
+    const els: JSX.Element[] = [];
+    let activeMask: string | null = null;
+    nodes.forEach((n) => {
+      if ((n as any).isMask) {
+        activeMask = makeMaskId(n.id);
+        return; // mask nodes are not rendered themselves
+      }
+      if (n.type === "Path") {
+        const p = n as PathNode;
         const props = p.props || {};
         const strokeWidth = props.strokeWidth ?? 0;
         const strokeProps =
@@ -66,26 +104,56 @@ export default function SVGLayer() {
                 strokeOpacity: props.strokeOpacity ?? 1,
               }
             : {};
-          return (
-            <path
-              key={p.id}
-              d={pathToD(p)}
-              fill={props.fill || "none"}
-              fillOpacity={props.fillOpacity ?? 1}
-              fillRule={
-                p.subpaths && p.subpaths.length
-                  ? props.fillRule || "evenodd"
-                  : props.fillRule || "nonzero"
-              }
-              className="pointer-events-auto"
-              onPointerDown={(e) => {
-                selectPath(p.id);
-                e.stopPropagation();
-              }}
-              {...strokeProps}
-            />
+        const pathEl = (
+          <path
+            key={p.id}
+            d={pathToD(p)}
+            fill={props.fill || "none"}
+            fillOpacity={props.fillOpacity ?? 1}
+            fillRule={
+              p.subpaths && p.subpaths.length
+                ? props.fillRule || "evenodd"
+                : props.fillRule || "nonzero"
+            }
+            className="pointer-events-auto"
+            onPointerDown={(e) => {
+              selectPath(p.id);
+              e.stopPropagation();
+            }}
+            {...strokeProps}
+          />
+        );
+        if (activeMask) {
+          els.push(
+            <g key={`g-${p.id}`} mask={`url(#${activeMask})`}>
+              {pathEl}
+            </g>,
           );
-        })}
+        } else {
+          els.push(pathEl);
+        }
+      } else if (n.children) {
+        const childEls = renderNodes(n.children);
+        if (childEls.length) {
+          if (activeMask) {
+            els.push(
+              <g key={n.id} mask={`url(#${activeMask})`}>
+                {childEls}
+              </g>,
+            );
+          } else {
+            els.push(<g key={n.id}>{childEls}</g>);
+          }
+        }
+      }
+    });
+    return els;
+  };
+
+  return (
+    <svg ref={svgRef} className="absolute inset-0 pointer-events-none">
+      {renderNodes(tree)}
     </svg>
   );
 }
+

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -10,6 +10,8 @@ export default function TopBar() {
     const togglePixelGrid = useEditorStore((s) => s.togglePixelGrid);
     const toggleSnapToPixel = useEditorStore((s) => s.toggleSnapToPixel);
     const selection = useEditorStore((s) => s.selectedIds);
+    const tree = useEditorStore((s) => s.tree);
+    const toggleMask = useEditorStore((s) => s.toggleMask);
     const combine = useEditorStore((s) => s.booleanCombine);
     const [replace, setReplace] = useState(false);
     const [toast, setToast] = useState(false);
@@ -33,6 +35,20 @@ export default function TopBar() {
         <div className="flex items-center gap-4">
           <button>Group</button>
           <button>Align</button>
+          <button
+            disabled={selection.length === 0}
+            className={(() => {
+              const id = selection[selection.length - 1];
+              const node = tree.find((n) => n.id === id) as any;
+              return node?.isMask ? "bg-blue-600" : undefined;
+            })()}
+            onClick={() => {
+              const id = selection[selection.length - 1];
+              if (id) toggleMask(id);
+            }}
+          >
+            Mask
+          </button>
           <button
             disabled={selection.length < 2}
             onClick={() => run('UNION')}

--- a/web/lib/vector/mask.ts
+++ b/web/lib/vector/mask.ts
@@ -1,0 +1,112 @@
+import type {
+  FrameNode,
+  ImageNode,
+  PathNode,
+  PathPoint,
+} from "@/types/editor";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+// Ensure a <defs> container exists on the root svg for mask elements
+export function ensureMaskDefs(rootSvg: SVGSVGElement): SVGDefsElement {
+  let defs = rootSvg.querySelector<SVGDefsElement>("defs[data-mask-defs]");
+  if (!defs) {
+    defs = rootSvg.ownerDocument.createElementNS(SVG_NS, "defs");
+    defs.setAttribute("data-mask-defs", "1");
+    rootSvg.insertBefore(defs, rootSvg.firstChild);
+  }
+  return defs;
+}
+
+// Generate a unique mask id for a given node
+export function makeMaskId(nodeId: string): string {
+  return `mask-${nodeId}`;
+}
+
+function areMirrored(pt: PathPoint) {
+  return (
+    pt.in &&
+    pt.out &&
+    Math.abs(pt.x * 2 - pt.in.x - pt.out.x) < 1e-6 &&
+    Math.abs(pt.y * 2 - pt.in.y - pt.out.y) < 1e-6
+  );
+}
+
+function segToCmd(prev: PathPoint, curr: PathPoint, prevSmooth: boolean) {
+  const c1 = prev.out || prev;
+  const c2 = curr.in || curr;
+  const useS = prevSmooth;
+  if (prev.out || curr.in) {
+    if (useS) return `S${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+    return `C${c1.x} ${c1.y} ${c2.x} ${c2.y} ${curr.x} ${curr.y}`;
+  }
+  return `L${curr.x} ${curr.y}`;
+}
+
+function pathToD(node: PathNode) {
+  const paths = node.subpaths && node.subpaths.length ? node.subpaths : [node.points];
+  const parts: string[] = [];
+  paths.forEach((pts) => {
+    if (!pts.length) return;
+    const cmds = [`M${pts[0].x} ${pts[0].y}`];
+    for (let i = 1; i < pts.length; i++) {
+      cmds.push(segToCmd(pts[i - 1], pts[i], areMirrored(pts[i - 1])));
+    }
+    const last = pts[pts.length - 1];
+    const first = pts[0];
+    cmds.push(segToCmd(last, first, areMirrored(last)));
+    cmds.push("Z");
+    parts.push(cmds.join(" "));
+  });
+  return parts.join(" ");
+}
+
+// Build a mask element for the given node
+export function buildMaskElement(
+  doc: Document,
+  node: PathNode | FrameNode | ImageNode,
+): SVGMaskElement {
+  const mask = doc.createElementNS(SVG_NS, "mask");
+  mask.setAttribute("id", makeMaskId(node.id));
+  mask.setAttribute("maskUnits", "userSpaceOnUse");
+
+  if (node.type === "Path") {
+    const path = doc.createElementNS(SVG_NS, "path");
+    path.setAttribute("d", pathToD(node));
+    path.setAttribute("fill", "white");
+    const props = node.props || {};
+    const rule =
+      node.subpaths && node.subpaths.length
+        ? props.fillRule || "evenodd"
+        : props.fillRule || "nonzero";
+    path.setAttribute("fill-rule", rule);
+    mask.appendChild(path);
+  } else if (node.type === "Frame") {
+    const rect = doc.createElementNS(SVG_NS, "rect");
+    const p = node.props || {};
+    rect.setAttribute("x", String(p.x || 0));
+    rect.setAttribute("y", String(p.y || 0));
+    rect.setAttribute("width", String(p.w || 0));
+    rect.setAttribute("height", String(p.h || 0));
+    rect.setAttribute("fill", "white");
+    mask.appendChild(rect);
+  } else if (node.type === "Image") {
+    const img = doc.createElementNS(SVG_NS, "image");
+    const p = node.props || {};
+    if (p.assetId) {
+      img.setAttributeNS("http://www.w3.org/1999/xlink", "href", p.assetId);
+    }
+    if (p.x !== undefined) img.setAttribute("x", String(p.x));
+    if (p.y !== undefined) img.setAttribute("y", String(p.y));
+    if (p.w !== undefined) img.setAttribute("width", String(p.w));
+    if (p.h !== undefined) img.setAttribute("height", String(p.h));
+    mask.appendChild(img);
+  }
+  return mask;
+}
+
+// Apply a mask to a group element
+export function applyMask(groupEl: SVGGElement, maskId: string): void {
+  groupEl.setAttribute("mask", `url(#${maskId})`);
+}
+

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -165,6 +165,7 @@ interface EditorActions {
   ) => void;
   addPointOnSegment: (pathId: string, segIndex: number, t: number) => void;
   toggleCorner: (id: string) => void;
+  toggleMask: (nodeId: string, enabled?: boolean) => void;
 }
 
 function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
@@ -1011,6 +1012,16 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               if (n.type === "Path") update(n.points);
             });
             draft.vector?.draft && update(draft.vector.draft.points);
+          });
+        },
+        toggleMask(nodeId, enabled) {
+          apply((draft) => {
+            const node = findNode(draft.tree, nodeId);
+            if (node) {
+              const next =
+                enabled === undefined ? !(node as any).isMask : enabled;
+              (node as any).isMask = next;
+            }
           });
         },
         undo() {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -131,11 +131,26 @@ export interface PathProps {
 
 export interface PathNode extends ComponentNode {
   type: "Path";
+  /** When true, this node acts as a mask for subsequent siblings */
+  isMask?: boolean;
   closed: boolean;
   points: PathPoint[];
   subpaths?: PathPoint[][];
   props?: ComponentNode["props"] & PathProps;
 }
+
+export interface FrameNode extends ComponentNode {
+  type: "Frame";
+  /** Frame can also be used as a mask, clipping by its bounds */
+  isMask?: boolean;
+}
+
+export interface ImageNode extends ComponentNode {
+  type: "Image";
+  props: ComponentNode["props"] & { isMask?: boolean; assetId?: string };
+}
+
+export type MaskTarget = "vector" | "frame" | "image";
 
 export interface ComponentNode {
   id: string;


### PR DESCRIPTION
## Summary
- allow Path/Frame/Image nodes to act as masks
- render SVG masks and toggle via UI

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a9150cea64832cbe9a053dd113d093