### PR TITLE
feat: add image adjustments and blending

### DIFF
--- a/web/components/editor/ImageView.tsx
+++ b/web/components/editor/ImageView.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState, type CSSProperties } from 'react';
 import { loadImage } from '@/lib/assets';
-import { cssFilter } from '@/lib/image/filters';
+import { normalizeAdjustments, toCssFilter } from '@/lib/image/filters';
 import type { ImageNode, AssetMeta } from '@/types/editor';
 import { useEditorStore } from '@/store/editorStore';
 
@@ -23,10 +23,12 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
   const pos = node.props.position || { x: 0.5, y: 0.5 };
   if (!url) return null;
   const crop = node.props.crop;
+  const adj = normalizeAdjustments(node.props.adjustments);
   const styleCommon: CSSProperties = {
-    filter: cssFilter(node.props.adjustments),
-    mixBlendMode: node.props.blend,
-    opacity: node.props.adjustments?.opacity,
+    filter: toCssFilter(node.props.adjustments),
+    mixBlendMode: node.props.blend || 'normal',
+    opacity: adj.opacity,
+    willChange: 'filter',
   };
   if (crop) {
     const scaleX = (node.props.w || meta.w) / crop.w;

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEditorStore } from "@/store/editorStore";
-import type { PathNode, ImageNode, ImageAdjustments } from "@/types/editor";
+import type { PathNode, ImageNode, ImageAdjustments, BlendMode } from "@/types/editor";
+import { normalizeAdjustments, DEFAULT_ADJ } from "@/lib/image/filters";
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedIds[0]);
@@ -14,96 +15,174 @@ export default function RightPane() {
   const toggleMask = useEditorStore((s) => s.toggleMask);
   if (node && (node as ImageNode).type === "Image") {
     const img = node as ImageNode;
-    const adj = img.props.adjustments || {};
-    const setAdj = (patch: Partial<ImageAdjustments>) =>
-      updateImage(img.id, {
-        adjustments: { ...adj, ...patch },
-      });
+    const adj = normalizeAdjustments(img.props.adjustments);
+    const setAdj = (key: keyof ImageAdjustments, value: number) => {
+      const next = normalizeAdjustments({ ...(img.props.adjustments || {}), [key]: value });
+      updateImage(img.id, { adjustments: next });
+    };
+    const blendModes: BlendMode[] = [
+      "normal",
+      "multiply",
+      "screen",
+      "overlay",
+      "darken",
+      "lighten",
+      "color-burn",
+      "color-dodge",
+      "hard-light",
+      "soft-light",
+      "difference",
+      "exclusion",
+    ];
     return (
       <div className="bg-gray-800 p-2 space-y-2 text-xs">
         <div className="font-bold">Image › Adjust</div>
         <label className="block">
           Brightness
-          <input
-            type="range"
-            min={0}
-            max={2}
-            step={0.01}
-            value={adj.brightness ?? 1}
-            onChange={(e) => setAdj({ brightness: Number(e.target.value) })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={0}
+              max={200}
+              step={1}
+              value={Math.round(adj.brightness * 100)}
+              onChange={(e) => setAdj("brightness", Number(e.target.value) / 100)}
+            />
+            <input
+              type="number"
+              min={0}
+              max={200}
+              className="w-16 bg-gray-700 p-1 text-white"
+              value={Math.round(adj.brightness * 100)}
+              onChange={(e) => setAdj("brightness", Number(e.target.value) / 100)}
+            />
+          </div>
         </label>
         <label className="block">
           Contrast
-          <input
-            type="range"
-            min={0}
-            max={2}
-            step={0.01}
-            value={adj.contrast ?? 1}
-            onChange={(e) => setAdj({ contrast: Number(e.target.value) })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={0}
+              max={200}
+              step={1}
+              value={Math.round(adj.contrast * 100)}
+              onChange={(e) => setAdj("contrast", Number(e.target.value) / 100)}
+            />
+            <input
+              type="number"
+              min={0}
+              max={200}
+              className="w-16 bg-gray-700 p-1 text-white"
+              value={Math.round(adj.contrast * 100)}
+              onChange={(e) => setAdj("contrast", Number(e.target.value) / 100)}
+            />
+          </div>
         </label>
         <label className="block">
           Saturation
-          <input
-            type="range"
-            min={0}
-            max={2}
-            step={0.01}
-            value={adj.saturation ?? 1}
-            onChange={(e) => setAdj({ saturation: Number(e.target.value) })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={0}
+              max={200}
+              step={1}
+              value={Math.round(adj.saturation * 100)}
+              onChange={(e) => setAdj("saturation", Number(e.target.value) / 100)}
+            />
+            <input
+              type="number"
+              min={0}
+              max={200}
+              className="w-16 bg-gray-700 p-1 text-white"
+              value={Math.round(adj.saturation * 100)}
+              onChange={(e) => setAdj("saturation", Number(e.target.value) / 100)}
+            />
+          </div>
         </label>
         <label className="block">
           Hue
-          <input
-            type="range"
-            min={-180}
-            max={180}
-            step={1}
-            value={adj.hue ?? 0}
-            onChange={(e) => setAdj({ hue: Number(e.target.value) })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={-180}
+              max={180}
+              step={1}
+              value={adj.hue}
+              onChange={(e) => setAdj("hue", Number(e.target.value))}
+            />
+            <input
+              type="number"
+              min={-180}
+              max={180}
+              className="w-16 bg-gray-700 p-1 text-white"
+              value={adj.hue}
+              onChange={(e) => setAdj("hue", Number(e.target.value))}
+            />
+          </div>
         </label>
         <label className="block">
           Blur
-          <input
-            type="range"
-            min={0}
-            max={100}
-            step={1}
-            value={adj.blur ?? 0}
-            onChange={(e) => setAdj({ blur: Number(e.target.value) })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={0}
+              max={50}
+              step={1}
+              value={adj.blur}
+              onChange={(e) => setAdj("blur", Number(e.target.value))}
+            />
+            <input
+              type="number"
+              min={0}
+              max={50}
+              className="w-16 bg-gray-700 p-1 text-white"
+              value={adj.blur}
+              onChange={(e) => setAdj("blur", Number(e.target.value))}
+            />
+          </div>
         </label>
         <label className="block">
           Opacity
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={adj.opacity ?? 1}
-            onChange={(e) => setAdj({ opacity: Number(e.target.value) })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={Math.round(adj.opacity * 100)}
+              onChange={(e) => setAdj("opacity", Number(e.target.value) / 100)}
+            />
+            <input
+              type="number"
+              min={0}
+              max={100}
+              className="w-16 bg-gray-700 p-1 text-white"
+              value={Math.round(adj.opacity * 100)}
+              onChange={(e) => setAdj("opacity", Number(e.target.value) / 100)}
+            />
+          </div>
         </label>
         <label className="block">
-          Blend
+          Blend Mode
           <select
             className="w-full bg-gray-700 ml-1 p-1 text-white"
             value={img.props.blend || "normal"}
-            onChange={(e) => updateImage(img.id, { blend: e.target.value })}
+            onChange={(e) => updateImage(img.id, { blend: e.target.value as BlendMode })}
           >
-            {["normal", "multiply", "screen", "overlay", "darken", "lighten"].map(
-              (m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ),
-            )}
+            {blendModes.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
           </select>
         </label>
+        <button
+          className="w-full p-1 bg-gray-700"
+          onClick={() => updateImage(img.id, { adjustments: DEFAULT_ADJ, blend: "normal" })}
+        >
+          Reset
+        </button>
       </div>
     );
   }

--- a/web/lib/image/export.ts
+++ b/web/lib/image/export.ts
@@ -1,14 +1,12 @@
 import type { ImageNode } from '@/types/editor';
-import { cssFilter } from './filters';
+import { normalizeAdjustments, toCssFilter } from './filters';
 
 export function exportImageStyle(node: ImageNode) {
-  const style: Record<string, any> = {};
-  if (node.props.adjustments) {
-    const f = cssFilter(node.props.adjustments);
-    if (f) style.filter = f;
-    if (node.props.adjustments.opacity !== undefined)
-      style.opacity = node.props.adjustments.opacity;
-  }
-  if (node.props.blend) style.mixBlendMode = node.props.blend;
+  const adj = normalizeAdjustments(node.props.adjustments);
+  const style: Record<string, any> = {
+    filter: toCssFilter(adj),
+    opacity: adj.opacity,
+    mixBlendMode: node.props.blend || 'normal',
+  };
   return style;
 }

--- a/web/lib/image/filters.ts
+++ b/web/lib/image/filters.ts
@@ -2,20 +2,29 @@ import type { ImageAdjustments } from '@/types/editor';
 
 const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
 
-export function normalize(adj: ImageAdjustments = {}): Required<ImageAdjustments> {
+export const DEFAULT_ADJ: Required<ImageAdjustments> = {
+  brightness: 1,
+  contrast: 1,
+  saturation: 1,
+  hue: 0,
+  blur: 0,
+  opacity: 1,
+};
+
+export function normalizeAdjustments(adj?: ImageAdjustments): Required<ImageAdjustments> {
+  const a = adj || {};
   return {
-    brightness: clamp(adj.brightness ?? 1, 0, 2),
-    contrast: clamp(adj.contrast ?? 1, 0, 2),
-    saturation: clamp(adj.saturation ?? 1, 0, 2),
-    hue: clamp(adj.hue ?? 0, -180, 180),
-    blur: clamp(adj.blur ?? 0, 0, 100),
-    opacity: clamp(adj.opacity ?? 1, 0, 1),
+    brightness: clamp(a.brightness ?? DEFAULT_ADJ.brightness, 0, 2),
+    contrast: clamp(a.contrast ?? DEFAULT_ADJ.contrast, 0, 2),
+    saturation: clamp(a.saturation ?? DEFAULT_ADJ.saturation, 0, 2),
+    hue: clamp(a.hue ?? DEFAULT_ADJ.hue, -180, 180),
+    blur: clamp(a.blur ?? DEFAULT_ADJ.blur, 0, 50),
+    opacity: clamp(a.opacity ?? DEFAULT_ADJ.opacity, 0, 1),
   };
 }
 
-export function cssFilter(adj?: ImageAdjustments): string {
-  if (!adj) return '';
-  const a = normalize(adj);
+export function toCssFilter(adj?: ImageAdjustments): string {
+  const a = normalizeAdjustments(adj);
   const parts = [
     `brightness(${a.brightness})`,
     `contrast(${a.contrast})`,

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -155,23 +155,37 @@ export interface AssetMeta {
   createdAt: number;
 }
 
+export type BlendMode =
+  | 'normal'
+  | 'multiply'
+  | 'screen'
+  | 'overlay'
+  | 'darken'
+  | 'lighten'
+  | 'color-burn'
+  | 'color-dodge'
+  | 'hard-light'
+  | 'soft-light'
+  | 'difference'
+  | 'exclusion';
+
 export interface ImageAdjustments {
-  brightness?: number;
-  contrast?: number;
-  saturation?: number;
-  hue?: number;
-  blur?: number;
-  opacity?: number;
+  brightness?: number; // 0..2, default 1
+  contrast?: number; // 0..2, default 1
+  saturation?: number; // 0..2, default 1
+  hue?: number; // -180..180 deg, default 0
+  blur?: number; // 0..50 px, default 0
+  opacity?: number; // 0..1, default 1
 }
 
 export interface ImageProps extends ComponentNode["props"] {
   assetId: string;
-  fit?: "contain" | "cover" | "fill";
+  fit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
   position?: { x: number; y: number };
   isMask?: boolean;
   crop?: { x: number; y: number; w: number; h: number };
   adjustments?: ImageAdjustments;
-  blend?: string;
+  blend?: BlendMode; // default 'normal'
 }
 
 export interface ImageNode extends ComponentNode {


### PR DESCRIPTION
## Summary
- support brightness/contrast/saturation/hue/blur/opacity adjustments and blend mode for images
- preview adjustments via CSS filters and blend mode in editor
- export image styles with matching filter and blending settings

## Testing
- `npm test` *(fails: Jest worker encountered 4 child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a92668fd50832c909a0995cad6e5ac