### PR TITLE
feat: add basic image crop mode

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -6,6 +6,7 @@ import SVGLayer from './SVGLayer';
 import PathEditorOverlay from './PathEditorOverlay';
 import PenTool from './tools/PenTool';
 import ImageView from './ImageView';
+import ImageCropOverlay from './ImageCropOverlay';
 import type { ComponentNode, InstanceNode, PathNode, ImageNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
@@ -199,6 +200,7 @@ export default function CanvasStage() {
       ))}
       <SVGLayer />
       <PathEditorOverlay />
+      <ImageCropOverlay />
       {activeTool === 'pen' && <PenTool />}
       {prefs.showLayoutGrid && (
         <div className="absolute inset-0 pointer-events-none layout-grid" />

--- a/web/components/editor/ImageCropOverlay.tsx
+++ b/web/components/editor/ImageCropOverlay.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useEditorStore } from '@/store/editorStore';
+import { moveCrop } from '@/lib/image/crop';
+import { useEffect } from 'react';
+
+export default function ImageCropOverlay() {
+  const draft = useEditorStore((s) => s.cropDraft);
+  const updateCrop = useEditorStore((s) => s.updateCrop);
+  const commitCrop = useEditorStore((s) => s.commitCrop);
+  const cancelCrop = useEditorStore((s) => s.cancelCrop);
+  const assets = useEditorStore((s) => s.assets.images);
+  const tree = useEditorStore((s) => s.tree);
+  if (!draft) return null;
+  const node = tree.find((n) => n.id === draft.nodeId) as any;
+  const meta = assets[node?.props.assetId];
+  const natural = { w: meta?.w || node?.props.w || 0, h: meta?.h || node?.props.h || 0 };
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        commitCrop();
+        e.preventDefault();
+      } else if (e.key === 'Escape') {
+        cancelCrop();
+        e.preventDefault();
+      } else if (e.key.startsWith('Arrow')) {
+        const dx = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+        const dy = e.key === 'ArrowUp' ? -1 : e.key === 'ArrowDown' ? 1 : 0;
+        const mul = e.shiftKey ? 10 : 1;
+        const next = moveCrop(draft.rect, dx * mul, dy * mul, natural);
+        updateCrop(next);
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [draft, commitCrop, cancelCrop, updateCrop, natural]);
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: draft.rect.x,
+    top: draft.rect.y,
+    width: draft.rect.w,
+    height: draft.rect.h,
+    border: '1px solid #4af',
+    boxSizing: 'border-box',
+  };
+  return (
+    <div className="absolute inset-0 pointer-events-none">
+      <div style={style} />
+    </div>
+  );
+}

--- a/web/components/editor/ImageView.tsx
+++ b/web/components/editor/ImageView.tsx
@@ -2,8 +2,10 @@
 import { useEffect, useState } from 'react';
 import { loadImage } from '@/lib/assets';
 import type { ImageNode, AssetMeta } from '@/types/editor';
+import { useEditorStore } from '@/store/editorStore';
 
 export default function ImageView({ node, meta }: { node: ImageNode; meta: AssetMeta }) {
+  const startCrop = useEditorStore((s) => s.startCrop);
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     let currentUrl: string | null = null;
@@ -19,6 +21,23 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
   const fit = node.props.fit || 'contain';
   const pos = node.props.position || { x: 0.5, y: 0.5 };
   if (!url) return null;
+  const crop = node.props.crop;
+  if (crop) {
+    const scaleX = (node.props.w || meta.w) / crop.w;
+    const scaleY = (node.props.h || meta.h) / crop.h;
+    return (
+      <div className="w-full h-full overflow-hidden" onDoubleClick={() => startCrop(node.id)}>
+        <img
+          src={url}
+          style={{
+            width: meta.w * scaleX,
+            height: meta.h * scaleY,
+            transform: `translate(${-crop.x * scaleX}px, ${-crop.y * scaleY}px)`,
+          }}
+        />
+      </div>
+    );
+  }
   return (
     <img
       src={url}
@@ -28,6 +47,7 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
         objectFit: fit,
         objectPosition: `${pos.x * 100}% ${pos.y * 100}%`,
       }}
