### PR TITLE
feat: add image metrics and dominant color info

### DIFF
--- a/web/components/editor/ImageView.tsx
+++ b/web/components/editor/ImageView.tsx
@@ -2,11 +2,13 @@
 import { useEffect, useState, type CSSProperties } from 'react';
 import { loadImage } from '@/lib/assets';
 import { normalizeAdjustments, toCssFilter } from '@/lib/image/filters';
+import { getScaleInfo, isUpscaled } from '@/lib/image/metrics';
 import type { ImageNode, AssetMeta } from '@/types/editor';
 import { useEditorStore } from '@/store/editorStore';
 
 export default function ImageView({ node, meta }: { node: ImageNode; meta: AssetMeta }) {
   const startCrop = useEditorStore((s) => s.startCrop);
+  const showBadges = useEditorStore((s) => s.prefs?.showImageBadges !== false);
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     let currentUrl: string | null = null;
@@ -24,6 +26,13 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
   if (!url) return null;
   const crop = node.props.crop;
   const adj = normalizeAdjustments(node.props.adjustments);
+  const si = getScaleInfo(node, meta);
+  const badge =
+    showBadges && isUpscaled(si) ? (
+      <div className="image-badge">
+        Upscaled ×{si.scaleMax.toFixed(2)}
+      </div>
+    ) : null;
   const styleCommon: CSSProperties = {
     filter: toCssFilter(node.props.adjustments),
     mixBlendMode: node.props.blend || 'normal',
@@ -34,7 +43,10 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
     const scaleX = (node.props.w || meta.w) / crop.w;
     const scaleY = (node.props.h || meta.h) / crop.h;
     return (
-      <div className="w-full h-full overflow-hidden" onDoubleClick={() => startCrop(node.id)}>
+      <div
+        className="w-full h-full overflow-hidden relative"
+        onDoubleClick={() => startCrop(node.id)}
+      >
         <img
           src={url}
           style={{
@@ -44,20 +56,23 @@ export default function ImageView({ node, meta }: { node: ImageNode; meta: Asset
             ...styleCommon,
           }}
         />
+        {badge}
       </div>
     );
   }
   return (
-    <img
-      src={url}
-      style={{
-        width: '100%',
-        height: '100%',
-        objectFit: fit,
-        objectPosition: `${pos.x * 100}% ${pos.y * 100}%`,
-        ...styleCommon,
-      }}
-      onDoubleClick={() => startCrop(node.id)}
-    />
+    <div className="w-full h-full relative" onDoubleClick={() => startCrop(node.id)}>
+      <img
+        src={url}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: fit,
+          objectPosition: `${pos.x * 100}% ${pos.y * 100}%`,
+          ...styleCommon,
+        }}
+      />
+      {badge}
+    </div>
   );
 }

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,7 +1,9 @@
 "use client";
+import { useEffect } from "react";
 import { useEditorStore } from "@/store/editorStore";
 import type { PathNode, ImageNode, ImageAdjustments, BlendMode } from "@/types/editor";
 import { normalizeAdjustments, DEFAULT_ADJ } from "@/lib/image/filters";
+import { getScaleInfo } from "@/lib/image/metrics";
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedIds[0]);
@@ -13,8 +15,21 @@ export default function RightPane() {
   );
   const setProps = useEditorStore((s) => s.setPathProps);
   const toggleMask = useEditorStore((s) => s.toggleMask);
