### PR TITLE
feat: add minimap navigator

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -20,6 +20,7 @@ import { useRef, useState, useEffect } from 'react';
 import { saveImageMulti } from '@/lib/assets';
 import DropOverlay from './DropOverlay';
 import MarqueeZoom from './MarqueeZoom';
+import Minimap from '@/components/hud/Minimap';
 
 function NodeView({
   node,
@@ -329,6 +330,7 @@ export default function CanvasStage() {
       {selected.length === 1 && <SelectionOutline />}
       {selected.length === 1 && <ResizeHandles />}
       <div className="absolute top-2 right-2"><ZoomControls /></div>
+      <div className="minimap"><Minimap /></div>
     </div>
   );
 }

--- a/web/components/hud/Minimap.tsx
+++ b/web/components/hud/Minimap.tsx
@@ -1,0 +1,110 @@
+'use client';
+import { useEditorStore } from '@/store/editorStore';
+import type { ComponentNode } from '@/types/editor';
+import { useEffect, useRef, useMemo, useCallback } from 'react';
+
+type Rect = { x: number; y: number; w: number; h: number };
+
+function collect(nodes: ComponentNode[], ox = 0, oy = 0, acc: Rect[] = []): Rect[] {
+  for (const n of nodes) {
+    const x = ox + (n.props?.x || 0);
+    const y = oy + (n.props?.y || 0);
+    const w = n.props?.w || 0;
+    const h = n.props?.h || 0;
+    acc.push({ x, y, w, h });
+    if (n.children) collect(n.children as ComponentNode[], x, y, acc);
+  }
+  return acc;
+}
+
+export default function Minimap() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const tree = useEditorStore((s) => s.tree);
+  const camera = useEditorStore((s) => s.camera);
+  const centerOn = useEditorStore((s) => s.centerOn);
+
+  const rects = useMemo(() => collect(tree), [tree]);
+  const transform = useRef({ scale: 1, ox: 0, oy: 0, x1: 0, y1: 0 });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const W = canvas.clientWidth;
+    const H = canvas.clientHeight;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = W * dpr;
+    canvas.height = H * dpr;
+    ctx.scale(dpr, dpr);
+
+    ctx.clearRect(0, 0, W, H);
+    if (!rects.length) return;
+
+    const x1 = Math.min(...rects.map((r) => r.x));
+    const y1 = Math.min(...rects.map((r) => r.y));
+    const x2 = Math.max(...rects.map((r) => r.x + r.w));
+    const y2 = Math.max(...rects.map((r) => r.y + r.h));
+    const w = x2 - x1;
+    const h = y2 - y1;
+    const scale = Math.min(W / w, H / h) || 1;
+    const ox = (W - w * scale) / 2 - x1 * scale;
+    const oy = (H - h * scale) / 2 - y1 * scale;
+    transform.current = { scale, ox, oy, x1, y1 };
+
+    ctx.strokeStyle = '#555';
+    rects.forEach((r) => {
+      ctx.strokeRect(r.x * scale + ox, r.y * scale + oy, r.w * scale, r.h * scale);
+    });
+
+    const vw = window.innerWidth / camera.zoom;
+    const vh = window.innerHeight / camera.zoom;
+    ctx.strokeStyle = '#0ff';
+    ctx.strokeRect(
+      camera.x * scale + ox,
+      camera.y * scale + oy,
+      vw * scale,
+      vh * scale,
+    );
+  }, [rects, camera]);
+
+  const moveTo = useCallback(
+    (e: React.PointerEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const { scale, ox, oy, x1, y1 } = transform.current;
+      const rect = canvas.getBoundingClientRect();
+      const px = e.clientX - rect.left;
+      const py = e.clientY - rect.top;
+      const wx = (px - ox) / scale + x1;
+      const wy = (py - oy) / scale + y1;
+      centerOn({ x: wx, y: wy });
+    },
+    [centerOn],
+  );
+
+  const dragging = useRef(false);
+  const onDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    moveTo(e);
+  };
+  const onMove = (e: React.PointerEvent) => {
+    if (dragging.current) moveTo(e);
+  };
+  const onUp = () => {
+    dragging.current = false;
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="w-full h-full"
+      onPointerDown={onDown}
+      onPointerMove={onMove}
+      onPointerUp={onUp}
+      onPointerLeave={onUp}
+    />
+  );
+}
+

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -120,6 +120,7 @@ interface EditorActions {
     cam: Camera | Partial<Camera>,
     opts?: { duration?: number },
   ) => void;
+  centerOn: (pt: { x: number; y: number }) => void;
   getViewportRect: () => { x: number; y: number; w: number; h: number };
   getSelectionBounds: () => {
     x: number;
@@ -761,6 +762,12 @@ export const useEditorStore = create<EditorState & EditorActions>()(
             next.zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next.zoom));
           }
           set({ camera: next });
+        },
+        centerOn(pt) {
+          const cam = get().camera;
+          const vw = window.innerWidth / cam.zoom;
+          const vh = window.innerHeight / cam.zoom;
+          set({ camera: { ...cam, x: pt.x - vw / 2, y: pt.y - vh / 2 } });
         },
         getViewportRect() {
           const { camera } = get();

--- a/web/styles/editor.css
+++ b/web/styles/editor.css
@@ -139,3 +139,22 @@
 .text-editor::selection {
   background: rgba(59,130,246,0.4);
 }
+
+/* minimap */
+.minimap {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  width: 200px;
+  height: 140px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid #555;
+  z-index: 40;
+  pointer-events: auto;
+}
+
+.minimap canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add canvas-based minimap overlay with node AABB drawing
- expose `centerOn` camera helper and wire into minimap drag
- style minimap with fixed layout

## Testing
- `npm test` (fails: TypeError: reject is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68aa86b26fec832cbb3d1fcfd39c3790