### PR TITLE
feat: add marquee zoom

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -17,6 +17,7 @@ import * as zoom from '@/lib/zoom';
 import { useRef, useState } from 'react';
 import { saveImageMulti } from '@/lib/assets';
 import DropOverlay from './DropOverlay';
+import MarqueeZoom from './MarqueeZoom';
 
 function NodeView({
   node,
@@ -182,6 +183,7 @@ export default function CanvasStage() {
   const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
 
   const [dragCount, setDragCount] = useState<number | null>(null);
+  const [marqueeStart, setMarqueeStart] = useState<{ x: number; y: number } | null>(null);
 
   const cursorMap: Record<string, string> = {
     pen: 'crosshair',
@@ -199,13 +201,17 @@ export default function CanvasStage() {
   };
 
   const onPointerDown = (e: React.PointerEvent) => {
+    if (e.shiftKey) {
+      setMarqueeStart({ x: e.clientX, y: e.clientY });
+      return;
+    }
     panning.current = true;
     last.current = { x: e.clientX, y: e.clientY, t: performance.now(), vx: 0, vy: 0 };
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
-    if (!panning.current) return;
+    if (!panning.current || marqueeStart) return;
     const now = performance.now();
     const state = useEditorStore.getState();
     const dx = e.clientX - last.current.x;
@@ -222,7 +228,7 @@ export default function CanvasStage() {
   };
 
   const onPointerUp = () => {
-    if (panning.current) {
+    if (panning.current && !marqueeStart) {
       panning.current = false;
       zoom.panWithInertia(last.current.vx, last.current.vy);
     }
@@ -274,6 +280,9 @@ export default function CanvasStage() {
         <NodeView key={n.id} node={n} components={components} />
       ))}
       {dragCount !== null && <DropOverlay count={dragCount} />}
+      {marqueeStart && (
+        <MarqueeZoom start={marqueeStart} onEnd={() => setMarqueeStart(null)} />
+      )}
       <SVGLayer />
       <PathEditorOverlay />
       <ImageCropOverlay />

--- a/web/components/editor/MarqueeZoom.tsx
+++ b/web/components/editor/MarqueeZoom.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useRef, useState, useEffect } from 'react';
+import * as zoom from '@/lib/zoom';
+import { useEditorStore } from '@/store/editorStore';
+
+interface Props {
+  start: { x: number; y: number };
+  onEnd: () => void;
+}
+
+export default function MarqueeZoom({ start, onEnd }: Props) {
+  const [rect, setRect] = useState({ x: start.x, y: start.y, w: 0, h: 0 });
+  const rectRef = useRef(rect);
+  useEffect(() => {
+    rectRef.current = rect;
+  }, [rect]);
+
+  useEffect(() => {
+    function onMove(e: PointerEvent) {
+      setRect({
+        x: Math.min(start.x, e.clientX),
+        y: Math.min(start.y, e.clientY),
+        w: Math.abs(e.clientX - start.x),
+        h: Math.abs(e.clientY - start.y),
+      });
+    }
+    function finish(confirm: boolean) {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('keydown', onKey);
+      if (confirm) {
+        const r = rectRef.current;
+        const center = { x: r.x + r.w / 2, y: r.y + r.h / 2 };
+        const cam = useEditorStore.getState().camera;
+        if (r.w < 16 || r.h < 16) {
+          zoom.zoomBy(1.5, center);
+        } else {
+          const target = zoom.fitRect(cam, r);
+          zoom.animateZoomTo(target, { duration: 240 });
+        }
+      }
+      onEnd();
+    }
+    function onUp() {
+      finish(true);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') finish(false);
+      if (e.key === 'Enter') finish(true);
+    }
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [start, onEnd]);
+
+  return (
+    <div
+      className="marquee-zoom"
+      style={{
+        left: rect.x,
+        top: rect.y,
+        width: rect.w,
+        height: rect.h,
+      }}
+    />
+  );
+}

--- a/web/components/editor/ZoomControls.tsx
+++ b/web/components/editor/ZoomControls.tsx
@@ -17,7 +17,13 @@ export default function ZoomControls() {
         -
       </button>
       <span className="text-xs w-12 text-center">{Math.round(z * 100)}%</span>
-      <button className="w-12 h-7" onClick={() => zoom.animateZoomTo(1)}>
+      <button
+        className="w-12 h-7"
+        onClick={() => {
+          const cam = useEditorStore.getState().camera;
+          zoom.animateZoomTo({ ...cam, zoom: 1 });
+        }}
+      >
         100%
       </button>
       <button className="w-7 h-7" onClick={() => zoom.fitAll()}>

--- a/web/lib/commands.ts
+++ b/web/lib/commands.ts
@@ -105,7 +105,10 @@ export const COMMANDS: Command[] = [
     id: 'zoom.to100',
     label: 'Zoom to 100%',
     shortcut: '1',
-    run: () => zoom.animateZoomTo(1),
+    run: () => {
+      const cam = useEditorStore.getState().camera;
+      zoom.animateZoomTo({ ...cam, zoom: 1 });
+    },
   },
 ];
 

--- a/web/lib/zoom.ts
+++ b/web/lib/zoom.ts
@@ -20,36 +20,62 @@ export function zoomBy(factor: number, anchor?: { x: number; y: number }) {
 }
 
 export function animateZoomTo(
-  targetZoom: number,
-  anchor?: { x: number; y: number },
+  target: { x: number; y: number; zoom: number },
   opts?: { duration?: number }
 ): Promise<void> {
   const store = useEditorStore.getState();
-  const start = performance.now();
-  const duration = opts?.duration ?? parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--motion-base')) || 200;
-  const from = store.camera;
-  const toZoom = clampZoom(targetZoom);
-  let toX = from.x;
-  let toY = from.y;
-  if (anchor) {
-    const wx = (anchor.x - from.x) / from.zoom;
-    const wy = (anchor.y - from.y) / from.zoom;
-    toX = anchor.x - wx * toZoom;
-    toY = anchor.y - wy * toZoom;
+  const to = { x: target.x, y: target.y, zoom: clampZoom(target.zoom) };
+  const prefersReduce =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const duration =
+    opts?.duration ??
+    parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue('--motion-base')
+    ) || 200;
+  if (prefersReduce || duration === 0) {
+    store.setCamera(to);
+    return Promise.resolve();
   }
+  const from = store.camera;
+  const start = performance.now();
   return new Promise((resolve) => {
     function frame(now: number) {
       const t = Math.min((now - start) / duration, 1);
-      const eased = t * (2 - t); // ease-out
-      const z = from.zoom + (toZoom - from.zoom) * eased;
-      const x = from.x + (toX - from.x) * eased;
-      const y = from.y + (toY - from.y) * eased;
+      const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
+      const x = from.x + (to.x - from.x) * eased;
+      const y = from.y + (to.y - from.y) * eased;
+      const z = from.zoom + (to.zoom - from.zoom) * eased;
       store.setCamera({ x, y, zoom: z });
       if (t < 1) requestAnimationFrame(frame);
       else resolve();
     }
     requestAnimationFrame(frame);
   });
+}
+
+export function fitRect(
+  camera: { x: number; y: number; zoom: number },
+  rect: { x: number; y: number; w: number; h: number },
+  opts?: { padding?: number }
+): { x: number; y: number; zoom: number } {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const pad = opts?.padding ?? 0;
+  const worldX = camera.x + rect.x / camera.zoom;
+  const worldY = camera.y + rect.y / camera.zoom;
+  const worldW = rect.w / camera.zoom;
+  const worldH = rect.h / camera.zoom;
+  const padW = worldW * pad;
+  const padH = worldH * pad;
+  const zoom = clampZoom(
+    Math.min(vw / (worldW + padW * 2), vh / (worldH + padH * 2))
+  );
+  const cx = worldX + worldW / 2;
+  const cy = worldY + worldH / 2;
+  const x = cx - vw / (2 * zoom);
+  const y = cy - vh / (2 * zoom);
+  return { x, y, zoom };
 }
 
 export function fitAll(): void {

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -118,6 +118,14 @@
   pointer-events: none;
 }
 
+.marquee-zoom {
+  position: absolute;
+  border: 1px dashed #fff;
+  background: rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+  z-index: 30;
+}
+
 .color-swatch {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
## Summary
- implement marquee-based zoom overlay
- add fitRect and enhanced animateZoomTo
- integrate zoom controls and commands

## Testing
- `npm test` (fails: TypeError: reject is not a function)

------
https://chatgpt.com/codex/tasks/task_e_68aa6b3460b8832cbd65fb32620cfeb4