### PR TITLE
fix: text tool hotfix

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -6,15 +6,17 @@ import SVGLayer from './SVGLayer';
 import PathEditorOverlay from './PathEditorOverlay';
 import PenTool from './tools/PenTool';
 import ImageView from './ImageView';
+import TextView from './TextView';
+import TextEditor from './TextEditor';
 import ImageCropOverlay from './ImageCropOverlay';
-import type { ComponentNode, InstanceNode, PathNode, ImageNode } from '@/types/editor';
+import type { ComponentNode, InstanceNode, PathNode, ImageNode, TextNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
 import ZoomControls from './ZoomControls';
 import { wheelRouter } from '@/lib/input/wheelRouter';
 import * as zoom from '@/lib/zoom';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { saveImageMulti } from '@/lib/assets';
 import DropOverlay from './DropOverlay';
 import MarqueeZoom from './MarqueeZoom';
@@ -105,6 +107,16 @@ function NodeView({
     );
   }
 
+  if (node.type === 'Text') {
+    const t = node as TextNode;
+    return (
+      <>
+        <TextView node={t} />
+        {t.edit?.active && <TextEditor node={t} />}
+      </>
+    );
+  }
+
   if (layout === 'auto') {
     const common = {
       onPointerEnter: () => setHover(node.id),
@@ -178,6 +190,9 @@ export default function CanvasStage() {
   const placeImages = useEditorStore((s) => s.placeImages);
   const replaceImageAsset = useEditorStore((s) => s.replaceImageAsset);
   const placeFromClipboard = useEditorStore((s) => s.placeFromClipboard);
+  const addText = useEditorStore((s) => s.addText);
+  const toggleEditText = useEditorStore((s) => s.toggleEditText);
+  const setActiveTool = useEditorStore((s) => s.setActiveTool);
 
   const panning = useRef(false);
   const last = useRef({ x: 0, y: 0, t: 0, vx: 0, vy: 0 });
@@ -200,7 +215,25 @@ export default function CanvasStage() {
     }
   };
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 't' || e.key === 'T') {
+        setActiveTool('text');
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [setActiveTool]);
+
   const onPointerDown = (e: React.PointerEvent) => {
+    if (activeTool === 'text') {
+      const state = useEditorStore.getState();
+      const x = state.camera.x + e.clientX / state.camera.zoom;
+      const y = state.camera.y + e.clientY / state.camera.zoom;
+      const id = addText({ x, y });
+      toggleEditText(id, true);
+      return;
+    }
     if (e.shiftKey) {
       setMarqueeStart({ x: e.clientX, y: e.clientY });
       return;

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect } from "react";
 import { useEditorStore } from "@/store/editorStore";
-import type { PathNode, ImageNode, ImageAdjustments, BlendMode } from "@/types/editor";
+import type { PathNode, ImageNode, ImageAdjustments, BlendMode, TextNode, TextResizeMode } from "@/types/editor";
 import { normalizeAdjustments, DEFAULT_ADJ } from "@/lib/image/filters";
 import { getScaleInfo } from "@/lib/image/metrics";
 
@@ -247,6 +247,66 @@ export default function RightPane() {
         >
           Reset
         </button>
+      </div>
+    );
+  }
+  if (node && node.type === 'Text') {
+    const t = node as TextNode;
+    const setStyle = useEditorStore((s) => s.setTextStyle);
+    const setResize = useEditorStore((s) => s.setTextResizeMode);
+    const applyRun = useEditorStore((s) => s.applyRunStyle);
+    const sel = useEditorStore((s) => s.textSel);
+    return (
+      <div className="bg-gray-800 p-2 space-y-2 text-xs">
+        <div className="font-bold">Typography</div>
+        <label className="block">
+          Font
+          <input
+            className="w-full bg-gray-700 p-1 text-white"
+            value={t.style.fontFamily}
+            onChange={(e) => setStyle(t.id, { fontFamily: e.target.value })}
+          />
+        </label>
+        <label className="block">
+          Size
+          <input
+            type="number"
+            className="w-full bg-gray-700 p-1 text-white"
+            value={t.style.fontSize}
+            onChange={(e) => setStyle(t.id, { fontSize: Number(e.target.value) })}
+          />
+        </label>
+        <label className="block">
+          Color
+          <input
+            type="color"
+            value={t.style.color || '#000000'}
+            onChange={(e) => setStyle(t.id, { color: e.target.value })}
+          />
+        </label>
+        <label className="block">
+          Resize
+          <select
+            className="w-full bg-gray-700 p-1 text-white"
+            value={t.resizeMode || 'AUTO_HEIGHT'}
+            onChange={(e) => setResize(t.id, e.target.value as TextResizeMode)}
+          >
+            <option value="AUTO_WIDTH">Auto width</option>
+            <option value="AUTO_HEIGHT">Auto height</option>
+            <option value="FIXED">Fixed</option>
+          </select>
+        </label>
+        {sel?.nodeId === t.id && sel.start !== sel.end && (
+          <label className="block">
+            Link
+            <input
+              className="w-full bg-gray-700 p-1 text-white"
+              onChange={(e) =>
+                applyRun(t.id, { from: sel.start, to: sel.end }, { link: e.target.value })
+              }
+            />
+          </label>
+        )}
       </div>
     );
   }

--- a/web/components/editor/TextEditor.tsx
+++ b/web/components/editor/TextEditor.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import type { TextNode } from '@/types/editor';
+import { useEditorStore } from '@/store/editorStore';
+
+export default function TextEditor({ node }: { node: TextNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const updateText = useEditorStore((s) => s.updateText);
+  const toggleEdit = useEditorStore((s) => s.toggleEditText);
+  const setSel = useEditorStore((s) => s.setTextSelection);
+  const clearSel = useEditorStore((s) => s.clearTextSelection);
+  const composing = useRef(false);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className="text-editor"
+      contentEditable
+      suppressContentEditableWarning
+      style={{
+        position: 'absolute',
+        left: node.props?.x,
+        top: node.props?.y,
+        minWidth: 1,
+        outline: 'none',
+        whiteSpace: node.resizeMode === 'AUTO_WIDTH' ? 'nowrap' : 'pre-wrap',
+        overflow: node.resizeMode === 'FIXED' ? 'hidden' : undefined,
+        width: node.resizeMode === 'AUTO_WIDTH' ? undefined : node.props?.w,
+        height: node.resizeMode === 'FIXED' ? node.props?.h : undefined,
+        fontFamily: node.style.fontFamily,
+        fontSize: node.style.fontSize,
+        fontWeight: node.style.fontWeight,
+        color: node.style.color,
+      }}
+      onCompositionStart={() => (composing.current = true)}
+      onCompositionEnd={(e) => {
+        composing.current = false;
+        updateText(node.id, (e.target as HTMLDivElement).innerText);
+      }}
+      onInput={(e) => {
+        if (!composing.current) {
+          updateText(node.id, (e.target as HTMLDivElement).innerText);
+        }
+      }}
+      onSelect={() => {
+        const sel = window.getSelection();
+        if (sel) {
+          const start = sel.anchorOffset || 0;
+          const end = sel.focusOffset || 0;
+          setSel({ nodeId: node.id, start, end });
+        }
+      }}
+      onBlur={() => clearSel()}
+      onKeyDown={(e) => {
+        if (composing.current) return;
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          toggleEdit(node.id, false);
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          toggleEdit(node.id, false);
+        }
+      }}
+    >
+      {node.text}
+    </div>
+  );
+}

--- a/web/components/editor/TextView.tsx
+++ b/web/components/editor/TextView.tsx
@@ -1,0 +1,64 @@
+import type { TextNode } from '@/types/editor';
+
+export default function TextView({ node }: { node: TextNode }) {
+  const s = node.style;
+  const lineHeight = s.lineHeight === 'AUTO' ? undefined : `${s.lineHeight?.px}px`;
+  const letterSpacing = s.letterSpacing
+    ? s.letterSpacing.unit === 'PX'
+      ? `${s.letterSpacing.value}px`
+      : `${s.letterSpacing.value}%`
+    : undefined;
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: node.props?.x,
+    top: node.props?.y,
+    whiteSpace: node.resizeMode === 'AUTO_WIDTH' ? 'nowrap' : 'pre-wrap',
+    overflow: node.resizeMode === 'FIXED' ? 'hidden' : undefined,
+    width: node.resizeMode === 'AUTO_WIDTH' ? undefined : node.props?.w,
+    height: node.resizeMode === 'FIXED' ? node.props?.h : undefined,
+  };
+  const spanStyle: React.CSSProperties = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight,
+    letterSpacing,
+    color: s.color,
+    textAlign: s.textAlign,
+    fontStyle: s.italic ? 'italic' : undefined,
+    textDecoration: [s.underline && 'underline', s.strike && 'line-through']
+      .filter(Boolean)
+      .join(' '),
+    textTransform: s.uppercase ? 'uppercase' : undefined,
+  };
+
+  const content = node.runs?.length
+    ? (() => {
+        const parts: React.ReactNode[] = [];
+        let cursor = 0;
+        for (const r of [...node.runs].sort((a, b) => a.from - b.from)) {
+          if (cursor < r.from) parts.push(node.text.slice(cursor, r.from));
+          const t = node.text.slice(r.from, r.to);
+          parts.push(
+            <span key={`${r.from}-${r.to}`} style={{
+              fontWeight: r.style.fontWeight,
+              fontStyle: r.style.italic ? 'italic' : undefined,
+              color: r.style.color,
+              textDecoration: r.style.link ? 'underline' : r.style.underline ? 'underline' : r.style.strike ? 'line-through' : undefined,
+            }}>
+              {r.style.link ? <a href={r.style.link}>{t}</a> : t}
+            </span>
+          );
+          cursor = r.to;
+        }
+        if (cursor < node.text.length) parts.push(node.text.slice(cursor));
+        return parts;
+      })()
+    : node.text;
+
+  return (
+    <div style={style}>
+      <span style={spanStyle}>{content}</span>
+    </div>
+  );
+}

