### PR TITLE
feat: support image nodes as masks

### DIFF
--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -36,7 +36,21 @@ export default function RightPane() {
     ];
     return (
       <div className="bg-gray-800 p-2 space-y-2 text-xs">
-        <div className="font-bold">Image › Adjust</div>
+        <div className="font-bold">Image</div>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={img.props.isMask || false}
+            onChange={() =>
+              updateImage(img.id, { isMask: !(img.props.isMask || false) })
+            }
+          />
+          Use as Mask
+        </label>
+        <div className="text-[10px] text-gray-400">
+          Applies to subsequent siblings until another mask appears.
+        </div>
+        <div className="font-bold">Adjust</div>
         <label className="block">
           Brightness
           <div className="flex items-center gap-1">

--- a/web/components/editor/SVGLayer.tsx
+++ b/web/components/editor/SVGLayer.tsx
@@ -11,8 +11,11 @@ import type {
 import {
   ensureMaskDefs,
   buildMaskElement,
+  buildImageMaskElement,
   makeMaskId,
 } from "@/lib/vector/mask";
+import { loadImage } from "@/lib/assets";
+import { computeDrawRect } from "@/lib/image/fit";
 
 function areMirrored(pt: PathPoint) {
   return (
@@ -55,6 +58,7 @@ function pathToD(node: PathNode) {
 export default function SVGLayer() {
   const tree = useEditorStore((s) => s.tree);
   const selectPath = useEditorStore((s) => s.selectPath);
+  const assets = useEditorStore((s) => s.assets?.images || {});
   const svgRef = useRef<SVGSVGElement>(null);
 
   // Build mask <defs> on every change to the tree
@@ -63,24 +67,70 @@ export default function SVGLayer() {
     if (!svg) return;
     const defs = ensureMaskDefs(svg);
     defs.innerHTML = "";
-    const masks: Array<PathNode | FrameNode | ImageNode> = [];
+    const urls: string[] = [];
+    const masks: ComponentNode[] = [];
     const collect = (nodes: ComponentNode[]) => {
       nodes.forEach((n) => {
-        if ((n as any).isMask) masks.push(n as any);
+        if ((n as any).isMask || n.props?.isMask) masks.push(n);
         if (n.children) collect(n.children);
       });
     };
     collect(tree);
     masks.forEach((m) => {
-      defs.appendChild(buildMaskElement(svg.ownerDocument, m));
+      if (m.type === "Image" && m.props?.isMask) {
+        const meta = assets[m.props.assetId];
+        if (!meta) return;
+        loadImage(meta.id).then((blob) => {
+          if (!blob) return;
+          const url = URL.createObjectURL(blob);
+          urls.push(url);
+          const frame = {
+            w: m.props.w ?? meta.w,
+            h: m.props.h ?? meta.h,
+          };
+          const draw = computeDrawRect(
+            frame,
+            { w: meta.w, h: meta.h },
+            m.props.fit || "contain",
+            m.props.position || { x: 0.5, y: 0.5 },
+            m.props.crop,
+          );
+          const viewport = {
+            x: m.props.x || 0,
+            y: m.props.y || 0,
+            w: frame.w,
+            h: frame.h,
+          };
+          const maskEl = buildImageMaskElement(svg.ownerDocument, {
+            nodeId: m.id,
+            href: url,
+            drawRect: {
+              x: draw.x + viewport.x,
+              y: draw.y + viewport.y,
+              w: draw.w,
+              h: draw.h,
+            },
+            viewport,
+            rotateDeg: m.props.rotation,
+            useLuminance: meta.mime !== "image/png",
+          });
+          defs.appendChild(maskEl);
+        });
+      } else {
+        defs.appendChild(buildMaskElement(svg.ownerDocument, m as any));
+      }
     });
-  }, [tree]);
+    return () => {
+      urls.forEach((u) => URL.revokeObjectURL(u));
+    };
+  }, [tree, assets]);
 
   const renderNodes = (nodes: ComponentNode[]): JSX.Element[] => {
     const els: JSX.Element[] = [];
     let activeMask: string | null = null;
     nodes.forEach((n) => {
-      if ((n as any).isMask) {
+      const isMask = (n as any).isMask || n.props?.isMask;
+      if (isMask) {
         activeMask = makeMaskId(n.id);
         return; // mask nodes are not rendered themselves
       }

--- a/web/lib/image/fit.ts
+++ b/web/lib/image/fit.ts
@@ -24,6 +24,60 @@ export function objectFit(
   return { x, y, w, h };
 }
 
+export function computeDrawRect(
+  frame: { w: number; h: number },
+  natural: { w: number; h: number },
+  fit:
+    | 'fill'
+    | 'contain'
+    | 'cover'
+    | 'none'
+    | 'scale-down',
+  position: { x: number; y: number },
+  crop?: { x: number; y: number; w: number; h: number },
+): FitRect {
+  if (crop) {
+    const scaleX = frame.w / crop.w;
+    const scaleY = frame.h / crop.h;
+    return {
+      x: -crop.x * scaleX,
+      y: -crop.y * scaleY,
+      w: natural.w * scaleX,
+      h: natural.h * scaleY,
+    };
+  }
+  let w = natural.w;
+  let h = natural.h;
+  let x = 0;
+  let y = 0;
+  let scale = 1;
+  switch (fit) {
+    case 'fill':
+      w = frame.w;
+      h = frame.h;
+      break;
+    case 'none':
+      x = (frame.w - w) * position.x;
+      y = (frame.h - h) * position.y;
+      return { x, y, w, h };
+    case 'cover':
+      scale = Math.max(frame.w / natural.w, frame.h / natural.h);
+      break;
+    case 'scale-down':
+      scale = Math.min(1, Math.min(frame.w / natural.w, frame.h / natural.h));
+      break;
+    case 'contain':
+    default:
+      scale = Math.min(frame.w / natural.w, frame.h / natural.h);
+      break;
+  }
+  w = natural.w * scale;
+  h = natural.h * scale;
+  x = (frame.w - w) * position.x;
+  y = (frame.h - h) * position.y;
+  return { x, y, w, h };
+}
+
 export function normalizeCrop(
   crop: { x: number; y: number; w: number; h: number },
   natural: { w: number; h: number },

--- a/web/lib/vector/mask.ts
+++ b/web/lib/vector/mask.ts
@@ -1,9 +1,4 @@
-import type {
-  FrameNode,
-  ImageNode,
-  PathNode,
-  PathPoint,
-} from "@/types/editor";
+import type { FrameNode, PathNode, PathPoint } from "@/types/editor";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -64,7 +59,7 @@ function pathToD(node: PathNode) {
 // Build a mask element for the given node
 export function buildMaskElement(
   doc: Document,
-  node: PathNode | FrameNode | ImageNode,
+  node: PathNode | FrameNode,
 ): SVGMaskElement {
   const mask = doc.createElementNS(SVG_NS, "mask");
   mask.setAttribute("id", makeMaskId(node.id));
@@ -90,17 +85,6 @@ export function buildMaskElement(
     rect.setAttribute("height", String(p.h || 0));
     rect.setAttribute("fill", "white");
     mask.appendChild(rect);
-  } else if (node.type === "Image") {
-    const img = doc.createElementNS(SVG_NS, "image");
-    const p = node.props || {};
-    if (p.assetId) {
-      img.setAttributeNS("http://www.w3.org/1999/xlink", "href", p.assetId);
-    }
-    if (p.x !== undefined) img.setAttribute("x", String(p.x));
-    if (p.y !== undefined) img.setAttribute("y", String(p.y));
-    if (p.w !== undefined) img.setAttribute("width", String(p.w));
-    if (p.h !== undefined) img.setAttribute("height", String(p.h));
-    mask.appendChild(img);
   }
   return mask;
 }
@@ -108,5 +92,59 @@ export function buildMaskElement(
 // Apply a mask to a group element
 export function applyMask(groupEl: SVGGElement, maskId: string): void {
   groupEl.setAttribute("mask", `url(#${maskId})`);
+}
+
+export function buildImageMaskElement(
+  doc: Document,
+  args: {
+    nodeId: string;
+    href: string;
+    drawRect: { x: number; y: number; w: number; h: number };
+    viewport: { x: number; y: number; w: number; h: number };
+    rotateDeg?: number;
+    useLuminance?: boolean;
+  },
+): SVGMaskElement {
+  const { nodeId, href, drawRect, viewport, rotateDeg, useLuminance } = args;
+  const mask = doc.createElementNS(SVG_NS, "mask");
+  mask.setAttribute("id", makeMaskId(nodeId));
+  mask.setAttribute("maskUnits", "userSpaceOnUse");
+  mask.setAttribute("maskContentUnits", "userSpaceOnUse");
+  mask.setAttribute("x", String(viewport.x));
+  mask.setAttribute("y", String(viewport.y));
+  mask.setAttribute("width", String(viewport.w));
+  mask.setAttribute("height", String(viewport.h));
+  mask.setAttribute("style", "mask-type:alpha");
+
+  const image = doc.createElementNS(SVG_NS, "image");
+  image.setAttributeNS("http://www.w3.org/1999/xlink", "href", href);
+  image.setAttribute("x", String(drawRect.x));
+  image.setAttribute("y", String(drawRect.y));
+  image.setAttribute("width", String(drawRect.w));
+  image.setAttribute("height", String(drawRect.h));
+  image.setAttribute("preserveAspectRatio", "none");
+  if (rotateDeg) {
+    const cx = drawRect.x + drawRect.w / 2;
+    const cy = drawRect.y + drawRect.h / 2;
+    image.setAttribute("transform", `rotate(${rotateDeg} ${cx} ${cy})`);
+  }
+
+  if (useLuminance) {
+    const filter = doc.createElementNS(SVG_NS, "filter");
+    const filterId = `lum-${nodeId}`;
+    filter.setAttribute("id", filterId);
+    const fe = doc.createElementNS(SVG_NS, "feColorMatrix");
+    fe.setAttribute("type", "matrix");
+    fe.setAttribute(
+      "values",
+      "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2126 0.7152 0.0722 0 0",
+    );
+    filter.appendChild(fe);
+    mask.appendChild(filter);
+    image.setAttribute("filter", `url(#${filterId})`);
+  }
+
+  mask.appendChild(image);
+  return mask;
 }
 

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -182,6 +182,7 @@ export interface ImageProps extends ComponentNode["props"] {
   assetId: string;
   fit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
   position?: { x: number; y: number };
+  /** When true, this image acts as a mask for subsequent siblings */
   isMask?: boolean;
   crop?: { x: number; y: number; w: number; h: number };
   adjustments?: ImageAdjustments;


### PR DESCRIPTION
## Summary
- allow image nodes to act as masks using alpha or luminance
- compute draw rect for image masking and cropping
- add UI checkbox to toggle image masking

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a92928933c832cb1cd8d0be4985fa1