### PR TITLE
feat(web): add asset browser

### DIFF
--- a/web/components/panels/AssetBrowser.tsx
+++ b/web/components/panels/AssetBrowser.tsx
@@ -1,0 +1,121 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { AssetMeta } from '@/types/editor';
+import { listAssets, loadImage, duplicates, touchAsset } from '@/lib/assets';
+import { useEditorStore } from '@/store/editorStore';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function AssetBrowser({ onClose }: Props) {
+  const [items, setItems] = useState<AssetMeta[]>([]);
+  const [thumbs, setThumbs] = useState<Record<string, string>>({});
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<'newest' | 'oldest' | 'size' | 'used'>('newest');
+  const [dups, setDups] = useState<Record<string, AssetMeta[]>>({});
+  const [hashFilter, setHashFilter] = useState<string | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      const q = hashFilter || query;
+      const list = await listAssets({ query: q, sort });
+      setItems(list);
+      const dup = await duplicates();
+      setDups(dup);
+    };
+    run();
+  }, [query, sort, hashFilter]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const entries = await Promise.all(
+        items.map(async (m) => {
+          const blob = await loadImage(m.id);
+          return [m.id, URL.createObjectURL(blob!)] as const;
+        })
+      );
+      if (cancelled) return;
+      const map: Record<string, string> = {};
+      entries.forEach(([id, url]) => (map[id] = url));
+      setThumbs(map);
+    };
+    load();
+    return () => {
+      cancelled = true;
+      Object.values(thumbs).forEach((u) => URL.revokeObjectURL(u));
+      setThumbs({});
+    };
+  }, [items]);
+
+  const select = async (meta: AssetMeta) => {
+    const next = { ...meta, lastUsedAt: Date.now() };
+    useEditorStore.getState().addImageNode(next);
+    await touchAsset(meta.id);
+    onClose();
+  };
+
+  const dupCount = (hash: string) => dups[hash]?.length || 0;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex flex-col">
+      <div className="p-2 bg-white flex items-center gap-2">
+        <input
+          className="border px-2 py-1 flex-1"
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <select
+          className="border px-1 py-1 text-sm"
+          value={sort}
+          onChange={(e) => setSort(e.target.value as any)}
+        >
+          <option value="newest">Newest</option>
+          <option value="oldest">Oldest</option>
+          <option value="size">Size</option>
+          <option value="used">Last used</option>
+        </select>
+        {hashFilter && (
+          <button
+            className="border px-2 py-1 text-sm"
+            onClick={() => setHashFilter(null)}
+          >
+            Back
+          </button>
+        )}
+        <button className="ml-auto border px-2 py-1" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto p-4 bg-white grid grid-cols-4 gap-4">
+        {items.map((m) => (
+          <div
+            key={m.id}
+            className="relative border rounded overflow-hidden cursor-pointer"
+            onClick={() => select(m)}
+          >
+            {thumbs[m.id] && (
+              <img src={thumbs[m.id]} className="w-full h-full object-cover" />
+            )}
+            {dupCount(m.hash) > 1 && (
+              <button
+                className="absolute top-1 right-1 bg-white bg-opacity-75 text-xs px-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setHashFilter(m.hash);
+                }}
+              >
+                dup {dupCount(m.hash)}
+              </button>
+            )}
+          </div>
+        ))}
+        {items.length === 0 && (
+          <div className="col-span-full text-sm text-gray-500">No assets</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from '@/store/editorStore';
 import { useState, useRef, useEffect } from 'react';
 import type { BooleanOp } from '@/lib/vector/boolean';
 import { saveImage } from '@/lib/assets';
+import AssetBrowser from '@/components/panels/AssetBrowser';
 
 export default function TopBar() {
     const prefs = useEditorStore((s) => s.prefs || {});
@@ -19,6 +20,7 @@ export default function TopBar() {
   const activeTool = useEditorStore((s) => s.ui.activeTool);
     const [replace, setReplace] = useState(false);
     const [toast, setToast] = useState(false);
+    const [showAssets, setShowAssets] = useState(false);
     const fileInput = useRef<HTMLInputElement | null>(null);
     const replaceInput = useRef<HTMLInputElement | null>(null);
 
@@ -60,6 +62,8 @@ export default function TopBar() {
       }
     };
   return (
+    <>
+      {showAssets && <AssetBrowser onClose={() => setShowAssets(false)} />}
       <div
         className="flex items-center justify-between px-3 gap-2 bg-gray-800 text-white relative"
         style={{ height: TOP_BAR_HEIGHT }}
@@ -73,6 +77,7 @@ export default function TopBar() {
           <button onClick={() => window.dispatchEvent(new CustomEvent('uibuilder:export'))}>
             Export
           </button>
+          <button onClick={() => setShowAssets(true)}>Assets</button>
           <button onClick={() => fileInput.current?.click()}>Place Image</button>
           <input
             ref={fileInput}
@@ -195,5 +200,6 @@ export default function TopBar() {
           </div>
         )}
       </div>
-    );
-  }
+    </>
+  );
+}

--- a/web/lib/assets.ts
+++ b/web/lib/assets.ts
@@ -47,6 +47,7 @@ export async function saveImage(file: Blob): Promise<AssetMeta> {
     size: blob.size,
     hash,
     createdAt: Date.now(),
+    lastUsedAt: Date.now(),
   };
   await db.images.put({ ...meta, blob });
   return meta;
@@ -71,4 +72,49 @@ export async function loadImage(id: string): Promise<Blob | null> {
 
 export async function hashBlob(blob: Blob): Promise<string> {
   return sha1(await blob.arrayBuffer());
+}
+
+export async function listAssets(opts: {
+  query?: string;
+  sort?: 'newest' | 'oldest' | 'size' | 'used';
+} = {}): Promise<AssetMeta[]> {
+  const rows = await db.images.toArray();
+  let items = rows.map(({ blob, ...meta }) => meta);
+  if (opts.query) {
+    const q = opts.query.toLowerCase();
+    items = items.filter(
+      (m) => m.id.toLowerCase().includes(q) || m.hash.includes(q),
+    );
+  }
+  switch (opts.sort) {
+    case 'oldest':
+      items.sort((a, b) => a.createdAt - b.createdAt);
+      break;
+    case 'size':
+      items.sort((a, b) => b.size - a.size);
+      break;
+    case 'used':
+      items.sort((a, b) => (b.lastUsedAt || 0) - (a.lastUsedAt || 0));
+      break;
+    default:
+      items.sort((a, b) => b.createdAt - a.createdAt);
+  }
+  return items;
+}
+
+export async function duplicates(): Promise<Record<string, AssetMeta[]>> {
+  const rows = await db.images.toArray();
+  const groups: Record<string, AssetMeta[]> = {};
+  rows.forEach(({ blob, ...meta }) => {
+    groups[meta.hash] = groups[meta.hash] || [];
+    groups[meta.hash].push(meta);
+  });
+  Object.keys(groups).forEach((h) => {
+    if (groups[h].length < 2) delete groups[h];
+  });
+  return groups;
+}
+
+export async function touchAsset(id: string): Promise<void> {
+  await db.images.update(id, { lastUsedAt: Date.now() });
 }


### PR DESCRIPTION
## Summary
- add image asset browser with grid view, search/sort and duplicate filtering
- expose listAssets and duplicates helpers for asset queries
- surface Assets button in top bar for inserting images

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aa869ff5f4832cac0de65976f8ac88