--- a/web/lib/text/layout.ts
+++ b/web/lib/text/layout.ts
@@ -1,0 +1,23 @@
+import type { TextNode } from '@/types/editor';
+import { measure } from './measure';
+
+export function layoutText(node: TextNode) {
+  const maxWidth = node.resizeMode === 'AUTO_HEIGHT' ? node.props?.w : undefined;
+  const m = measure(node.text, node.style, { maxWidth });
+  let w = node.props?.w || m.width;
+  let h = node.props?.h || m.lineHeight;
+  if (node.resizeMode === 'AUTO_WIDTH') {
+    w = m.width;
+    h = m.lineHeight;
+  } else if (node.resizeMode === 'AUTO_HEIGHT') {
+    h = m.height;
+    w = node.props?.w ?? m.width;
+  } else if (node.resizeMode === 'FIXED') {
+    w = node.props?.w ?? m.width;
+    h = node.props?.h ?? m.height;
+  } else {
+    w = m.width;
+    h = m.height;
+  }
+  return { w, h };
+}

--- a/web/lib/text/measure.ts
+++ b/web/lib/text/measure.ts
@@ -1,0 +1,39 @@
+import type { TextStyle } from '@/types/editor';
+
+const canvas = typeof document !== 'undefined' ? document.createElement('canvas') : ({} as any);
+const ctx = canvas.getContext ? canvas.getContext('2d')! : null as any;
+
+export function measure(text: string, style: TextStyle, opts?: { maxWidth?: number }) {
+  if (!ctx) return { width: 0, height: 0, lineHeight: style.fontSize };
+  ctx.font = `${style.fontWeight || 400} ${style.fontSize}px ${style.fontFamily}`;
+  const lineHeight = style.lineHeight === 'AUTO'
+    ? style.fontSize * 1.3
+    : style.lineHeight?.px || style.fontSize * 1.3;
+  const maxWidth = opts?.maxWidth;
+  const lines: string[] = [];
+  if (maxWidth) {
+    let current = '';
+    for (const ch of text) {
+      const test = current + ch;
+      if (ctx.measureText(test).width > maxWidth && current !== '') {
+        lines.push(current);
+        current = ch;
+      } else {
+        current = test;
+      }
+      if (ch === '\n') {
+        lines.push(current.slice(0, -1));
+        current = '';
+      }
+    }
+    if (current) lines.push(current);
+  } else {
+    lines.push(...text.split('\n'));
+  }
+  let width = 0;
+  for (const l of lines) {
+    width = Math.max(width, ctx.measureText(l).width);
+  }
+  const height = lines.length * lineHeight;
+  return { width, height, lineHeight };
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -18,6 +18,12 @@ import type {
   ImageNode,
   AssetMeta,
   ImageProps,
+  TextNode,
+  TextStyle,
+  TextResizeMode,
+  TextStyleDef,
+  TextSelection,
+  TextRun,
 } from "@/types/editor";
 import { idbStorage } from "@/lib/idb";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
@@ -32,6 +38,8 @@ import {
 } from "@/lib/vector/boolean";
 import { saveImage, loadImage } from "@/lib/assets";
 import { computeDominantColor } from "@/lib/color/dominant";
+import { nanoid } from "nanoid";
+import { layoutText } from "@/lib/text/layout";
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -193,6 +201,27 @@ interface EditorActions {
   updateCrop: (patch: Partial<CropDraft['rect']>) => void;
   commitCrop: () => void;
   cancelCrop: () => void;
+  // Text actions
+  setActiveTool: (tool: EditorState['ui']['activeTool']) => void;
+  addText: (opts: { x: number; y: number; text?: string; style?: TextStyle }) => string;
+  updateText: (id: string, text: string) => void;
+  setTextStyle: (id: string, patch: Partial<TextStyle>) => void;
+  toggleEditText: (id: string, active?: boolean) => void;
+  setTextResizeMode: (id: string, mode: TextResizeMode) => void;
+  createTextStyle: (name: string, style: TextStyle) => string;
+  updateTextStyle: (id: string, style: TextStyle) => void;
+  applyTextStyle: (nodeId: string, styleId: string) => void;
+  detachTextStyle: (nodeId: string) => void;
+  removeTextStyle: (id: string) => void;
+  syncTextStyles: (styleId: string) => void;
+  setTextSelection: (sel: TextSelection) => void;
+  clearTextSelection: () => void;
+  updateTextRuns: (id: string, runs: TextRun[]) => void;
+  applyRunStyle: (
+    id: string,
+    range: { from: number; to: number },
+    style: Partial<TextStyle> & { link?: string },
+  ) => void;
 }
 
 export interface CropDraft {
@@ -278,6 +307,8 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         lastCommandId: undefined,
         review: { status: "DRAFT", requireApprovedToShare: false },
         comments: { threads: {}, users: {} },
+        styles: { text: {} },
+        textSel: undefined,
         setHover(id) {
           set({ hoverId: id });
         },
@@ -1221,6 +1252,144 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           apply((draft) => {
             draft.cropDraft = undefined;
             draft.ui = { ...(draft.ui || {}), activeTool: 'select' };
+          });
+        },
+        // text actions implementations
+        setActiveTool(tool) {
+          set((state) => ({ ui: { ...(state.ui || {}), activeTool: tool } }));
+        },
+        addText({ x, y, text = '', style }) {
+          const id = nanoid();
+          apply((draft) => {
+            draft.tree.push({
+              id,
+              type: 'Text',
+              text,
+              style: style || {
+                fontFamily: 'sans-serif',
+                fontSize: 16,
+                letterSpacing: { unit: 'PERCENT', value: 0 },
+              },
+              props: { x, y, w: 0, h: 0 },
+            } as TextNode);
+            draft.selectedIds = [id];
+          });
+          return id;
+        },
+        updateText(id, text) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (n) {
+              n.text = text;
+              const size = layoutText(n);
+              n.props = { ...(n.props || {}), w: size.w, h: size.h };
+            }
+          });
+        },
+        setTextStyle(id, patch) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (n) {
+              Object.assign(n.style, patch);
+              const size = layoutText(n);
+              n.props = { ...(n.props || {}), w: size.w, h: size.h };
+            }
+          });
+        },
+        toggleEditText(id, active) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (n) n.edit = { active: active ?? !(n.edit?.active) };
+          });
+        },
+        setTextResizeMode(id, mode) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (n) {
+              n.resizeMode = mode;
+              const size = layoutText(n);
+              n.props = { ...(n.props || {}), w: size.w, h: size.h };
+            }
+          });
+        },
+        createTextStyle(name, style) {
+          const id = nanoid();
+          apply((draft) => {
+            draft.styles.text[id] = { id, name, style };
+          });
+          return id;
+        },
+        updateTextStyle(id, style) {
+          apply((draft) => {
+            if (draft.styles.text[id]) draft.styles.text[id].style = style;
+          });
+          get().syncTextStyles(id);
+        },
+        applyTextStyle(nodeId, styleId) {
+          apply((draft) => {
+            const n = findNode(draft.tree, nodeId) as TextNode | null;
+            const def = draft.styles.text[styleId];
+            if (n && def) {
+              n.styleRef = styleId;
+              n.style = JSON.parse(JSON.stringify(def.style));
+              const size = layoutText(n);
+              n.props = { ...(n.props || {}), w: size.w, h: size.h };
+            }
+          });
+        },
+        detachTextStyle(nodeId) {
+          apply((draft) => {
+            const n = findNode(draft.tree, nodeId) as TextNode | null;
+            if (n) n.styleRef = undefined;
+          });
+        },
+        removeTextStyle(id) {
+          apply((draft) => {
+            delete draft.styles.text[id];
+          });
+        },
+        syncTextStyles(styleId) {
+          const def = get().styles.text[styleId];
+          if (!def) return;
+          apply((draft) => {
+            const visit = (nodes: ComponentNode[]) => {
+              nodes.forEach((n) => {
+                if ((n as TextNode).type === 'Text') {
+                  const t = n as TextNode;
+                  if (t.styleRef === styleId) {
+                    t.style = JSON.parse(JSON.stringify(def.style));
+                    const size = layoutText(t);
+                    t.props = { ...(t.props || {}), w: size.w, h: size.h };
+                  }
+                }
+                if (n.children) visit(n.children);
+              });
+            };
+            visit(draft.tree);
+          });
+        },
+        setTextSelection(sel) {
+          set({ textSel: sel });
+        },
+        clearTextSelection() {
+          set({ textSel: undefined });
+        },
+        updateTextRuns(id, runs) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (n) n.runs = runs;
+          });
+        },
+        applyRunStyle(id, range, style) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (!n) return;
+            const from = Math.max(0, Math.min(range.from, range.to));
+            const to = Math.min(n.text.length, Math.max(range.from, range.to));
+            if (from === to) return;
+            n.runs = n.runs?.filter((r) => !(r.from >= from && r.to <= to)) || [];
+            n.runs.push({ from, to, style });
+            n.runs.sort((a, b) => a.from - b.from);
           });
         },
         undo() {

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -131,3 +131,11 @@
   height: 16px;
   border: 1px solid #fff;
 }
