### PR TITLE
feat: add cross-format text export

### DIFF
--- a/web/lib/export/html.ts
+++ b/web/lib/export/html.ts
@@ -1,10 +1,7 @@
-import { serialize } from '../serialize';
-import { useEditorStore } from '@/store/editorStore';
-import type { ExportScope, ExportOptions } from './index';
+import type { TextNode } from '@/types/editor';
+import { renderTextToHTML } from './text';
 
-export async function exportHTML(_scope: ExportScope, _opts: ExportOptions = {}): Promise<{ html: string }> {
-  const state = useEditorStore.getState();
-  const data = JSON.stringify(serialize(state));
-  const html = `<!DOCTYPE html><html><head></head><body><pre>${data}</pre></body></html>`;
+export async function exportHTML(node: TextNode, opts: { dpr?: number } = {}): Promise<{ html: string }> {
+  const html = renderTextToHTML(node, opts);
   return { html };
 }

--- a/web/lib/export/png.ts
+++ b/web/lib/export/png.ts
@@ -1,21 +1,9 @@
-import { toPng } from 'html-to-image';
-import type { ExportScope, ExportOptions } from './index';
+import type { TextNode } from '@/types/editor';
+import { renderTextToCanvas } from './text';
 
-function getTargetElement(_scope: ExportScope): HTMLElement {
-  // Placeholder: export entire document body
-  return document.body as HTMLElement;
-}
-
-export async function exportPNG(scope: ExportScope, opts: ExportOptions = {}): Promise<Blob> {
-  const el = getTargetElement(scope);
-  const dataUrl = await toPng(el, {
-    cacheBust: true,
-    pixelRatio: opts.scale ?? 1,
-    backgroundColor:
-      opts.background && opts.background !== 'transparent'
-        ? opts.background.color
-        : undefined,
+export async function exportPNG(node: TextNode, opts: { dpr?: number } = {}): Promise<Blob> {
+  const canvas = renderTextToCanvas(node, { dpr: opts.dpr });
+  return await new Promise<Blob>((resolve) => {
+    canvas.toBlob((b) => resolve(b!), 'image/png');
   });
-  const res = await fetch(dataUrl);
-  return await res.blob();
 }

--- a/web/lib/export/react.ts
+++ b/web/lib/export/react.ts
@@ -1,10 +1,7 @@
-import { serialize } from '../serialize';
-import { useEditorStore } from '@/store/editorStore';
-import type { ExportScope, ExportOptions } from './index';
+import type { TextNode } from '@/types/editor';
+import { renderTextToReact } from './text';
 
-export async function exportReact(_scope: ExportScope, _opts: ExportOptions = {}): Promise<{ jsx: string }> {
-  const state = useEditorStore.getState();
-  const data = JSON.stringify(serialize(state));
-  const jsx = `export default function Design(){return <pre>{JSON.stringify(${data}, null, 2)}</pre>;}`;
+export async function exportReact(node: TextNode, opts: { dpr?: number } = {}): Promise<{ jsx: string }> {
+  const jsx = renderTextToReact(node, opts);
   return { jsx };
 }

--- a/web/lib/export/svg.ts
+++ b/web/lib/export/svg.ts
@@ -1,18 +1,6 @@
-import { toSvg } from 'html-to-image';
-import type { ExportScope, ExportOptions } from './index';
+import type { TextNode } from '@/types/editor';
+import { renderTextToSVG } from './text';
 
-function getTargetElement(_scope: ExportScope): HTMLElement {
-  return document.body as HTMLElement;
-}
-
-export async function exportSVG(scope: ExportScope, opts: ExportOptions = {}): Promise<string> {
-  const el = getTargetElement(scope);
-  const svgText = await toSvg(el, {
-    cacheBust: true,
-    backgroundColor:
-      opts.background && opts.background !== 'transparent'
-        ? opts.background.color
-        : undefined,
-  });
-  return svgText;
+export async function exportSVG(node: TextNode, opts: { dpr?: number } = {}): Promise<string> {
+  return renderTextToSVG(node, opts);
 }

--- a/web/lib/export/text.ts
+++ b/web/lib/export/text.ts
@@ -1,0 +1,167 @@
+import { layoutTextNode } from '../text/layout';
+import type { TextNode, TextStyle } from '@/types/editor';
+import { splitGraphemes, measureWidth, computeLetterSpacing, calcLineHeight } from '../text/measure';
+
+function escapeHtml(s: string) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function applyStyle(base: TextStyle, run: Partial<TextStyle> & { link?: string }) {
+  return { ...base, ...run } as TextStyle & { link?: string };
+}
+
+export function renderTextToCanvas(node: TextNode, opts?: { dpr?: number }): HTMLCanvasElement {
+  const layout = layoutTextNode(node, opts);
+  const dpr = opts?.dpr ?? 1;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.ceil(layout.box.w * dpr);
+  canvas.height = Math.ceil(layout.box.h * dpr);
+  const ctx = canvas.getContext('2d')!;
+  ctx.scale(dpr, dpr);
+  ctx.textBaseline = 'alphabetic';
+  layout.lines.forEach((line) => {
+    let penX = line.x;
+    line.runs.forEach((run) => {
+      const { link, ...stylePart } = run.style as any;
+      const style = applyStyle(node.style, stylePart);
+      const ls = computeLetterSpacing(style);
+      ctx.font = `${style.italic ? 'italic ' : ''}${style.fontWeight || 400} ${style.fontSize}px ${style.fontFamily}`;
+      ctx.fillStyle = style.color || '#000';
+      const chars = splitGraphemes(style.uppercase ? run.text.toUpperCase() : run.text);
+      const startX = penX;
+      chars.forEach((ch, i) => {
+        ctx.fillText(ch, penX, line.y);
+        const w = measureWidth(ch, style);
+        penX += w;
+        if (i < chars.length - 1) penX += ls;
+      });
+      const runWidth = penX - startX;
+      const decoThickness = style.fontSize * 0.06;
+      const underline = style.underline || link;
+      if (underline) {
+        ctx.fillRect(startX, line.y + decoThickness, runWidth, decoThickness);
+      }
+      if (style.strike) {
+        ctx.fillRect(startX, line.y - style.fontSize / 3, runWidth, decoThickness);
+      }
+    });
+  });
+  return canvas;
+}
+
+function runStyleToCss(style: TextStyle, isSvg = false) {
+  const ls = computeLetterSpacing(style);
+  const deco: string[] = [];
+  if (style.underline) deco.push('underline');
+  if (style.strike) deco.push('line-through');
+  const props: string[] = [];
+  props.push(`font-family:${style.fontFamily}`);
+  props.push(`font-size:${style.fontSize}px`);
+  if (style.fontWeight) props.push(`font-weight:${style.fontWeight}`);
+  if (style.italic) props.push('font-style:italic');
+  if (style.color) props.push(`${isSvg ? 'fill' : 'color'}:${style.color}`);
+  if (ls) props.push(`letter-spacing:${ls}px`);
+  if (deco.length) props.push(`text-decoration:${deco.join(' ')}`);
+  return props.join(';');
+}
+
+export function renderTextToSVG(node: TextNode, opts?: { dpr?: number }): string {
+  const layout = layoutTextNode(node, opts);
+  const lines = layout.lines
+    .map((line) => {
+      const runs = line.runs
+        .map((run) => {
+          const { link, ...stylePart } = run.style as any;
+          const style = applyStyle(node.style, stylePart);
+          const css = runStyleToCss(style, true);
+          const content = escapeHtml(style.uppercase ? run.text.toUpperCase() : run.text);
+          const tspan = `<tspan style="${css}">${content}</tspan>`;
+          return link
+            ? `<a href="${link}" target="_blank" rel="noopener">${tspan}</a>`
+            : tspan;
+        })
+        .join('');
+      return `<tspan x="${line.x}" y="${line.y}">${runs}</tspan>`;
+    })
+    .join('');
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${layout.box.w}" height="${layout.box.h}"><text>${lines}</text></svg>`;
+}
+
+export function renderTextToHTML(node: TextNode, opts?: { dpr?: number }): string {
+  const layout = layoutTextNode(node, opts);
+  const lineHeight = calcLineHeight(node.style);
+  const lines = layout.lines
+    .map((line) => {
+      const runs = line.runs
+        .map((run) => {
+          const { link, ...stylePart } = run.style as any;
+          const style = applyStyle(node.style, stylePart);
+          const css = runStyleToCss(style);
+          const content = escapeHtml(style.uppercase ? run.text.toUpperCase() : run.text);
+          const span = `<span style="${css};white-space:pre">${content}</span>`;
+          return link
+            ? `<a href="${link}" target="_blank" rel="noopener">${span}</a>`
+            : span;
+        })
+        .join('');
+      const top = line.y - lineHeight + (lineHeight - node.style.fontSize);
+      return `<div class="line" style="position:absolute;left:${line.x}px;top:${top}px">${runs}</div>`;
+    })
+    .join('');
+  return `<div style="position:relative;width:${layout.box.w}px;height:${layout.box.h}px;overflow:hidden">${lines}</div>`;
+}
+
+function objToJsx(style: Record<string, any>) {
+  const entries = Object.entries(style).filter(([, v]) => v !== undefined);
+  return `{${entries
+    .map(([k, v]) => `${k}:${typeof v === 'number' ? v : `'${v}'`}`)
+    .join(',')}}`;
+}
+
+export function renderTextToReact(node: TextNode, opts?: { dpr?: number }): string {
+  const layout = layoutTextNode(node, opts);
+  const lineHeight = calcLineHeight(node.style);
+  const lines = layout.lines
+    .map((line) => {
+      const runs = line.runs
+        .map((run) => {
+          const { link, ...stylePart } = run.style as any;
+          const style = applyStyle(node.style, stylePart);
+          const ls = computeLetterSpacing(style);
+          const deco: string[] = [];
+          if (style.underline) deco.push('underline');
+          if (style.strike) deco.push('line-through');
+          const styleObj: Record<string, any> = {
+            fontFamily: style.fontFamily,
+            fontSize: style.fontSize,
+            fontWeight: style.fontWeight,
+            fontStyle: style.italic ? 'italic' : undefined,
+            color: style.color,
+            letterSpacing: ls ? `${ls}px` : undefined,
+            textDecoration: deco.length ? deco.join(' ') : undefined,
+            whiteSpace: 'pre',
+          };
+          const content = escapeHtml(style.uppercase ? run.text.toUpperCase() : run.text);
+          const span = `<span style=${objToJsx(styleObj)}>${content}</span>`;
+          return link
+            ? `<a href="${link}" target="_blank" rel="noopener">${span}</a>`
+            : span;
+        })
+        .join('');
+      const top = line.y - lineHeight + (lineHeight - node.style.fontSize);
+      const styleObj = {
+        position: 'absolute',
+        left: line.x,
+        top,
+      } as Record<string, any>;
+      return `<div style=${objToJsx(styleObj)}>${runs}</div>`;
+    })
+    .join('');
+  const containerStyle = objToJsx({
+    position: 'relative',
+    width: layout.box.w,
+    height: layout.box.h,
+    overflow: 'hidden',
+  });
+  return `<div style=${containerStyle}>${lines}</div>`;
+}

--- a/web/lib/text/layout.ts
+++ b/web/lib/text/layout.ts
@@ -1,23 +1,130 @@
-import type { TextNode } from '@/types/editor';
-import { measure } from './measure';
+import type { TextNode, TextStyle } from '@/types/editor';
+import { splitGraphemes, measureWidth, computeLetterSpacing, calcLineHeight } from './measure';
 
-export function layoutText(node: TextNode) {
-  const maxWidth = node.resizeMode === 'AUTO_HEIGHT' ? node.props?.w : undefined;
-  const m = measure(node.text, node.style, { maxWidth });
-  let w = node.props?.w || m.width;
-  let h = node.props?.h || m.lineHeight;
-  if (node.resizeMode === 'AUTO_WIDTH') {
-    w = m.width;
-    h = m.lineHeight;
-  } else if (node.resizeMode === 'AUTO_HEIGHT') {
-    h = m.height;
-    w = node.props?.w ?? m.width;
-  } else if (node.resizeMode === 'FIXED') {
-    w = node.props?.w ?? m.width;
-    h = node.props?.h ?? m.height;
-  } else {
-    w = m.width;
-    h = m.height;
+export interface LaidOutRun {
+  text: string;
+  style: Partial<TextStyle> & { link?: string };
+}
+export interface LaidOutLine {
+  x: number;
+  y: number;
+  width: number;
+  runs: LaidOutRun[];
+}
+export interface TextLayout {
+  lines: LaidOutLine[];
+  box: { w: number; h: number };
+}
+
+interface Token {
+  char: string;
+  width: number;
+  spacing: number;
+  runStyle: Partial<TextStyle> & { link?: string };
+}
+
+export function layoutTextNode(node: TextNode, opts?: { dpr?: number }): TextLayout {
+  const base = node.style;
+  const lineHeight = calcLineHeight(base);
+  const chars = splitGraphemes(node.text);
+  const runs = (node.runs ?? []).slice().sort((a, b) => a.from - b.from);
+  const tokens: Token[] = [];
+  const emptyStyle: Partial<TextStyle> = {};
+  let runIdx = 0;
+  for (let i = 0; i < chars.length; i++) {
+    while (runIdx < runs.length && i >= runs[runIdx].to) runIdx++;
+    const run = runIdx < runs.length && i >= runs[runIdx].from ? runs[runIdx] : null;
+    const runStyle = run ? run.style : emptyStyle;
+    const merged: TextStyle = { ...base, ...runStyle } as TextStyle;
+    const width = measureWidth(chars[i], merged);
+    const spacing = computeLetterSpacing(merged);
+    tokens.push({ char: chars[i], width, spacing, runStyle });
   }
-  return { w, h };
+  const maxWidth =
+    node.resizeMode === 'AUTO_HEIGHT' || node.resizeMode === 'FIXED'
+      ? node.props?.w ?? Infinity
+      : Infinity;
+
+  const lines: { tokens: Token[]; width: number }[] = [];
+  let lineStart = 0;
+  let lineWidth = 0;
+  let lastBreak = -1;
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t.char === '\n') {
+      finalize(lineStart, i);
+      lineStart = i + 1;
+      lineWidth = 0;
+      lastBreak = -1;
+      continue;
+    }
+    const adv = t.width + t.spacing;
+    if (maxWidth !== Infinity && lineWidth + adv > maxWidth && i > lineStart) {
+      const breakIdx = lastBreak >= lineStart ? lastBreak + 1 : i;
+      finalize(lineStart, breakIdx);
+      i = breakIdx - 1;
+      lineStart = breakIdx;
+      lineWidth = 0;
+      lastBreak = -1;
+      continue;
+    }
+    lineWidth += adv;
+    if (/\s/.test(t.char)) lastBreak = i;
+  }
+  finalize(lineStart, tokens.length);
+
+  function finalize(start: number, end: number) {
+    const slice = tokens.slice(start, end);
+    let width = 0;
+    slice.forEach((tok, idx) => {
+      width += tok.width;
+      if (idx < slice.length - 1) width += tok.spacing;
+    });
+    lines.push({ tokens: slice, width });
+  }
+
+  const laidLines: LaidOutLine[] = [];
+  lines.forEach((l, idx) => {
+    const runsArr: LaidOutRun[] = [];
+    if (l.tokens.length) {
+      let current = l.tokens[0].runStyle;
+      let txt = '';
+      for (const tok of l.tokens) {
+        if (tok.runStyle !== current) {
+          runsArr.push({ text: txt, style: current });
+          current = tok.runStyle;
+          txt = tok.char;
+        } else {
+          txt += tok.char;
+        }
+      }
+      runsArr.push({ text: txt, style: current });
+    }
+    laidLines.push({ x: 0, y: (idx + 1) * lineHeight, width: l.width, runs: runsArr });
+  });
+
+  let boxW: number;
+  let boxH: number;
+  if (node.resizeMode === 'AUTO_WIDTH') {
+    boxW = lines[0]?.width ?? 0;
+    boxH = lineHeight;
+  } else if (node.resizeMode === 'AUTO_HEIGHT') {
+    boxW = node.props?.w ?? Math.max(0, ...lines.map((l) => l.width));
+    boxH = lines.length * lineHeight;
+  } else if (node.resizeMode === 'FIXED') {
+    boxW = node.props?.w ?? Math.max(0, ...lines.map((l) => l.width));
+    boxH = node.props?.h ?? lines.length * lineHeight;
+  } else {
+    boxW = Math.max(0, ...lines.map((l) => l.width));
+    boxH = lines.length * lineHeight;
+  }
+
+  const align = base.textAlign || 'left';
+  laidLines.forEach((l) => {
+    if (align === 'center') l.x = (boxW - l.width) / 2;
+    else if (align === 'right') l.x = boxW - l.width;
+    else l.x = 0; // left & justify minimal
+  });
+
+  return { lines: laidLines, box: { w: boxW, h: boxH } };
 }

--- a/web/lib/text/measure.ts
+++ b/web/lib/text/measure.ts
@@ -3,37 +3,32 @@ import type { TextStyle } from '@/types/editor';
 const canvas = typeof document !== 'undefined' ? document.createElement('canvas') : ({} as any);
 const ctx = canvas.getContext ? canvas.getContext('2d')! : null as any;
 
-export function measure(text: string, style: TextStyle, opts?: { maxWidth?: number }) {
-  if (!ctx) return { width: 0, height: 0, lineHeight: style.fontSize };
-  ctx.font = `${style.fontWeight || 400} ${style.fontSize}px ${style.fontFamily}`;
-  const lineHeight = style.lineHeight === 'AUTO'
+let segmenter: Intl.Segmenter | null = null;
+if (typeof Intl !== 'undefined' && (Intl as any).Segmenter) {
+  segmenter = new (Intl as any).Segmenter(undefined, { granularity: 'grapheme' });
+}
+
+export function splitGraphemes(text: string): string[] {
+  if (segmenter) {
+    return Array.from(segmenter.segment(text), (s: any) => s.segment);
+  }
+  return Array.from(text);
+}
+
+export function computeLetterSpacing(style: TextStyle): number {
+  const ls = style.letterSpacing;
+  if (!ls) return 0;
+  return ls.unit === 'PX' ? ls.value : style.fontSize * (ls.value / 100);
+}
+
+export function calcLineHeight(style: TextStyle): number {
+  return style.lineHeight === 'AUTO'
     ? style.fontSize * 1.3
     : style.lineHeight?.px || style.fontSize * 1.3;
-  const maxWidth = opts?.maxWidth;
-  const lines: string[] = [];
-  if (maxWidth) {
-    let current = '';
-    for (const ch of text) {
-      const test = current + ch;
-      if (ctx.measureText(test).width > maxWidth && current !== '') {
-        lines.push(current);
-        current = ch;
-      } else {
-        current = test;
-      }
-      if (ch === '\n') {
-        lines.push(current.slice(0, -1));
-        current = '';
-      }
-    }
-    if (current) lines.push(current);
-  } else {
-    lines.push(...text.split('\n'));
-  }
-  let width = 0;
-  for (const l of lines) {
-    width = Math.max(width, ctx.measureText(l).width);
-  }
-  const height = lines.length * lineHeight;
-  return { width, height, lineHeight };
+}
+
+export function measureWidth(text: string, style: TextStyle): number {
+  if (!ctx) return text.length * style.fontSize;
+  ctx.font = `${style.italic ? 'italic ' : ''}${style.fontWeight || 400} ${style.fontSize}px ${style.fontFamily}`;
+  return ctx.measureText(text).width;
 }


### PR DESCRIPTION
## Summary
- add grapheme-aware text measurement and layout
- implement canvas/SVG/HTML/React text rendering helper
- route PNG, SVG, HTML and React exporters through shared text renderer

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa811e2f64832c982cc201c9351be4