### PR TITLE
feat: add image crop overlay with handles

### DIFF
--- a/web/components/editor/ImageCropOverlay.tsx
+++ b/web/components/editor/ImageCropOverlay.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEditorStore } from '@/store/editorStore';
-import { moveCrop } from '@/lib/image/crop';
-import { useEffect } from 'react';
+import { moveCrop, resizeCrop, imageToWorld, worldToImage } from '@/lib/image/crop';
+import { useEffect, useRef, useState } from 'react';
 
 export default function ImageCropOverlay() {
   const draft = useEditorStore((s) => s.cropDraft);
@@ -10,10 +10,77 @@ export default function ImageCropOverlay() {
   const cancelCrop = useEditorStore((s) => s.cancelCrop);
   const assets = useEditorStore((s) => s.assets.images);
   const tree = useEditorStore((s) => s.tree);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [drag, setDrag] = useState<
+    | null
+    | {
+        mode: 'move' | 'resize';
+        handle?: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw';
+        start: { x: number; y: number };
+        rect: { x: number; y: number; w: number; h: number };
+      }
+  >(null);
   if (!draft) return null;
   const node = tree.find((n) => n.id === draft.nodeId) as any;
   const meta = assets[node?.props.assetId];
   const natural = { w: meta?.w || node?.props.w || 0, h: meta?.h || node?.props.h || 0 };
+
+  const tl = imageToWorld({ x: draft.rect.x, y: draft.rect.y }, node);
+  const br = imageToWorld(
+    { x: draft.rect.x + draft.rect.w, y: draft.rect.y + draft.rect.h },
+    node,
+  );
+  const rectWorld = { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y };
+
+  const getWorld = (e: { clientX: number; clientY: number }) => {
+    const rect = overlayRef.current!.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+
+  const onMoveDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startImg = worldToImage(getWorld(e), node);
+    setDrag({ mode: 'move', start: startImg, rect: draft.rect });
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const onHandleDown = (
+    handle: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw',
+  ) => (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startImg = worldToImage(getWorld(e), node);
+    setDrag({ mode: 'resize', handle, start: startImg, rect: draft.rect });
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  useEffect(() => {
+    if (!drag) return;
+    let raf = 0;
+    const onMove = (e: PointerEvent) => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const imgPt = worldToImage(getWorld(e), node);
+        const dx = imgPt.x - drag.start.x;
+        const dy = imgPt.y - drag.start.y;
+        const next =
+          drag.mode === 'move'
+            ? moveCrop(drag.rect, dx, dy, natural)
+            : resizeCrop(drag.rect, drag.handle!, dx, dy, { center: e.altKey }, natural);
+        updateCrop(next);
+      });
+    };
+    const onUp = () => setDrag(null);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      cancelAnimationFrame(raf);
+    };
+  }, [drag, node, natural, updateCrop]);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Enter') {
@@ -34,18 +101,102 @@ export default function ImageCropOverlay() {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [draft, commitCrop, cancelCrop, updateCrop, natural]);
-  const style: React.CSSProperties = {
-    position: 'absolute',
-    left: draft.rect.x,
-    top: draft.rect.y,
-    width: draft.rect.w,
-    height: draft.rect.h,
-    border: '1px solid #4af',
-    boxSizing: 'border-box',
+
+  const handleSize = 8;
+  const half = handleSize / 2;
+  const handles: (
+    | 'n'
+    | 'ne'
+    | 'e'
+    | 'se'
+    | 's'
+    | 'sw'
+    | 'w'
+    | 'nw'
+  )[] = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'];
+  const handleStyle = (h: string): React.CSSProperties => {
+    const { x, y, w, h: hh } = rectWorld;
+    const cx = x + w / 2 - half;
+    const cy = y + hh / 2 - half;
+    switch (h) {
+      case 'n':
+        return { left: cx, top: y - half, cursor: 'ns-resize' };
+      case 's':
+        return { left: cx, top: y + hh - half, cursor: 'ns-resize' };
+      case 'e':
+        return { left: x + w - half, top: cy, cursor: 'ew-resize' };
+      case 'w':
+        return { left: x - half, top: cy, cursor: 'ew-resize' };
+      case 'ne':
+        return { left: x + w - half, top: y - half, cursor: 'nesw-resize' };
+      case 'se':
+        return { left: x + w - half, top: y + hh - half, cursor: 'nwse-resize' };
+      case 'sw':
+        return { left: x - half, top: y + hh - half, cursor: 'nesw-resize' };
+      case 'nw':
+        return { left: x - half, top: y - half, cursor: 'nwse-resize' };
+      default:
+        return {};
+    }
   };
+
   return (
-    <div className="absolute inset-0 pointer-events-none">
-      <div style={style} />
+    <div ref={overlayRef} className="absolute inset-0">
+      {/* darken outside */}
+      <div className="pointer-events-none">
+        <div
+          className="absolute bg-black/50"
+          style={{ left: 0, top: 0, width: '100%', height: rectWorld.y }}
+        />
+        <div
+          className="absolute bg-black/50"
+          style={{ left: 0, top: rectWorld.y, width: rectWorld.x, height: rectWorld.h }}
+        />
+        <div
+          className="absolute bg-black/50"
+          style={{
+            left: rectWorld.x + rectWorld.w,
+            top: rectWorld.y,
+            width: `calc(100% - ${rectWorld.x + rectWorld.w}px)`,
+            height: rectWorld.h,
+          }}
+        />
+        <div
+          className="absolute bg-black/50"
+          style={{
+            left: 0,
+            top: rectWorld.y + rectWorld.h,
+            width: '100%',
+            height: `calc(100% - ${rectWorld.y + rectWorld.h}px)`,
+          }}
+        />
+      </div>
+
+      <div
+        className="absolute border border-blue-400 box-border cursor-move"
+        style={{
+          left: rectWorld.x,
+          top: rectWorld.y,
+          width: rectWorld.w,
+          height: rectWorld.h,
+        }}
+        onPointerDown={onMoveDown}
+      >
+        {/* grid lines */}
+        <div className="absolute inset-y-0 left-1/3 w-px bg-white/60 pointer-events-none" />
+        <div className="absolute inset-y-0 left-2/3 w-px bg-white/60 pointer-events-none" />
+        <div className="absolute inset-x-0 top-1/3 h-px bg-white/60 pointer-events-none" />
+        <div className="absolute inset-x-0 top-2/3 h-px bg-white/60 pointer-events-none" />
+      </div>
+      {handles.map((h) => (
+        <div
+          key={h}
+          className="absolute bg-white border border-blue-400 box-border"
+          style={{ width: handleSize, height: handleSize, ...handleStyle(h) }}
+          onPointerDown={onHandleDown(h)}
+        />
+      ))}
     </div>
   );
 }
