### PR TITLE
feat: add image adjustments and blend options

### DIFF
--- a/web/components/editor/ImageView.tsx
+++ b/web/components/editor/ImageView.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { loadImage } from '@/lib/assets';
+import { cssFilter } from '@/lib/image/filters';
 import type { ImageNode, AssetMeta } from '@/types/editor';
 import { useEditorStore } from '@/store/editorStore';
 
@@ -22,6 +23,11 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
   const pos = node.props.position || { x: 0.5, y: 0.5 };
   if (!url) return null;
   const crop = node.props.crop;
+  const styleCommon: CSSProperties = {
+    filter: cssFilter(node.props.adjustments),
+    mixBlendMode: node.props.blend,
+    opacity: node.props.adjustments?.opacity,
+  };
   if (crop) {
     const scaleX = (node.props.w || meta.w) / crop.w;
     const scaleY = (node.props.h || meta.h) / crop.h;
@@ -33,6 +39,7 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
             width: meta.w * scaleX,
             height: meta.h * scaleY,
             transform: `translate(${-crop.x * scaleX}px, ${-crop.y * scaleY}px)`,
+            ...styleCommon,
           }}
         />
       </div>
@@ -46,6 +53,7 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
         height: '100%',
         objectFit: fit,
         objectPosition: `${pos.x * 100}% ${pos.y * 100}%`,
+        ...styleCommon,
       }}
       onDoubleClick={() => startCrop(node.id)}
     />

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,14 +1,112 @@
 "use client";
 import { useEditorStore } from "@/store/editorStore";
-import type { PathNode } from "@/types/editor";
+import type { PathNode, ImageNode, ImageAdjustments } from "@/types/editor";
 
 export default function RightPane() {
-  const selected = useEditorStore((s) => s.vector?.selection?.pathId);
+  const selectedId = useEditorStore((s) => s.selectedIds[0]);
+  const node = useEditorStore((s) => s.tree.find((n) => n.id === selectedId));
+  const updateImage = useEditorStore((s) => s.updateImageNode);
+  const selectedPath = useEditorStore((s) => s.vector?.selection?.pathId);
   const path = useEditorStore((s) =>
-    s.tree.find((n): n is PathNode => n.id === selected && n.type === "Path"),
+    s.tree.find((n): n is PathNode => n.id === selectedPath && n.type === "Path"),
   );
   const setProps = useEditorStore((s) => s.setPathProps);
   const toggleMask = useEditorStore((s) => s.toggleMask);
+  if (node && (node as ImageNode).type === "Image") {
+    const img = node as ImageNode;
+    const adj = img.props.adjustments || {};
+    const setAdj = (patch: Partial<ImageAdjustments>) =>
+      updateImage(img.id, {
+        adjustments: { ...adj, ...patch },
+      });
+    return (
+      <div className="bg-gray-800 p-2 space-y-2 text-xs">
+        <div className="font-bold">Image › Adjust</div>
+        <label className="block">
+          Brightness
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.01}
+            value={adj.brightness ?? 1}
+            onChange={(e) => setAdj({ brightness: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Contrast
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.01}
+            value={adj.contrast ?? 1}
+            onChange={(e) => setAdj({ contrast: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Saturation
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.01}
+            value={adj.saturation ?? 1}
+            onChange={(e) => setAdj({ saturation: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Hue
+          <input
+            type="range"
+            min={-180}
+            max={180}
+            step={1}
+            value={adj.hue ?? 0}
+            onChange={(e) => setAdj({ hue: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Blur
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={adj.blur ?? 0}
+            onChange={(e) => setAdj({ blur: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Opacity
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={adj.opacity ?? 1}
+            onChange={(e) => setAdj({ opacity: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Blend
+          <select
+            className="w-full bg-gray-700 ml-1 p-1 text-white"
+            value={img.props.blend || "normal"}
+            onChange={(e) => updateImage(img.id, { blend: e.target.value })}
+          >
+            {["normal", "multiply", "screen", "overlay", "darken", "lighten"].map(
+              (m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ),
+            )}
+          </select>
+        </label>
+      </div>
+    );
+  }
   if (!path) return <div className="bg-gray-800" />;
   const props = path.props || {};
   const parseDash = (v: string) => {

--- a/web/lib/image/export.ts
+++ b/web/lib/image/export.ts
@@ -1,0 +1,14 @@
+import type { ImageNode } from '@/types/editor';
+import { cssFilter } from './filters';
+
+export function exportImageStyle(node: ImageNode) {
+  const style: Record<string, any> = {};
+  if (node.props.adjustments) {
+    const f = cssFilter(node.props.adjustments);
+    if (f) style.filter = f;
+    if (node.props.adjustments.opacity !== undefined)
+      style.opacity = node.props.adjustments.opacity;
+  }
+  if (node.props.blend) style.mixBlendMode = node.props.blend;
+  return style;
+}

--- a/web/lib/image/filters.ts
+++ b/web/lib/image/filters.ts
@@ -1,0 +1,27 @@
+import type { ImageAdjustments } from '@/types/editor';
+
+const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
+
+export function normalize(adj: ImageAdjustments = {}): Required<ImageAdjustments> {
+  return {
+    brightness: clamp(adj.brightness ?? 1, 0, 2),
+    contrast: clamp(adj.contrast ?? 1, 0, 2),
+    saturation: clamp(adj.saturation ?? 1, 0, 2),
+    hue: clamp(adj.hue ?? 0, -180, 180),
+    blur: clamp(adj.blur ?? 0, 0, 100),
+    opacity: clamp(adj.opacity ?? 1, 0, 1),
+  };
+}
+
+export function cssFilter(adj?: ImageAdjustments): string {
+  if (!adj) return '';
+  const a = normalize(adj);
+  const parts = [
+    `brightness(${a.brightness})`,
+    `contrast(${a.contrast})`,
+    `saturate(${a.saturation})`,
+    `hue-rotate(${a.hue}deg)`,
+  ];
+  if (a.blur > 0) parts.push(`blur(${a.blur}px)`);
+  return parts.join(' ');
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -155,12 +155,23 @@ export interface AssetMeta {
   createdAt: number;
 }
 
+export interface ImageAdjustments {
+  brightness?: number;
+  contrast?: number;
+  saturation?: number;
+  hue?: number;
+  blur?: number;
+  opacity?: number;
+}
+
 export interface ImageProps extends ComponentNode["props"] {
   assetId: string;
   fit?: "contain" | "cover" | "fill";
   position?: { x: number; y: number };
   isMask?: boolean;
   crop?: { x: number; y: number; w: number; h: number };
+  adjustments?: ImageAdjustments;
+  blend?: string;
 }
 
 export interface ImageNode extends ComponentNode {


### PR DESCRIPTION
## Summary
- allow configuring brightness, contrast, saturation, hue, blur, opacity, and blend mode for images
- apply CSS filters and mix-blend-mode to images
- expose utilities for building filter strings and export styles

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a91c23d3dc832c8cafe36d9ed4b478