### PR TITLE
feat: add wrap and space-between auto layout

### DIFF
--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -82,19 +82,47 @@ export default function RightInspector() {
           </select>
         </label>
         {node?.props?.layout === 'auto' && (
-          <label className="block text-xs">
-            Direction:
-            <select
-              className="w-full bg-gray-700 ml-1 p-1 text-white"
-              value={node?.props?.axis || 'vertical'}
-              onChange={(e) =>
-                setLayout(selected, { axis: e.target.value as any })
-              }
-            >
-              <option value="horizontal">Row</option>
-              <option value="vertical">Column</option>
-            </select>
-          </label>
+          <div className="space-y-1">
+            <label className="block text-xs">
+              Direction:
+              <select
+                className="w-full bg-gray-700 ml-1 p-1 text-white"
+                value={node?.props?.axis || 'vertical'}
+                onChange={(e) =>
+                  setLayout(selected, { axis: e.target.value as any })
+                }
+              >
+                <option value="horizontal">Row</option>
+                <option value="vertical">Column</option>
+              </select>
+            </label>
+            <label className="block text-xs">
+              Wrap:
+              <input
+                type="checkbox"
+                className="ml-1"
+                checked={node?.props?.wrap || false}
+                onChange={(e) =>
+                  setLayout(selected, { wrap: e.target.checked })
+                }
+              />
+            </label>
+            {node?.props?.wrap && (
+              <label className="block text-xs">
+                Max per line:
+                <input
+                  type="number"
+                  className="w-full bg-gray-700 ml-1 p-1 text-white"
+                  value={node?.props?.maxPerLine ?? 0}
+                  onChange={(e) =>
+                    setLayout(selected, {
+                      maxPerLine: Number(e.target.value),
+                    })
+                  }
+                />
+              </label>
+            )}
+          </div>
         )}
         <div className="mt-2 space-y-1">
           <h3 className="text-xs font-bold">Constraints</h3>

--- a/web/lib/layout/autolayout.ts
+++ b/web/lib/layout/autolayout.ts
@@ -1,0 +1,69 @@
+import type { ComponentNode } from '@/types/editor';
+
+export interface Positioned {
+  id: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * Computes basic auto layout positioning for a frame's children.
+ * Supports gap, padding, wrap and justifyContent='space-between'.
+ * This is a simplified layout engine used for Canvas preview.
+ */
+export function computeAutoLayout(frame: ComponentNode): Record<string, { x: number; y: number }> {
+  const res: Record<string, { x: number; y: number }> = {};
+  const p = frame.props || {};
+  if (!frame.children || frame.children.length === 0) return res;
+  if (p.layout !== 'auto') return res;
+
+  const isHorizontal = p.axis === 'horizontal';
+  const gap = p.gap ?? 0;
+  const pad = normalizePadding(p.padding);
+  const wrap = p.wrap;
+  const maxPerLine = p.maxPerLine ?? Infinity;
+
+  const availableMain = (isHorizontal ? p.w ?? 0 : p.h ?? 0) - (isHorizontal ? pad.left + pad.right : pad.top + pad.bottom);
+  let lines: ComponentNode[][] = [];
+  let line: ComponentNode[] = [];
+  let count = 0;
+  for (const child of frame.children) {
+    line.push(child);
+    count++;
+    if (wrap && count >= maxPerLine) {
+      lines.push(line);
+      line = [];
+      count = 0;
+    }
+  }
+  if (line.length) lines.push(line);
+
+  let cross = pad.top;
+  for (const items of lines) {
+    let main = pad.left;
+    const mainSize = items.reduce((sum, c) => sum + (isHorizontal ? c.props?.w || 0 : c.props?.h || 0), 0);
+    let spacing = gap;
+    if (p.justifyContent === 'space-between' && items.length > 1) {
+      spacing = (availableMain - mainSize) / (items.length - 1);
+    }
+    for (const c of items) {
+      res[c.id] = { x: isHorizontal ? main : pad.left, y: isHorizontal ? cross : main };
+      main += (isHorizontal ? c.props?.w || 0 : c.props?.h || 0) + spacing;
+    }
+    cross += (isHorizontal
+      ? Math.max(...items.map((c) => c.props?.h || 0))
+      : Math.max(...items.map((c) => c.props?.w || 0))) + gap;
+  }
+  return res;
+}
+
+function normalizePadding(pad: any): { top: number; right: number; bottom: number; left: number } {
+  if (pad == null) return { top: 0, right: 0, bottom: 0, left: 0 };
+  if (typeof pad === 'number') return { top: pad, right: pad, bottom: pad, left: pad };
+  return {
+    top: pad.top || 0,
+    right: pad.right || 0,
+    bottom: pad.bottom || 0,
+    left: pad.left || 0,
+  };
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -1,6 +1,19 @@
 export type LayoutMode = "free" | "auto";
 export type Axis = "horizontal" | "vertical";
 export type SizeMode = "HUG" | "FIXED" | "FILL";
+export type AlignMain = "start" | "center" | "end" | "space-between";
+export type AlignCross = "start" | "center" | "end" | "stretch";
+
+export interface LayoutProps {
+  enabled: boolean;
+  axis: Axis;
+  gap: number;
+  padding: { top: number; right: number; bottom: number; left: number };
+  alignMain: AlignMain;
+  alignCross: AlignCross;
+  wrap?: boolean;
+  maxPerLine?: number;
+}
 
 export type ConstraintH = "LEFT" | "RIGHT" | "LEFT_RIGHT" | "CENTER" | "SCALE";
 export type ConstraintV = "TOP" | "BOTTOM" | "TOP_BOTTOM" | "CENTER" | "SCALE";
@@ -223,6 +236,7 @@ export interface ComponentNode {
       | "space-around"
       | "space-evenly";
     wrap?: boolean;
+    maxPerLine?: number;
     widthMode?: SizeMode;
     heightMode?: SizeMode;
     minW?: number;


### PR DESCRIPTION
## Summary
- add layout typing for wrap and max items per line
- basic autolayout engine supporting wrap and space-between
- expose wrap and max per line controls in inspector

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6ddd2f6c832c9fcb5901111a9b26