+

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -68,6 +68,9 @@ export default function TopBar() {
           >
             Crop
           </button>
+          {activeTool === 'crop' && (
+            <span className="text-xs">Enter to confirm / Esc to cancel</span>
+          )}
           <button>Align</button>
           <button
             disabled={selection.length === 0}

--- a/web/lib/image/crop.ts
+++ b/web/lib/image/crop.ts
@@ -21,11 +21,11 @@ export function resizeCrop(rect:Rect, handle:'n'|'ne'|'e'|'se'|'s'|'sw'|'w'|'nw'
   return normalizeCrop({ x, y, w, h }, natural);
 }
 export function worldToImage(pt:{x:number;y:number}, node:any){
-  const { w, h } = node.props;
+  const { x: nx, y: ny, w, h } = node.props;
   const crop = node.props.crop || { x:0, y:0, w:node.meta?.w||w, h:node.meta?.h||h };
   const scaleX = crop.w / w;
   const scaleY = crop.h / h;
-  return { x: pt.x * scaleX + crop.x, y: pt.y * scaleY + crop.y };
+  return { x: (pt.x - nx) * scaleX + crop.x, y: (pt.y - ny) * scaleY + crop.y };
 }
 export function imageToWorld(pt:{x:number;y:number}, node:any){
   const { x: nx, y: ny, w, h } = node.props;


### PR DESCRIPTION
## Summary
- add interactive image crop overlay with guides and handles
- support world-to-image coordinate mapping for crops
- show crop confirmation hint in top bar

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a92005bd38832cade25834859a78b4