### PR TITLE
feat: add basic text selection toolbar

### DIFF
--- a/web/components/editor/TextEditor.tsx
+++ b/web/components/editor/TextEditor.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import type { TextNode } from '@/types/editor';
 import { useEditorStore } from '@/store/editorStore';
+import { readSelection } from '@/lib/text/selection';
+import TextToolbar from './TextToolbar';
 
 export default function TextEditor({ node }: { node: TextNode }) {
   const ref = useRef<HTMLDivElement>(null);
@@ -8,6 +10,8 @@ export default function TextEditor({ node }: { node: TextNode }) {
   const toggleEdit = useEditorStore((s) => s.toggleEditText);
   const setSel = useEditorStore((s) => s.setTextSelection);
   const clearSel = useEditorStore((s) => s.clearTextSelection);
+  const sel = useEditorStore((s) => s.textSel);
+  const toggleRun = useEditorStore((s) => s.toggleRunStyle);
   const composing = useRef(false);
 
   useEffect(() => {
@@ -35,10 +39,15 @@ export default function TextEditor({ node }: { node: TextNode }) {
         fontWeight: node.style.fontWeight,
         color: node.style.color,
       }}
-      onCompositionStart={() => (composing.current = true)}
+      onCompositionStart={() => {
+        composing.current = true;
+        clearSel();
+      }}
       onCompositionEnd={(e) => {
         composing.current = false;
         updateText(node.id, (e.target as HTMLDivElement).innerText);
+        const r = readSelection(ref.current!);
+        setSel({ nodeId: node.id, start: r.start, end: r.end, rect: r.rect ?? undefined });
       }}
       onInput={(e) => {
         if (!composing.current) {
@@ -46,17 +55,26 @@ export default function TextEditor({ node }: { node: TextNode }) {
         }
       }}
       onSelect={() => {
-        const sel = window.getSelection();
-        if (sel) {
-          const start = sel.anchorOffset || 0;
-          const end = sel.focusOffset || 0;
-          setSel({ nodeId: node.id, start, end });
-        }
+        const r = readSelection(ref.current!);
+        setSel({ nodeId: node.id, start: r.start, end: r.end, rect: r.rect ?? undefined });
       }}
       onBlur={() => clearSel()}
+      onKeyUp={() => {
+        const r = readSelection(ref.current!);
+        setSel({ nodeId: node.id, start: r.start, end: r.end, rect: r.rect ?? undefined });
+      }}
       onKeyDown={(e) => {
         if (composing.current) return;
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'b') {
+          e.preventDefault();
+          toggleRun(node.id, { from: sel?.start || 0, to: sel?.end || 0 }, { fontWeight: 700 });
+        } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'i') {
+          e.preventDefault();
+          toggleRun(node.id, { from: sel?.start || 0, to: sel?.end || 0 }, { italic: true });
+        } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'u') {
+          e.preventDefault();
+          toggleRun(node.id, { from: sel?.start || 0, to: sel?.end || 0 }, { underline: true });
+        } else if (e.key === 'Enter' && !e.shiftKey) {
           e.preventDefault();
           toggleEdit(node.id, false);
         } else if (e.key === 'Escape') {
@@ -66,6 +84,9 @@ export default function TextEditor({ node }: { node: TextNode }) {
       }}
     >
       {node.text}
+      {node.edit?.active && sel?.nodeId === node.id && sel.start !== sel.end ? (
+        <TextToolbar />
+      ) : null}
     </div>
   );
 }

--- a/web/components/editor/TextToolbar.tsx
+++ b/web/components/editor/TextToolbar.tsx
@@ -1,0 +1,25 @@
+import { useEditorStore } from '@/store/editorStore';
+
+export default function TextToolbar() {
+  const sel = useEditorStore((s) => s.textSel);
+  const toggle = useEditorStore((s) => s.toggleRunStyle);
+  if (!sel || !sel.rect || !sel.nodeId) return null;
+  const style: React.CSSProperties = {
+    left: sel.rect.x + sel.rect.w / 2,
+    top: sel.rect.y,
+    transform: 'translate(-50%, -8px)',
+  };
+  const apply = (s: any) => {
+    toggle(sel.nodeId!, { from: sel.start, to: sel.end }, s);
+  };
+  const onMouseDown = (e: React.MouseEvent) => e.preventDefault();
+  return (
+    <div className="text-toolbar" style={style} role="toolbar" onMouseDown={onMouseDown} contentEditable={false}>
+      <button aria-pressed="false" onClick={() => apply({ fontWeight: 700 })}>
+        B
+      </button>
+      <button aria-pressed="false" onClick={() => apply({ italic: true })}>I</button>
+      <button aria-pressed="false" onClick={() => apply({ underline: true })}>U</button>
+    </div>
+  );
+}

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -42,7 +42,11 @@ export type Command =
   | 'nudge.big.up'
   | 'nudge.big.down'
   | 'nudge.big.left'
-  | 'nudge.big.right';
+  | 'nudge.big.right'
+  | 'text.bold'
+  | 'text.italic'
+  | 'text.underline'
+  | 'text.link';
 
 const map: Record<string, Command> = {
   KeyP: 'tool.pen',
@@ -59,6 +63,13 @@ const map: Record<string, Command> = {
 export function getCommand(e: KeyboardEvent): Command | undefined {
   if (useEditorStore.getState().ui?.activeTool === 'crop') return undefined;
   const mod = e.metaKey || e.ctrlKey;
+  const editing = !!useEditorStore.getState().textSel;
+  if (mod && editing) {
+    if (e.code === 'KeyB') return 'text.bold';
+    if (e.code === 'KeyI') return 'text.italic';
+    if (e.code === 'KeyU') return 'text.underline';
+    if (e.code === 'KeyK') return 'text.link';
+  }
   if (mod && e.altKey) {
     if (e.code === 'KeyK') return 'createComponent';
     if (e.code === 'KeyB') return 'detachInstance';

--- a/web/lib/text/rangeOps.ts
+++ b/web/lib/text/rangeOps.ts
@@ -1,0 +1,77 @@
+import type { TextRun, TextStyle } from '@/types/editor';
+
+function cleanStyle(style: Partial<TextStyle> & { link?: string }): Partial<TextStyle> & { link?: string } {
+  const s: any = { ...style };
+  Object.keys(s).forEach((k) => {
+    const v = (s as any)[k];
+    if (v === undefined || v === false) delete (s as any)[k];
+  });
+  return s;
+}
+
+function stylesEqual(a: Partial<TextStyle> & { link?: string }, b: Partial<TextStyle> & { link?: string }) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function removeRun(
+  runs: TextRun[] | undefined,
+  from: number,
+  to: number,
+  keys: (keyof TextStyle | 'link')[],
+): TextRun[] {
+  if (!runs || runs.length === 0) return [];
+  const res: TextRun[] = [];
+  for (const r of runs) {
+    if (r.to <= from || r.from >= to) {
+      res.push({ ...r });
+      continue;
+    }
+    if (r.from < from) {
+      res.push({ from: r.from, to: from, style: { ...r.style } });
+    }
+    const midFrom = Math.max(r.from, from);
+    const midTo = Math.min(r.to, to);
+    const newStyle = { ...r.style } as any;
+    for (const k of keys) delete newStyle[k];
+    const cleaned = cleanStyle(newStyle);
+    if (Object.keys(cleaned).length) {
+      res.push({ from: midFrom, to: midTo, style: cleaned });
+    }
+    if (r.to > to) {
+      res.push({ from: to, to: r.to, style: { ...r.style } });
+    }
+  }
+  res.sort((a, b) => a.from - b.from);
+  const merged: TextRun[] = [];
+  for (const r of res) {
+    const last = merged[merged.length - 1];
+    if (last && last.to === r.from && stylesEqual(last.style, r.style)) {
+      last.to = r.to;
+    } else {
+      merged.push({ ...r });
+    }
+  }
+  return merged;
+}
+
+export function applyRun(
+  runs: TextRun[] | undefined,
+  from: number,
+  to: number,
+  style: Partial<TextStyle> & { link?: string },
+): TextRun[] {
+  const keys = Object.keys(style) as (keyof TextStyle | 'link')[];
+  let res = removeRun(runs, from, to, keys);
+  res.push({ from, to, style: cleanStyle(style) });
+  res.sort((a, b) => a.from - b.from);
+  const merged: TextRun[] = [];
+  for (const r of res) {
+    const last = merged[merged.length - 1];
+    if (last && last.to === r.from && stylesEqual(last.style, r.style)) {
+      last.to = r.to;
+    } else {
+      merged.push({ ...r });
+    }
+  }
+  return merged;
+}

--- a/web/lib/text/selection.ts
+++ b/web/lib/text/selection.ts
@@ -1,0 +1,36 @@
+import type { TextSelection } from '@/types/editor';
+
+export function readSelection(root: HTMLElement): { start: number; end: number; rect: DOMRect | null } {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) {
+    return { start: 0, end: 0, rect: null };
+  }
+
+  const range = sel.getRangeAt(0);
+  const anchor = sel.anchorNode;
+  const focus = sel.focusNode;
+  let start = 0;
+  let end = 0;
+  let foundAnchor = false;
+  let foundFocus = false;
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let current: Node | null = walker.nextNode();
+  while (current) {
+    const text = current.textContent || '';
+    if (current === anchor) {
+      start += sel.anchorOffset;
+      foundAnchor = true;
+    }
+    if (current === focus) {
+      end += sel.focusOffset;
+      foundFocus = true;
+    }
+    if (!foundAnchor) start += text.length;
+    if (!foundFocus) end += text.length;
+    current = walker.nextNode();
+  }
+
+  const rect = range.collapsed ? null : range.getBoundingClientRect();
+  return { start, end, rect };
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -40,6 +40,7 @@ import { saveImage, loadImage } from "@/lib/assets";
 import { computeDominantColor } from "@/lib/color/dominant";
 import { nanoid } from "nanoid";
 import { layoutText } from "@/lib/text/layout";
+import { applyRun, removeRun } from "@/lib/text/rangeOps";
 
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
@@ -214,10 +215,20 @@ interface EditorActions {
   detachTextStyle: (nodeId: string) => void;
   removeTextStyle: (id: string) => void;
   syncTextStyles: (styleId: string) => void;
-  setTextSelection: (sel: TextSelection) => void;
+  setTextSelection: (sel: EditorState['textSel']) => void;
   clearTextSelection: () => void;
   updateTextRuns: (id: string, runs: TextRun[]) => void;
   applyRunStyle: (
+    id: string,
+    range: { from: number; to: number },
+    style: Partial<TextStyle> & { link?: string },
+  ) => void;
+  removeRunStyle: (
+    id: string,
+    range: { from: number; to: number },
+    keys: (keyof TextStyle | 'link')[],
+  ) => void;
+  toggleRunStyle: (
     id: string,
     range: { from: number; to: number },
     style: Partial<TextStyle> & { link?: string },
@@ -1390,6 +1401,30 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             n.runs = n.runs?.filter((r) => !(r.from >= from && r.to <= to)) || [];
             n.runs.push({ from, to, style });
             n.runs.sort((a, b) => a.from - b.from);
+          });
+        },
+        removeRunStyle(id, range, keys) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (!n) return;
+            const from = Math.max(0, Math.min(range.from, range.to));
+            const to = Math.min(n.text.length, Math.max(range.from, range.to));
+            if (from === to) return;
+            n.runs = removeRun(n.runs, from, to, keys);
+          });
+        },
+        toggleRunStyle(id, range, style) {
+          apply((draft) => {
+            const n = findNode(draft.tree, id) as TextNode | null;
+            if (!n) return;
+            const from = Math.max(0, Math.min(range.from, range.to));
+            const to = Math.min(n.text.length, Math.max(range.from, range.to));
+            if (from === to) return;
+            const applied = applyRun(n.runs, from, to, style);
+            const same = JSON.stringify(applied) === JSON.stringify(n.runs || []);
+            n.runs = same
+              ? removeRun(n.runs, from, to, Object.keys(style) as (keyof TextStyle | 'link')[])
+              : applied;
           });
         },
         undo() {

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -139,3 +139,32 @@
 .text-editor::selection {
   background: rgba(59,130,246,0.4);
 }
+
+.text-toolbar {
+  position: fixed;
+  z-index: 1000;
+  backdrop-filter: blur(6px);
+  background: rgba(17,17,17,.7);
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: 8px;
+  padding: 6px;
+  display: flex;
+  gap: 6px;
+}
+
+.text-toolbar button {
+  padding: 4px 6px;
+  border-radius: 6px;
+}
+
+.text-toolbar input[type="color"] {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+@media (prefers-reduced-motion:no-preference){
+  .text-toolbar{ transition: opacity .12s ease; }
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -251,6 +251,7 @@ export interface TextSelection {
   nodeId: string | null;
   start: number;
   end: number;
+  rect?: { x: number; y: number; w: number; h: number };
 }
 
 export type MaskTarget = "vector" | "frame" | "image";


### PR DESCRIPTION
## Summary
- add utilities for selection and run style
- introduce floating text toolbar with bold/italic/underline
- hook shortcuts and store state for text selections

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aa85674054832ca1220cac5c0d2fb4