### PR TITLE
feat: enhance command palette with search and recents

### DIFF
--- a/web/components/editor/CommandPalette.tsx
+++ b/web/components/editor/CommandPalette.tsx
@@ -16,7 +16,7 @@ export default function CommandPalette({ open, onClose }: Props) {
   const results = useMemo(() => {
     const q = query.toLowerCase();
     return COMMANDS.filter((c) =>
-      c.label.toLowerCase().includes(q) || c.keywords?.some((k) => k.includes(q))
+      c.title.toLowerCase().includes(q) || c.keywords?.some((k) => k.includes(q))
     );
   }, [query]);
 
@@ -67,7 +67,7 @@ export default function CommandPalette({ open, onClose }: Props) {
               onMouseEnter={() => setIndex(i)}
               onClick={() => run(c)}
             >
-              <span>{c.label}</span>
+              <span>{c.title}</span>
               {c.shortcut && <span className="float-right opacity-60">{c.shortcut}</span>}
             </li>
           ))}

--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -8,7 +8,7 @@ import ExportPanel from './ExportPanel';
 import ShareButton from './ShareButton';
 import { useState, useEffect } from 'react';
 import { getCommand } from '@/lib/keymap';
-import { COMMANDS } from '@/lib/commands';
+import { COMMANDS, runCommand } from '@/lib/commands';
 import { useEditorStore } from '@/store/editorStore';
 
 export default function EditorShell() {
@@ -52,7 +52,7 @@ export default function EditorShell() {
       const found = COMMANDS.find((c) => c.id === cmd);
       if (found) {
         e.preventDefault();
-        found.run();
+        runCommand(found.id);
       }
     };
     window.addEventListener('keydown', handler);

--- a/web/components/hud/CommandPalette.tsx
+++ b/web/components/hud/CommandPalette.tsx
@@ -1,0 +1,140 @@
+'use client';
+import { useState, useMemo, useEffect } from 'react';
+import { COMMANDS, Command, runCommand } from '@/lib/commands';
+import { useEditorStore } from '@/store/editorStore';
+import type { ComponentNode } from '@/types/editor';
+import { getWorldAABB } from '@/lib/geometry';
+import { fitRect } from '@/lib/zoom';
+
+interface Item extends Command {}
+
+function searchNodes(nodes: ComponentNode[], q: string, acc: Item[]): void {
+  for (const n of nodes) {
+    if (n.name && n.name.toLowerCase().includes(q)) {
+      acc.push({
+        id: `node.${n.id}`,
+        title: n.name,
+        run: () => {
+          const store = useEditorStore.getState();
+          store.select([n.id]);
+          const rect = getWorldAABB(n.id, store);
+          const cam = fitRect(store.camera, rect);
+          store.tweenCamera(cam, { duration: 0 });
+        },
+      });
+    }
+    if (n.children) searchNodes(n.children, q, acc);
+  }
+}
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [index, setIndex] = useState(0);
+  const tree = useEditorStore((s) => s.tree);
+  const recentIds = useEditorStore((s) => s.recentCommands);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const recent = useMemo(() => {
+    return recentIds
+      .map((id) => COMMANDS.find((c) => c.id === id))
+      .filter((c): c is Command => Boolean(c));
+  }, [recentIds]);
+
+  const sections = useMemo(() => {
+    const q = query.toLowerCase();
+    const cmdResults = COMMANDS.filter(
+      (c) => c.title.toLowerCase().includes(q) || c.keywords?.some((k) => k.includes(q)),
+    );
+    const nodeResults: Item[] = [];
+    if (q) searchNodes(tree, q, nodeResults);
+    const secs: { title: string; items: Item[] }[] = [];
+    if (recent.length) secs.push({ title: 'Recent', items: recent });
+    if (cmdResults.length) secs.push({ title: 'Commands', items: cmdResults });
+    if (nodeResults.length) secs.push({ title: 'Layers', items: nodeResults });
+    return secs;
+  }, [query, tree, recent]);
+
+  const items = sections.flatMap((s) => s.items);
+
+  useEffect(() => {
+    setIndex(0);
+  }, [query, sections.length]);
+
+  const run = (item: Item) => {
+    if (!runCommand(item.id)) item.run();
+    setOpen(false);
+    setQuery('');
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-24 pointer-events-auto"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        className="w-[560px] rounded bg-gray-800 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown') {
+              e.preventDefault();
+              setIndex((i) => Math.min(i + 1, items.length - 1));
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault();
+              setIndex((i) => Math.max(i - 1, 0));
+            } else if (e.key === 'Enter') {
+              const item = items[index];
+              if (item) run(item);
+            } else if (e.key === 'Escape') {
+              setOpen(false);
+            }
+          }}
+          className="w-full bg-gray-700 px-4 py-2 outline-none"
+          placeholder="Search commands..."
+        />
+        <ul className="max-h-72 overflow-y-auto">
+          {sections.map((sec, sIdx) => (
+            <li key={sec.title}>
+              <div className="px-4 py-1 text-xs opacity-60">{sec.title}</div>
+              {sec.items.map((c, i) => {
+                const pos = sections
+                  .slice(0, sIdx)
+                  .reduce((sum, s) => sum + s.items.length, 0) + i;
+                return (
+                  <div
+                    key={c.id}
+                    className={`px-4 py-2 cursor-pointer ${pos === index ? 'bg-gray-700' : ''}`}
+                    onMouseEnter={() => setIndex(pos)}
+                    onClick={() => run(c)}
+                  >
+                    <span>{c.title}</span>
+                    {'shortcut' in c && c.shortcut && (
+                      <span className="float-right opacity-60">{c.shortcut}</span>
+                    )}
+                  </div>
+                );
+              })}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/components/hud/HUDContainer.tsx
+++ b/web/components/hud/HUDContainer.tsx
@@ -7,12 +7,14 @@ import SkillShortcutsHUD from './skills/SkillShortcutsHUD'
 import ExpGaugeHUD from './exp/ExpGaugeHUD'
 import ContextNotificationsHUD from './notify/ContextNotificationsHUD'
 import HUDBar from './HUDBar'
+import CommandPalette from './CommandPalette'
 
 export default function HUDContainer(){
   const { hud } = useHUD()
   return (
     <div className="pointer-events-none absolute inset-0 z-40">
       <HUDBar />
+      <CommandPalette />
       {hud.arGuide && <ARGuide/>}
       {hud.workMap && <WorkMapHUD/>}
       {hud.skillShortcuts && <SkillShortcutsHUD/>}

--- a/web/lib/commands.ts
+++ b/web/lib/commands.ts
@@ -1,6 +1,6 @@
 export interface Command {
   id: string;
-  label: string;
+  title: string;
   keywords?: string[];
   shortcut?: string;
   run: () => void;
@@ -12,98 +12,98 @@ import * as zoom from '@/lib/zoom';
 export const COMMANDS: Command[] = [
   {
     id: 'align.left',
-    label: 'Align Left',
+    title: 'Align Left',
     keywords: ['align', 'left'],
     shortcut: 'Ctrl+Shift+L',
     run: () => useEditorStore.getState().align('left'),
   },
   {
     id: 'align.center.h',
-    label: 'Align Horizontal Center',
+    title: 'Align Horizontal Center',
     shortcut: 'Ctrl+Shift+H',
     run: () => useEditorStore.getState().align('centerH'),
   },
   {
     id: 'distribute.h',
-    label: 'Distribute Horizontally',
+    title: 'Distribute Horizontally',
     shortcut: 'Ctrl+Alt+H',
     run: () => useEditorStore.getState().distribute('h'),
   },
   {
     id: 'order.front',
-    label: 'Bring to Front',
+    title: 'Bring to Front',
     shortcut: 'Ctrl+]',
     run: () => useEditorStore.getState().reorder('front'),
   },
   {
     id: 'view.toggleRulers',
-    label: 'Toggle Rulers',
+    title: 'Toggle Rulers',
     shortcut: 'Ctrl+R',
     run: () => useEditorStore.getState().toggleRulers(),
   },
   {
     id: 'view.toggleGuides',
-    label: 'Toggle Guides',
+    title: 'Toggle Guides',
     shortcut: 'Ctrl+;',
     run: () => useEditorStore.getState().toggleGuides(),
   },
   {
     id: 'view.toggleOutline',
-    label: 'Toggle Outline',
+    title: 'Toggle Outline',
     shortcut: 'Ctrl+Y',
     run: () => useEditorStore.getState().toggleOutline(),
   },
   {
     id: 'view.toggleLayoutGrid',
-    label: 'Toggle Layout Grid',
+    title: 'Toggle Layout Grid',
     shortcut: 'Ctrl+Shift+G',
     run: () => useEditorStore.getState().toggleLayoutGrid(),
   },
   {
     id: 'view.togglePixelGrid',
-    label: 'Toggle Pixel Grid',
+    title: 'Toggle Pixel Grid',
     shortcut: "Ctrl+'",
     run: () => useEditorStore.getState().togglePixelGrid(),
   },
   {
     id: 'view.toggleSnapToPixel',
-    label: 'Toggle Snap To Pixel',
+    title: 'Toggle Snap To Pixel',
     shortcut: 'Ctrl+Shift+P',
     run: () => useEditorStore.getState().toggleSnapToPixel(),
   },
   {
     id: 'export',
-    label: 'Export',
+    title: 'Export',
     shortcut: 'Ctrl+Shift+E',
     run: () => window.dispatchEvent(new CustomEvent('uibuilder:export')),
   },
   {
     id: 'zoom.in',
-    label: 'Zoom In',
+    title: 'Zoom In',
     shortcut: 'Ctrl++',
     run: () => zoom.zoomBy(1.1),
   },
   {
     id: 'zoom.out',
-    label: 'Zoom Out',
+    title: 'Zoom Out',
     shortcut: 'Ctrl+-',
     run: () => zoom.zoomBy(0.9),
   },
   {
     id: 'zoom.fitAll',
-    label: 'Fit All',
+    title: 'Fit All',
     shortcut: 'Shift+1',
     run: () => zoom.fitAll(),
   },
   {
     id: 'zoom.fitSelection',
-    label: 'Fit Selection',
+    title: 'Fit Selection',
     shortcut: 'Shift+2',
     run: () => zoom.fitSelection(),
   },
   {
     id: 'zoom.to100',
-    label: 'Zoom to 100%',
+    title: 'Zoom to 100%',
     shortcut: '1',
     run: () => {
       const cam = useEditorStore.getState().camera;
@@ -116,6 +116,8 @@ export function runCommand(id: string): boolean {
   const cmd = COMMANDS.find((c) => c.id === id);
   if (!cmd) return false;
   cmd.run();
-  useEditorStore.getState().setLastCommand(id);
+  const store = useEditorStore.getState();
+  store.setLastCommand(id);
+  store.addRecentCommand(id);
   return true;
 }

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -115,6 +115,7 @@ interface EditorActions {
     opts?: { replace?: boolean; flatness?: number; simplify?: number },
   ) => string;
   setLastCommand: (id: string) => void;
+  addRecentCommand: (id: string) => void;
   setCamera: (cam: Partial<Camera>) => void;
   tweenCamera: (
     cam: Camera | Partial<Camera>,
@@ -305,6 +306,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           showImageBadges: true,
         },
         lastCommandId: undefined,
+        recentCommands: [],
         review: { status: "DRAFT", requireApprovedToShare: false },
         comments: { threads: {}, users: {} },
         styles: { text: {} },
@@ -744,6 +746,11 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         },
         setLastCommand(id) {
           set({ lastCommandId: id });
+        },
+        addRecentCommand(id) {
+          set((state) => ({
+            recentCommands: [id, ...state.recentCommands.filter((c) => c !== id)].slice(0, 10),
+          }));
         },
         setCamera(cam) {
           set((state) => {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -341,6 +341,7 @@ export interface EditorState {
   textSel?: TextSelection;
   styles: { text: Record<string, TextStyleDef> };
   lastCommandId?: string;
+  recentCommands?: string[];
   review: {
     status: ReviewStatus;
     requireApprovedToShare: boolean;


### PR DESCRIPTION
## Summary
- add HUD command palette with search, recent commands and layer jumping
- track recent command executions in editor store
- rename command labels to titles and update runner to record recents

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8675271c832c87253748909bf899