+  const assets = useEditorStore((s) => s.assets.images);
+  const prefs = useEditorStore((s) => s.prefs);
+  const setPrefs = useEditorStore((s) => s.setPrefs);
+  const ensureDominantColor = useEditorStore((s) => s.ensureDominantColor);
+
+  useEffect(() => {
+    if (node && node.type === "Image") {
+      const meta = assets[(node as ImageNode).props.assetId];
+      if (meta && !meta.dominant) ensureDominantColor(meta.id);
+    }
+  }, [node, assets, ensureDominantColor]);
   if (node && (node as ImageNode).type === "Image") {
     const img = node as ImageNode;
+    const meta = assets[img.props.assetId];
+    const si = meta ? getScaleInfo(img, meta) : undefined;
     const adj = normalizeAdjustments(img.props.adjustments);
     const setAdj = (key: keyof ImageAdjustments, value: number) => {
       const next = normalizeAdjustments({ ...(img.props.adjustments || {}), [key]: value });
@@ -37,6 +52,41 @@ export default function RightPane() {
     return (
       <div className="bg-gray-800 p-2 space-y-2 text-xs">
         <div className="font-bold">Image</div>
+        {meta && si && (
+          <div className="space-y-1">
+            <div>Natural: {si.natural.w}×{si.natural.h} px</div>
+            <div>
+              Display: CSS {Math.round(si.displayCss.w)}×{Math.round(si.displayCss.h)} px / Device {Math.round(si.displayDevice.w)}×{Math.round(si.displayDevice.h)} px
+            </div>
+            <div>
+              Scale: {si.scaleX.toFixed(2)} / {si.scaleY.toFixed(2)} / {si.scaleMax.toFixed(2)}
+            </div>
+            <div className="flex items-center gap-2">
+              Dominant:
+              <span
+                className="color-swatch"
+                style={{ background: meta.dominant || "#000" }}
+              />
+              <span>{meta.dominant || "-"}</span>
+              <button
+                className="ml-auto px-1 bg-gray-700"
+                onClick={() => ensureDominantColor(meta.id)}
+              >
+                Recompute
+              </button>
+            </div>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={prefs?.showImageBadges !== false}
+                onChange={(e) =>
+                  setPrefs({ showImageBadges: e.target.checked })
+                }
+              />
+              Show image badges
+            </label>
+          </div>
+        )}
         <label className="flex items-center gap-1">
           <input
             type="checkbox"

--- a/web/lib/color/dominant.ts
+++ b/web/lib/color/dominant.ts
@@ -1,0 +1,46 @@
+export async function computeDominantColor(
+  blob: Blob,
+  opts?: { downscale?: number; ignoreAlphaBelow?: number },
+): Promise<string> {
+  const downscale = opts?.downscale ?? 64;
+  const alphaThreshold = opts?.ignoreAlphaBelow ?? 16;
+  const bitmap = await createImageBitmap(blob, {
+    imageOrientation: 'from-image',
+  } as any);
+  const scale = Math.min(1, downscale / Math.min(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close();
+  const data = ctx.getImageData(0, 0, w, h).data;
+  const hist = new Map<number, number>();
+  for (let i = 0; i < data.length; i += 4) {
+    const a = data[i + 3];
+    if (a < alphaThreshold) continue;
+    const r = data[i] >> 3;
+    const g = data[i + 1] >> 3;
+    const b = data[i + 2] >> 3;
+    const key = (r << 10) | (g << 5) | b;
+    hist.set(key, (hist.get(key) || 0) + 1);
+  }
+  let maxKey = 0;
+  let max = -1;
+  hist.forEach((count, key) => {
+    if (count > max) {
+      max = count;
+      maxKey = key;
+    }
+  });
+  const r5 = (maxKey >> 10) & 0x1f;
+  const g5 = (maxKey >> 5) & 0x1f;
+  const b5 = maxKey & 0x1f;
+  const r8 = (r5 << 3) | (r5 >> 2);
+  const g8 = (g5 << 3) | (g5 >> 2);
+  const b8 = (b5 << 3) | (b5 >> 2);
+  const hex = `#${((r8 << 16) | (g8 << 8) | b8).toString(16).padStart(6, '0')}`;
+  return hex;
+}

--- a/web/lib/image/metrics.ts
+++ b/web/lib/image/metrics.ts
@@ -1,0 +1,45 @@
+import type { ImageNode, AssetMeta } from '@/types/editor';
+import { computeDrawRect } from './fit';
+
+export interface ScaleInfo {
+  displayCss: { w: number; h: number };
+  displayDevice: { w: number; h: number };
+  natural: { w: number; h: number };
+  scaleX: number;
+  scaleY: number;
+  scaleMax: number;
+}
+
+export function getScaleInfo(
+  node: ImageNode,
+  asset: AssetMeta,
+  dpr = typeof window !== 'undefined' ? window.devicePixelRatio : 1,
+): ScaleInfo {
+  const natural = node.props.crop
+    ? { w: node.props.crop.w, h: node.props.crop.h }
+    : { w: asset.w, h: asset.h };
+  const frame = {
+    w: node.props.w || asset.w,
+    h: node.props.h || asset.h,
+  };
+  const fit = node.props.fit || 'contain';
+  const pos = node.props.position || { x: 0.5, y: 0.5 };
+  const draw = computeDrawRect(frame, natural, fit, pos, node.props.crop);
+  const displayCss = { w: draw.w, h: draw.h };
+  const displayDevice = { w: draw.w * dpr, h: draw.h * dpr };
+  const scaleX = displayDevice.w / natural.w;
+  const scaleY = displayDevice.h / natural.h;
+  return {
+    displayCss,
+    displayDevice,
+    natural,
+    scaleX,
+    scaleY,
+    scaleMax: Math.max(scaleX, scaleY),
+  };
+}
+
+export function isUpscaled(si: ScaleInfo, threshold = 1.3): boolean {
+  return si.scaleMax > threshold;
+}
+

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -30,7 +30,8 @@ import {
   booleanCombine as combinePolys,
   BooleanOp,
 } from "@/lib/vector/boolean";
-import { saveImage } from "@/lib/assets";
+import { saveImage, loadImage } from "@/lib/assets";
+import { computeDominantColor } from "@/lib/color/dominant";
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -96,6 +97,8 @@ interface EditorActions {
   toggleLayoutGrid: () => void;
   togglePixelGrid: () => void;
   toggleSnapToPixel: () => void;
+  setPrefs: (patch: Partial<EditorState['prefs']>) => void;
+  ensureDominantColor: (assetId: string) => Promise<string>;
   booleanCombine: (
     op: BooleanOp,
     ids: string[],
@@ -267,6 +270,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           showLayoutGrid: false,
           showPixelGrid: false,
           snapToPixel: true,
+          showImageBadges: true,
         },
         lastCommandId: undefined,
         review: { status: "DRAFT", requireApprovedToShare: false },
@@ -641,6 +645,22 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             draft.prefs = draft.prefs || {};
             draft.prefs.snapToPixel = !draft.prefs.snapToPixel;
           });
+        },
+        setPrefs(patch) {
+          apply((draft) => {
+            draft.prefs = { ...(draft.prefs || {}), ...patch };
+          });
+        },
+        async ensureDominantColor(assetId) {
+          const asset = get().assets.images?.[assetId];
+          if (asset?.dominant) return asset.dominant;
+          const blob = await loadImage(assetId);
+          if (!blob) return '#000000';
+          const color = await computeDominantColor(blob);
+          apply((draft) => {
+            draft.assets.images[assetId].dominant = color;
+          });
+          return color;
         },
         booleanCombine(op, ids, opts) {
           const flat = opts?.flatness ?? 0.5;

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -105,3 +105,21 @@
   padding: 0 6px;
   font-size: 12px;
 }
+
+.image-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 2px 4px;
+  font-size: 10px;
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.color-swatch {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #fff;
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -153,6 +153,8 @@ export interface AssetMeta {
   size: number;
   hash: string;
   createdAt: number;
+  dominant?: string;
+  lastUsedAt?: number;
 }
 
 export type BlendMode =
@@ -275,6 +277,7 @@ export interface EditorState {
     showLayoutGrid?: boolean;
     showPixelGrid?: boolean;
     snapToPixel?: boolean;
+    showImageBadges?: boolean;
   };
   lastCommandId?: string;
   review: {


### PR DESCRIPTION
## Summary
- compute image display scale and detect upscaling
- extract and cache dominant image color with recompute option
- show image info panel and optional Upscaled badge

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9527d3de0832c8535a6882f147864