### PR TITLE
feat: add basic image asset handling

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -5,7 +5,8 @@ import ResizeHandles from './ResizeHandles';
 import SVGLayer from './SVGLayer';
 import PathEditorOverlay from './PathEditorOverlay';
 import PenTool from './tools/PenTool';
-import type { ComponentNode, InstanceNode, PathNode } from '@/types/editor';
+import ImageView from './ImageView';
+import type { ComponentNode, InstanceNode, PathNode, ImageNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
@@ -13,6 +14,7 @@ import ZoomControls from './ZoomControls';
 import { wheelRouter } from '@/lib/input/wheelRouter';
 import * as zoom from '@/lib/zoom';
 import { useRef } from 'react';
+import { saveImage } from '@/lib/assets';
 
 function NodeView({
   node,
@@ -69,6 +71,17 @@ function NodeView({
     Object.assign(style, sizeStyle(node, parentAxis));
   }
 
+  if (node.type === 'Image') {
+    const asset = useEditorStore(
+      (s) => (node.props as any).assetId && s.assets?.images[(node.props as any).assetId]
+    );
+    return (
+      <div style={style}>
+        {asset && <ImageView node={node as ImageNode} meta={asset} />}
+      </div>
+    );
+  }
+
   if (layout === 'auto') {
     return (
       <div
@@ -117,6 +130,13 @@ export default function CanvasStage() {
   const panning = useRef(false);
   const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
 
+  const handleFiles = async (files: FileList) => {
+    for (const file of Array.from(files)) {
+      const meta = await saveImage(file);
+      useEditorStore.getState().addImageNode(meta);
+    }
+  };
+
   const onPointerDown = (e: React.PointerEvent) => {
     panning.current = true;
     last.current = { x: e.clientX, y: e.clientY, t: performance.now(), vx: 0, vy: 0 };
@@ -161,6 +181,14 @@ export default function CanvasStage() {
             y: state.camera.y - act.dy,
           });
         e.preventDefault();
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        if (e.dataTransfer.files?.length) handleFiles(e.dataTransfer.files);
+      }}
+      onDragOver={(e) => e.preventDefault()}
+      onPaste={(e) => {
+        if (e.clipboardData.files?.length) handleFiles(e.clipboardData.files);
       }}
       onPointerDown={activeTool === 'pen' ? undefined : onPointerDown}
       onPointerMove={activeTool === 'pen' ? undefined : onPointerMove}

--- a/web/components/editor/ImageView.tsx
+++ b/web/components/editor/ImageView.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { loadImage } from '@/lib/assets';
+import type { ImageNode, AssetMeta } from '@/types/editor';
+
+export default function ImageView({ node, meta }: { node: ImageNode; meta: AssetMeta }) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let currentUrl: string | null = null;
+    loadImage(meta.id).then((blob) => {
+      if (!blob) return;
+      currentUrl = URL.createObjectURL(blob);
+      setUrl(currentUrl);
+    });
+    return () => {
+      if (currentUrl) URL.revokeObjectURL(currentUrl);
+    };
+  }, [meta.id]);
+  const fit = node.props.fit || 'contain';
+  const pos = node.props.position || { x: 0.5, y: 0.5 };
+  if (!url) return null;
+  return (
+    <img
+      src={url}
+      style={{
+        width: '100%',
+        height: '100%',
+        objectFit: fit,
+        objectPosition: `${pos.x * 100}% ${pos.y * 100}%`,
+      }}
+    />
+  );
+}

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -1,8 +1,9 @@
 'use client';
 import { TOP_BAR_HEIGHT } from '@/lib/layout/constants';
 import { useEditorStore } from '@/store/editorStore';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import type { BooleanOp } from '@/lib/vector/boolean';
+import { saveImage } from '@/lib/assets';
 
 export default function TopBar() {
     const prefs = useEditorStore((s) => s.prefs || {});
@@ -15,6 +16,15 @@ export default function TopBar() {
     const combine = useEditorStore((s) => s.booleanCombine);
     const [replace, setReplace] = useState(false);
     const [toast, setToast] = useState(false);
+    const fileInput = useRef<HTMLInputElement | null>(null);
+
+    const handleFiles = async (files: FileList | null) => {
+      if (!files) return;
+      for (const file of Array.from(files)) {
+        const meta = await saveImage(file);
+        useEditorStore.getState().addImageNode(meta);
+      }
+    };
 
     const run = (op: BooleanOp) => {
       const id = combine(op, selection, { replace });
@@ -34,6 +44,15 @@ export default function TopBar() {
       </div>
         <div className="flex items-center gap-4">
           <button>Group</button>
+          <button onClick={() => fileInput.current?.click()}>Place Image</button>
+          <input
+            ref={fileInput}
+            type="file"
+            accept="image/*"
+            multiple
+            className="hidden"
+            onChange={(e) => handleFiles(e.target.files)}
+          />
           <button>Align</button>
           <button
             disabled={selection.length === 0}

--- a/web/lib/assets.ts
+++ b/web/lib/assets.ts
@@ -1,0 +1,62 @@
+import Dexie, { Table } from 'dexie';
+import type { AssetMeta } from '@/types/editor';
+
+interface ImageRecord extends AssetMeta {
+  blob: Blob;
+}
+
+class AssetDB extends Dexie {
+  images!: Table<ImageRecord, string>;
+  constructor() {
+    super('uibuilder-assets');
+    this.version(1).stores({ images: '&id,hash' });
+  }
+}
+
+const db = new AssetDB();
+
+async function sha1(buf: ArrayBuffer) {
+  const hash = await crypto.subtle.digest('SHA-1', buf);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function saveImage(file: Blob): Promise<AssetMeta> {
+  const buffer = await file.arrayBuffer();
+  const hash = await sha1(buffer);
+  const existing = await db.images.where('hash').equals(hash).first();
+  if (existing) return existing;
+  const bitmap = await createImageBitmap(file, {
+    imageOrientation: 'from-image',
+  } as any);
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0);
+  const blob: Blob = await new Promise((resolve) =>
+    canvas.toBlob((b) => resolve(b as Blob), file.type),
+  );
+  const id = crypto.randomUUID();
+  const meta: AssetMeta = {
+    id,
+    mime: file.type,
+    w: bitmap.width,
+    h: bitmap.height,
+    size: blob.size,
+    hash,
+    createdAt: Date.now(),
+  };
+  await db.images.put({ ...meta, blob });
+  return meta;
+}
+
+export async function loadImage(id: string): Promise<Blob | null> {
+  const row = await db.images.get(id);
+  return row ? row.blob : null;
+}
+
+export async function hashBlob(blob: Blob): Promise<string> {
+  return sha1(await blob.arrayBuffer());
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -15,6 +15,9 @@ import type {
   PathNode,
   PathPoint,
   PathProps,
+  ImageNode,
+  AssetMeta,
+  ImageProps,
 } from "@/types/editor";
 import { idbStorage } from "@/lib/idb";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
@@ -41,6 +44,10 @@ interface EditorActions {
   rotateNode: (id: string, deg: number) => void;
   duplicate: (ids?: string[]) => void;
   remove: (ids?: string[]) => void;
+  addImageAsset: (meta: AssetMeta) => void;
+  removeImageAsset: (id: string) => void;
+  addImageNode: (meta: AssetMeta, opts?: { x?: number; y?: number }) => string;
+  updateImageNode: (id: string, patch: Partial<ImageProps>) => void;
   undo: () => void;
   redo: () => void;
   makeAutoLayout: (frameId?: string) => void;
@@ -226,6 +233,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         meta: { version: 1, updatedAt: Date.now() },
         components: {},
         guides: [],
+        assets: { images: {} },
         vector: { selection: {} },
         ui: {
           showRulers: false,
@@ -308,6 +316,53 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               });
             draft.tree = removeRec(draft.tree);
             draft.selectedIds = [];
+          });
+        },
+        addImageAsset(meta) {
+          apply((draft) => {
+            draft.assets = draft.assets || { images: {} };
+            draft.assets.images[meta.id] = meta;
+          });
+        },
+        removeImageAsset(id) {
+          apply((draft) => {
+            if (draft.assets?.images) delete draft.assets.images[id];
+          });
+        },
+        addImageNode(meta, opts) {
+          const id = uuid();
+          const rect = get().getViewportRect();
+          const pos = {
+            x: opts?.x ?? rect.x + rect.w / 2 - meta.w / 2,
+            y: opts?.y ?? rect.y + rect.h / 2 - meta.h / 2,
+          };
+          apply((draft) => {
+            draft.assets = draft.assets || { images: {} };
+            draft.assets.images[meta.id] = meta;
+            const node: ImageNode = {
+              id,
+              type: "Image",
+              props: {
+                x: pos.x,
+                y: pos.y,
+                w: meta.w,
+                h: meta.h,
+                assetId: meta.id,
+                fit: "contain",
+                position: { x: 0.5, y: 0.5 },
+              },
+            };
+            draft.tree.push(node);
+            draft.selectedIds = [id];
+          });
+          return id;
+        },
+        updateImageNode(id, patch) {
+          apply((draft) => {
+            const node = findNode(draft.tree, id) as ImageNode | null;
+            if (node && node.type === "Image") {
+              node.props = { ...node.props, ...patch } as ImageProps;
+            }
           });
         },
         makeAutoLayout(frameId) {
@@ -1035,7 +1090,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
     {
       name: "uibuilder:editor",
       storage: createJSONStorage(() => idbStorage),
-      version: 6,
+      version: 7,
       migrate: (persisted, version) => {
         if (!persisted) return persisted;
         const state = persisted as EditorState;
@@ -1080,6 +1135,9 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             });
           };
           migratePath(state.tree);
+        }
+        if (version < 7) {
+          if (!state.assets) state.assets = { images: {} } as any;
         }
         return state;
       },

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -145,9 +145,26 @@ export interface FrameNode extends ComponentNode {
   isMask?: boolean;
 }
 
+export interface AssetMeta {
+  id: string;
+  mime: string;
+  w: number;
+  h: number;
+  size: number;
+  hash: string;
+  createdAt: number;
+}
+
+export interface ImageProps extends ComponentNode["props"] {
+  assetId: string;
+  fit?: "contain" | "cover" | "fill";
+  position?: { x: number; y: number };
+  isMask?: boolean;
+}
+
 export interface ImageNode extends ComponentNode {
   type: "Image";
-  props: ComponentNode["props"] & { isMask?: boolean; assetId?: string };
+  props: ImageProps;
 }
 
 export type MaskTarget = "vector" | "frame" | "image";
@@ -215,6 +232,7 @@ export interface EditorState {
   meta: { version: number; updatedAt: number };
   components: Record<string, ComponentDefinition>;
   guides: Guide[];
+  assets?: { images: Record<string, AssetMeta> };
   vector?: {
     selection?: { pathId?: string; pointIds?: string[] };
     draft?: { pathId: string; points: PathPoint[] };


### PR DESCRIPTION
## Summary
- introduce image asset metadata and storage
- allow dropping, pasting, or selecting images to create Image nodes
- render stored images with basic positioning

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a9164885dc832cb9c6e501e94cdf76