+      onDoubleClick={() => startCrop(node.id)}
     />
   );
 }

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -12,8 +12,11 @@ export default function TopBar() {
     const toggleSnapToPixel = useEditorStore((s) => s.toggleSnapToPixel);
     const selection = useEditorStore((s) => s.selectedIds);
     const tree = useEditorStore((s) => s.tree);
-    const toggleMask = useEditorStore((s) => s.toggleMask);
-    const combine = useEditorStore((s) => s.booleanCombine);
+  const toggleMask = useEditorStore((s) => s.toggleMask);
+  const combine = useEditorStore((s) => s.booleanCombine);
+  const startCrop = useEditorStore((s) => s.startCrop);
+  const cancelCrop = useEditorStore((s) => s.cancelCrop);
+  const activeTool = useEditorStore((s) => s.ui.activeTool);
     const [replace, setReplace] = useState(false);
     const [toast, setToast] = useState(false);
     const fileInput = useRef<HTMLInputElement | null>(null);
@@ -53,6 +56,18 @@ export default function TopBar() {
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
           />
+          <button
+            disabled={selection.length === 0}
+            className={activeTool === 'crop' ? 'bg-blue-600' : undefined}
+            onClick={() => {
+              const id = selection[selection.length - 1];
+              if (!id) return;
+              if (activeTool === 'crop') cancelCrop();
+              else startCrop(id);
+            }}
+          >
+            Crop
+          </button>
           <button>Align</button>
           <button
             disabled={selection.length === 0}

--- a/web/lib/image/crop.ts
+++ b/web/lib/image/crop.ts
@@ -1,0 +1,36 @@
+export interface Rect { x:number; y:number; w:number; h:number }
+export function normalizeCrop(rect:Rect, natural:{w:number;h:number}):Rect {
+  const x = Math.max(0, Math.min(rect.x, natural.w));
+  const y = Math.max(0, Math.min(rect.y, natural.h));
+  const w = Math.max(1, Math.min(rect.w, natural.w - x));
+  const h = Math.max(1, Math.min(rect.h, natural.h - y));
+  return { x, y, w, h };
+}
+export function moveCrop(rect:Rect, dx:number, dy:number, natural:{w:number;h:number}):Rect {
+  return normalizeCrop({ x: rect.x + dx, y: rect.y + dy, w: rect.w, h: rect.h }, natural);
+}
+export function resizeCrop(rect:Rect, handle:'n'|'ne'|'e'|'se'|'s'|'sw'|'w'|'nw', dx:number, dy:number, opts:{center?:boolean;keepAspect?:boolean}={}, natural:{w:number;h:number}):Rect {
+  let { x, y, w, h } = rect;
+  let cx = 0, cy = 0;
+  if (opts.center) { cx = dx/2; cy = dy/2; }
+  if (handle.includes('w')) { x += dx; w -= dx; }
+  if (handle.includes('e')) { w += dx; }
+  if (handle.includes('n')) { y += dy; h -= dy; }
+  if (handle.includes('s')) { h += dy; }
+  if (opts.center) { x -= cx; y -= cy; w += cx*2; h += cy*2; }
+  return normalizeCrop({ x, y, w, h }, natural);
+}
+export function worldToImage(pt:{x:number;y:number}, node:any){
+  const { w, h } = node.props;
+  const crop = node.props.crop || { x:0, y:0, w:node.meta?.w||w, h:node.meta?.h||h };
+  const scaleX = crop.w / w;
+  const scaleY = crop.h / h;
+  return { x: pt.x * scaleX + crop.x, y: pt.y * scaleY + crop.y };
+}
+export function imageToWorld(pt:{x:number;y:number}, node:any){
+  const { x: nx, y: ny, w, h } = node.props;
+  const crop = node.props.crop || { x:0, y:0, w:node.meta?.w||w, h:node.meta?.h||h };
+  const scaleX = w / crop.w;
+  const scaleY = h / crop.h;
+  return { x: (pt.x - crop.x) * scaleX + nx, y: (pt.y - crop.y) * scaleY + ny };
+}

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -1,3 +1,5 @@
+import { useEditorStore } from '@/store/editorStore';
+
 export type Command =
   | 'select'
   | 'tool.pen'
@@ -55,6 +57,7 @@ const map: Record<string, Command> = {
 };
 
 export function getCommand(e: KeyboardEvent): Command | undefined {
+  if (useEditorStore.getState().ui?.activeTool === 'crop') return undefined;
   const mod = e.metaKey || e.ctrlKey;
   if (mod && e.altKey) {
     if (e.code === 'KeyK') return 'createComponent';

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -173,6 +173,15 @@ interface EditorActions {
   addPointOnSegment: (pathId: string, segIndex: number, t: number) => void;
   toggleCorner: (id: string) => void;
   toggleMask: (nodeId: string, enabled?: boolean) => void;
+  startCrop: (nodeId: string) => void;
+  updateCrop: (patch: Partial<CropDraft['rect']>) => void;
+  commitCrop: () => void;
+  cancelCrop: () => void;
+}
+
+export interface CropDraft {
+  nodeId: string;
+  rect: { x: number; y: number; w: number; h: number };
 }
 
 function findNode(nodes: ComponentNode[], id: string): ComponentNode | null {
@@ -235,6 +244,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         guides: [],
         assets: { images: {} },
         vector: { selection: {} },
+        cropDraft: undefined,
         ui: {
           showRulers: false,
           showGuides: true,
@@ -1077,6 +1087,48 @@ export const useEditorStore = create<EditorState & EditorActions>()(
                 enabled === undefined ? !(node as any).isMask : enabled;
               (node as any).isMask = next;
             }
+          });
+        },
+        startCrop(nodeId) {
+          apply((draft) => {
+            const node = findNode(draft.tree, nodeId) as ImageNode | null;
+            if (!node) return;
+            const meta = draft.assets.images[node.props.assetId];
+            const rect =
+              node.props.crop || {
+                x: 0,
+                y: 0,
+                w: meta?.w || node.props.w || 0,
+                h: meta?.h || node.props.h || 0,
+              };
+            draft.cropDraft = { nodeId, rect };
+            draft.ui = { ...(draft.ui || {}), activeTool: 'crop' };
+          });
+        },
+        updateCrop(patch) {
+          apply((draft) => {
+            if (!draft.cropDraft) return;
+            draft.cropDraft.rect = { ...draft.cropDraft.rect, ...patch };
+          });
+        },
+        commitCrop() {
+          apply((draft) => {
+            if (!draft.cropDraft) return;
+            const node = findNode(
+              draft.tree,
+              draft.cropDraft.nodeId,
+            ) as ImageNode | null;
+            if (node) {
+              node.props = { ...node.props, crop: { ...draft.cropDraft.rect } };
+            }
+            draft.cropDraft = undefined;
+            draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
+          });
+        },
+        cancelCrop() {
+          apply((draft) => {
+            draft.cropDraft = undefined;
+            draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
           });
         },
         undo() {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -160,6 +160,7 @@ export interface ImageProps extends ComponentNode["props"] {
   fit?: "contain" | "cover" | "fill";
   position?: { x: number; y: number };
   isMask?: boolean;
+  crop?: { x: number; y: number; w: number; h: number };
 }
 
 export interface ImageNode extends ComponentNode {


### PR DESCRIPTION
## Summary
- add placeholder crop utilities and overlay
- enable starting and canceling image crop with basic keyboard support

## Testing
- `npm test` (fails: TypeError: reject is not a function)

------
https://chatgpt.com/codex/tasks/task_e_68a9196c0534832ca0ef6fcc37c6832b