+
+.text-editor {
+  caret-color: var(--accent-color);
+}
+
+.text-editor::selection {
+  background: rgba(59,130,246,0.4);
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -209,6 +209,50 @@ export interface ImageNode extends ComponentNode {
   props: ImageProps;
 }
 
+export type TextResizeMode = "AUTO_WIDTH" | "AUTO_HEIGHT" | "FIXED";
+
+export interface TextStyle {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight?: number;
+  lineHeight?: "AUTO" | { px: number };
+  letterSpacing?: { unit: "PERCENT" | "PX"; value: number };
+  color?: string;
+  textAlign?: "left" | "center" | "right" | "justify";
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  uppercase?: boolean;
+}
+
+export interface TextRun {
+  from: number;
+  to: number;
+  style: Partial<TextStyle> & { link?: string };
+}
+
+export interface TextNode extends ComponentNode {
+  type: "Text";
+  text: string;
+  style: TextStyle;
+  edit?: { active: boolean };
+  resizeMode?: TextResizeMode;
+  runs?: TextRun[];
+  styleRef?: string;
+}
+
+export interface TextStyleDef {
+  id: string;
+  name: string;
+  style: TextStyle;
+}
+
+export interface TextSelection {
+  nodeId: string | null;
+  start: number;
+  end: number;
+}
+
 export type MaskTarget = "vector" | "frame" | "image";
 
 export interface ComponentNode {
@@ -286,7 +330,7 @@ export interface EditorState {
     showGuides?: boolean;
     showSmartGuides?: boolean;
     showOutline?: boolean;
-    activeTool?: "select" | "pen";
+    activeTool?: "select" | "pen" | "text" | string;
   };
   prefs?: {
     showLayoutGrid?: boolean;
@@ -294,6 +338,8 @@ export interface EditorState {
     snapToPixel?: boolean;
     showImageBadges?: boolean;
   };
+  textSel?: TextSelection;
+  styles: { text: Record<string, TextStyleDef> };
   lastCommandId?: string;
   review: {
     status: ReviewStatus;


### PR DESCRIPTION
## Summary
- wire TextView/TextEditor rendering on canvas with text tool activation
- maintain text selection and apply link styles from inspector
- sync text styles and auto-resize text nodes

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6f92c3f4832cacbc94f7b883a111