### PR TITLE
feat: basic image replace and drag drop

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -14,8 +14,9 @@ import { applyOverrides } from '@/lib/overrideMerge';
 import ZoomControls from './ZoomControls';
 import { wheelRouter } from '@/lib/input/wheelRouter';
 import * as zoom from '@/lib/zoom';
-import { useRef } from 'react';
-import { saveImage } from '@/lib/assets';
+import { useRef, useState } from 'react';
+import { saveImageMulti } from '@/lib/assets';
+import DropOverlay from './DropOverlay';
 
 function NodeView({
   node,
@@ -127,14 +128,22 @@ export default function CanvasStage() {
   const components = useEditorStore((s) => s.components);
   const prefs = useEditorStore((s) => s.prefs || {});
   const activeTool = useEditorStore((s) => s.ui?.activeTool || 'select');
+  const placeImages = useEditorStore((s) => s.placeImages);
+  const replaceImageAsset = useEditorStore((s) => s.replaceImageAsset);
+  const placeFromClipboard = useEditorStore((s) => s.placeFromClipboard);
 
   const panning = useRef(false);
   const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
 
+  const [dragCount, setDragCount] = useState<number | null>(null);
+
   const handleFiles = async (files: FileList) => {
-    for (const file of Array.from(files)) {
-      const meta = await saveImage(file);
-      useEditorStore.getState().addImageNode(meta);
+    const metas = await saveImageMulti(files);
+    if (selected.length === 1 && files.length === 1) {
+      useEditorStore.getState().addImageAsset(metas[0]);
+      replaceImageAsset(selected[0], metas[0].id);
+    } else {
+      placeImages(metas);
     }
   };
 
@@ -183,13 +192,27 @@ export default function CanvasStage() {
           });
         e.preventDefault();
       }}
+      onDragEnter={(e) => {
+        e.preventDefault();
+        if (e.dataTransfer.items?.length) setDragCount(e.dataTransfer.items.length);
+      }}
+      onDragLeave={(e) => {
+        if (e.target === e.currentTarget) setDragCount(null);
+      }}
       onDrop={(e) => {
         e.preventDefault();
+        setDragCount(null);
         if (e.dataTransfer.files?.length) handleFiles(e.dataTransfer.files);
       }}
       onDragOver={(e) => e.preventDefault()}
       onPaste={(e) => {
-        if (e.clipboardData.files?.length) handleFiles(e.clipboardData.files);
+        const item = Array.from(e.clipboardData.items || []).find((i) =>
+          i.type.startsWith('image/')
+        );
+        if (item) {
+          const file = item.getAsFile();
+          if (file) placeFromClipboard(file);
+        }
       }}
       onPointerDown={activeTool === 'pen' ? undefined : onPointerDown}
       onPointerMove={activeTool === 'pen' ? undefined : onPointerMove}
@@ -198,6 +221,7 @@ export default function CanvasStage() {
       {tree.map((n) => (
         <NodeView key={n.id} node={n} components={components} />
       ))}
+      {dragCount !== null && <DropOverlay count={dragCount} />}
       <SVGLayer />
       <PathEditorOverlay />
       <ImageCropOverlay />

--- a/web/components/editor/DropOverlay.tsx
+++ b/web/components/editor/DropOverlay.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function DropOverlay({ count = 0 }: { count?: number }) {
+  return (
+    <div className="drop-overlay flex items-center justify-center text-blue-500">
+      {count > 1 && (
+        <span className="badge">+{count - 1}</span>
+      )}
+    </div>
+  );
+}

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { TOP_BAR_HEIGHT } from '@/lib/layout/constants';
 import { useEditorStore } from '@/store/editorStore';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import type { BooleanOp } from '@/lib/vector/boolean';
 import { saveImage } from '@/lib/assets';
 
@@ -20,6 +20,7 @@ export default function TopBar() {
     const [replace, setReplace] = useState(false);
     const [toast, setToast] = useState(false);
     const fileInput = useRef<HTMLInputElement | null>(null);
+    const replaceInput = useRef<HTMLInputElement | null>(null);
 
     const handleFiles = async (files: FileList | null) => {
       if (!files) return;
@@ -28,6 +29,28 @@ export default function TopBar() {
         useEditorStore.getState().addImageNode(meta);
       }
     };
+
+    const handleReplace = async (files: FileList | null) => {
+      if (!files || selection.length === 0) return;
+      const file = files[0];
+      const meta = await saveImage(file);
+      const id = selection[selection.length - 1];
+      useEditorStore.getState().addImageAsset(meta);
+      useEditorStore.getState().replaceImageAsset(id, meta.id);
+    };
+
+    useEffect(() => {
+      const onKey = (e: KeyboardEvent) => {
+        if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'r') {
+          if (selection.length === 1) {
+            e.preventDefault();
+            replaceInput.current?.click();
+          }
+        }
+      };
+      window.addEventListener('keydown', onKey);
+      return () => window.removeEventListener('keydown', onKey);
+    }, [selection]);
 
     const run = (op: BooleanOp) => {
       const id = combine(op, selection, { replace });
@@ -55,6 +78,19 @@ export default function TopBar() {
             multiple
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
+          />
+          <button
+            disabled={selection.length !== 1}
+            onClick={() => replaceInput.current?.click()}
+          >
+            Replace
+          </button>
+          <input
+            ref={replaceInput}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => handleReplace(e.target.files)}
           />
           <button
             disabled={selection.length === 0}

--- a/web/lib/assets.ts
+++ b/web/lib/assets.ts
@@ -52,6 +52,18 @@ export async function saveImage(file: Blob): Promise<AssetMeta> {
   return meta;
 }
 
+export async function saveImageMulti(
+  files: Iterable<Blob>,
+): Promise<AssetMeta[]> {
+  const metas: AssetMeta[] = [];
+  for (const f of Array.from(files)) {
+    // sequentially process to avoid blocking main thread too much
+    const meta = await saveImage(f);
+    metas.push(meta);
+  }
+  return metas;
+}
+
 export async function loadImage(id: string): Promise<Blob | null> {
   const row = await db.images.get(id);
   return row ? row.blob : null;

--- a/web/lib/image/fit.ts
+++ b/web/lib/image/fit.ts
@@ -1,0 +1,36 @@
+export interface FitRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export function objectFit(
+  container: { w: number; h: number },
+  image: { w: number; h: number },
+  fit: 'contain' | 'cover',
+  position: { x: number; y: number } = { x: 0.5, y: 0.5 },
+): FitRect {
+  let scale = 1;
+  if (fit === 'contain') {
+    scale = Math.min(container.w / image.w, container.h / image.h);
+  } else {
+    scale = Math.max(container.w / image.w, container.h / image.h);
+  }
+  const w = image.w * scale;
+  const h = image.h * scale;
+  const x = (container.w - w) * position.x;
+  const y = (container.h - h) * position.y;
+  return { x, y, w, h };
+}
+
+export function normalizeCrop(
+  crop: { x: number; y: number; w: number; h: number },
+  natural: { w: number; h: number },
+) {
+  const x = Math.max(0, Math.min(crop.x, natural.w - crop.w));
+  const y = Math.max(0, Math.min(crop.y, natural.h - crop.h));
+  const w = Math.min(crop.w, natural.w);
+  const h = Math.min(crop.h, natural.h);
+  return { x, y, w, h };
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -30,6 +30,7 @@ import {
   booleanCombine as combinePolys,
   BooleanOp,
 } from "@/lib/vector/boolean";
+import { saveImage } from "@/lib/assets";
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -48,6 +49,16 @@ interface EditorActions {
   removeImageAsset: (id: string) => void;
   addImageNode: (meta: AssetMeta, opts?: { x?: number; y?: number }) => string;
   updateImageNode: (id: string, patch: Partial<ImageProps>) => void;
+  replaceImageAsset: (
+    nodeId: string,
+    newAssetId: string,
+    opts?: { preserveCrop?: boolean; fitPolicy?: 'keep' | 'cover' | 'contain' },
+  ) => void;
+  placeImages: (
+    assets: { id: string; w: number; h: number }[],
+    opts?: { grid?: { cols?: number; gap?: number }; start?: { x: number; y: number } },
+  ) => string[];
+  placeFromClipboard: (blob: Blob) => Promise<string>;
   undo: () => void;
   redo: () => void;
   makeAutoLayout: (frameId?: string) => void;
@@ -374,6 +385,58 @@ export const useEditorStore = create<EditorState & EditorActions>()(
               node.props = { ...node.props, ...patch } as ImageProps;
             }
           });
+        },
+        replaceImageAsset(nodeId, newAssetId) {
+          apply((draft) => {
+            const node = findNode(draft.tree, nodeId) as ImageNode | null;
+            if (node && node.type === "Image") {
+              if (node.props) (node.props as any).assetId = newAssetId;
+            }
+          });
+        },
+        placeImages(assets, opts) {
+          const ids: string[] = [];
+          const cols = opts?.grid?.cols ?? 4;
+          const gap = opts?.grid?.gap ?? 16;
+          const rect = get().getViewportRect();
+          const startX = opts?.start?.x ?? rect.x;
+          const startY = opts?.start?.y ?? rect.y;
+          apply((draft) => {
+            draft.assets = draft.assets || { images: {} };
+            assets.forEach((meta, i) => {
+              draft.assets.images[meta.id] = meta;
+              const short = Math.min(meta.w, meta.h);
+              const scale = 240 / short;
+              const w = meta.w * scale;
+              const h = meta.h * scale;
+              const col = i % cols;
+              const row = Math.floor(i / cols);
+              const x = startX + col * (w + gap);
+              const y = startY + row * (h + gap);
+              const id = uuid();
+              const node: ImageNode = {
+                id,
+                type: "Image",
+                props: {
+                  x,
+                  y,
+                  w,
+                  h,
+                  assetId: meta.id,
+                  fit: "contain",
+                  position: { x: 0.5, y: 0.5 },
+                },
+              };
+              draft.tree.push(node);
+              ids.push(id);
+            });
+            if (ids.length) draft.selectedIds = [ids[ids.length - 1]];
+          });
+          return ids;
+        },
+        async placeFromClipboard(blob) {
+          const meta = await saveImage(blob);
+          return get().addImageNode(meta);
         },
         makeAutoLayout(frameId) {
           apply((draft) => {

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -85,3 +85,23 @@
 .path-anchor.selected {
   fill: #ffa500;
 }
+
+/* drag & drop overlay */
+.drop-overlay {
+  position: absolute;
+  inset: 0;
+  border: 2px dashed #3b82f6;
+  background: rgba(59, 130, 246, 0.1);
+  pointer-events: none;
+  z-index: 50;
+}
+.drop-overlay .badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: #3b82f6;
+  color: white;
+  border-radius: 9999px;
+  padding: 0 6px;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- add multi-image saving utility
- enable placing and replacing images from DnD, paste or menu
- add drag overlay and keyboard shortcut for replace

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a927fd4af4832c84a2136efb60b04c