### PR TITLE
feat: add export presets and dev event log

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css'
 import React, { ReactNode } from 'react'
 import { HUDProvider } from '../components/hud/hudStore'
 import PerfHUD from '@/components/dev/PerfHUD'
+import EventLog from '@/components/dev/EventLog'
 import { ThemeProvider, ThemeScript } from '../lib/theme/ThemeProvider'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
@@ -15,7 +16,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <ThemeProvider>
           <HUDProvider>
             {children}
-            {process.env.NODE_ENV !== 'production' && <PerfHUD />}
+            {process.env.NODE_ENV !== 'production' && (
+              <>
+                <PerfHUD />
+                <EventLog />
+              </>
+            )}
           </HUDProvider>
         </ThemeProvider>
       </body>

--- a/web/components/dev/EventLog.tsx
+++ b/web/components/dev/EventLog.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useEditorStore } from '@/store/editorStore';
+
+export default function EventLog() {
+  const logs = useEditorStore((s) => s.devLog);
+  const log = useEditorStore((s) => s.logDev);
+  const clear = useEditorStore((s) => s.clearDevLog);
+  const lastCmd = useEditorStore((s) => s.lastCommandId);
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    const toggle = () => setOpen((o) => !o);
+    window.addEventListener('uibuilder:toggleEventLog', toggle);
+    return () => window.removeEventListener('uibuilder:toggleEventLog', toggle);
+  }, []);
+
+  useEffect(() => {
+    if (lastCmd) log({ ts: Date.now(), type: 'action', payload: { id: lastCmd } });
+  }, [lastCmd, log]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    const handlePointer = (e: PointerEvent) =>
+      log({ ts: Date.now(), type: e.type, payload: { x: e.clientX, y: e.clientY, button: e.button } });
+    const handleWheel = (e: WheelEvent) =>
+      log({ ts: Date.now(), type: 'wheel', payload: { dx: e.deltaX, dy: e.deltaY } });
+    const handleKey = (e: KeyboardEvent) =>
+      log({ ts: Date.now(), type: e.type, payload: { key: e.key, code: e.code } });
+    window.addEventListener('pointerdown', handlePointer);
+    window.addEventListener('pointermove', handlePointer);
+    window.addEventListener('pointerup', handlePointer);
+    window.addEventListener('wheel', handleWheel);
+    window.addEventListener('keydown', handleKey);
+    window.addEventListener('keyup', handleKey);
+    return () => {
+      window.removeEventListener('pointerdown', handlePointer);
+      window.removeEventListener('pointermove', handlePointer);
+      window.removeEventListener('pointerup', handlePointer);
+      window.removeEventListener('wheel', handleWheel);
+      window.removeEventListener('keydown', handleKey);
+      window.removeEventListener('keyup', handleKey);
+    };
+  }, [log]);
+
+  if (!open) return null;
+
+  const entries = logs?.filter((l) => !filter || l.type.includes(filter)) || [];
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 max-h-64 bg-white text-black text-xs border-t z-50">
+      <div className="flex items-center p-1 border-b">
+        <input
+          className="border px-1 mr-1 flex-1"
+          placeholder="filter"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <button className="px-1 border" onClick={clear}>
+          Clear
+        </button>
+      </div>
+      <div className="overflow-auto max-h-56 p-1">
+        <ul>
+          {entries.map((l, i) => (
+            <li key={i} className="whitespace-pre">
+              {new Date(l.ts).toLocaleTimeString()} {l.type} {JSON.stringify(l.payload)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/components/editor/ExportPanel.tsx
+++ b/web/components/editor/ExportPanel.tsx
@@ -1,11 +1,20 @@
 'use client';
 import { useState } from 'react';
-import { exportPNG, exportSVG, exportHTML, exportReact, ExportScope, ExportOptions } from '@/lib/export';
+import {
+  exportMany,
+  PRESETS,
+  ExportScope,
+  ExportOptions,
+  ExportPreset,
+} from '@/lib/export';
+import { useEditorStore } from '@/store/editorStore';
 
 export default function ExportPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [tab, setTab] = useState<'presets' | 'custom'>('presets');
   const [format, setFormat] = useState<'png' | 'svg' | 'html' | 'react'>('png');
   const [scale, setScale] = useState(1);
   const [background, setBackground] = useState<'transparent' | 'white'>('transparent');
+  const selectedIds = useEditorStore((s) => s.selectedIds);
   if (!open) return null;
 
   const download = (blob: Blob, filename: string) => {
@@ -18,27 +27,25 @@ export default function ExportPanel({ open, onClose }: { open: boolean; onClose:
   };
 
   const handleExport = async () => {
-    const scope: ExportScope = { mode: 'selection' };
+    const scopes: ExportScope[] =
+      selectedIds.length > 1
+        ? selectedIds.map((id) => ({ mode: 'frame', id }))
+        : [{ mode: 'selection' }];
     const opts: ExportOptions = {
       scale,
       background: background === 'transparent' ? 'transparent' : { color: background },
     };
-    if (format === 'png') {
-      const blob = await exportPNG(scope, opts);
-      download(blob, 'export.png');
-    } else if (format === 'svg') {
-      const res = await exportSVG(scope, opts);
-      const blob = res instanceof Blob ? res : new Blob([res], { type: 'image/svg+xml' });
-      download(blob, 'export.svg');
-    } else if (format === 'html') {
-      const { html } = await exportHTML(scope, opts);
-      const blob = new Blob([html], { type: 'text/html' });
-      download(blob, 'export.html');
-    } else {
-      const { jsx } = await exportReact(scope, opts);
-      const blob = new Blob([jsx], { type: 'text/plain' });
-      download(blob, 'export.tsx');
-    }
+    const results = await exportMany(scopes, { format, ...opts } as ExportPreset);
+    results.forEach((res, i) => {
+      let blob: Blob;
+      if (format === 'png') blob = res as Blob;
+      else if (format === 'svg')
+        blob = res instanceof Blob ? res : new Blob([res as any], { type: 'image/svg+xml' });
+      else if (format === 'html')
+        blob = new Blob([(res as any).html], { type: 'text/html' });
+      else blob = new Blob([(res as any).jsx], { type: 'text/plain' });
+      download(blob, `export-${i}.${format === 'react' ? 'tsx' : format}`);
+    });
     onClose();
   };
 
@@ -46,31 +53,70 @@ export default function ExportPanel({ open, onClose }: { open: boolean; onClose:
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
       <div className="bg-white text-black p-4 rounded" onClick={(e) => e.stopPropagation()}>
         <h2 className="mb-2">Export</h2>
-        <div className="mb-2">
-          <label className="mr-2">Format</label>
-          <select value={format} onChange={(e) => setFormat(e.target.value as any)}>
-            <option value="png">PNG</option>
-            <option value="svg">SVG</option>
-            <option value="html">HTML</option>
-            <option value="react">React</option>
-          </select>
+        <div className="mb-2 border-b flex mb-4">
+          <button className={`px-2 py-1 ${tab === 'presets' ? 'border-b-2' : ''}`} onClick={() => setTab('presets')}>Presets</button>
+          <button className={`px-2 py-1 ${tab === 'custom' ? 'border-b-2' : ''}`} onClick={() => setTab('custom')}>Custom</button>
         </div>
-        <div className="mb-2">
-          <label className="mr-2">Scale</label>
-          <select value={scale} onChange={(e) => setScale(Number(e.target.value))}>
-            {[1, 2, 3, 4].map((s) => (
-              <option key={s} value={s}>{`${s}x`}</option>
+        {tab === 'presets' ? (
+          <div className="space-y-2">
+            {Object.entries(PRESETS).map(([id, p]) => (
+              <button
+                key={id}
+                className="px-2 py-1 border block w-full text-left"
+                onClick={async () => {
+                  const scopes: ExportScope[] =
+                    selectedIds.length > 1
+                      ? selectedIds.map((sid) => ({ mode: 'frame', id: sid }))
+                      : [{ mode: 'selection' }];
+                  const results = await exportMany(scopes, p);
+                  results.forEach((res, i) => {
+                    let blob: Blob;
+                    if (p.format === 'png') blob = res as Blob;
+                    else if (p.format === 'svg')
+                      blob = res instanceof Blob ? res : new Blob([res as any], { type: 'image/svg+xml' });
+                    else if (p.format === 'html')
+                      blob = new Blob([(res as any).html], { type: 'text/html' });
+                    else blob = new Blob([(res as any).jsx], { type: 'text/plain' });
+                    download(blob, `export-${i}.${p.format === 'react' ? 'tsx' : p.format}`);
+                  });
+                  onClose();
+                }}
+              >
+                {id.toUpperCase()}
+              </button>
             ))}
-          </select>
-        </div>
-        <div className="mb-4">
-          <label className="mr-2">Background</label>
-          <select value={background} onChange={(e) => setBackground(e.target.value as any)}>
-            <option value="transparent">Transparent</option>
-            <option value="white">White</option>
-          </select>
-        </div>
-        <button className="px-2 py-1 border" onClick={handleExport}>Export</button>
+          </div>
+        ) : (
+          <>
+            <div className="mb-2">
+              <label className="mr-2">Format</label>
+              <select value={format} onChange={(e) => setFormat(e.target.value as any)}>
+                <option value="png">PNG</option>
+                <option value="svg">SVG</option>
+                <option value="html">HTML</option>
+                <option value="react">React</option>
+              </select>
+            </div>
+            <div className="mb-2">
+              <label className="mr-2">Scale</label>
+              <select value={scale} onChange={(e) => setScale(Number(e.target.value))}>
+                {[1, 2, 3, 4].map((s) => (
+                  <option key={s} value={s}>{`${s}x`}</option>
+                ))}
+              </select>
+            </div>
+            <div className="mb-4">
+              <label className="mr-2">Background</label>
+              <select value={background} onChange={(e) => setBackground(e.target.value as any)}>
+                <option value="transparent">Transparent</option>
+                <option value="white">White</option>
+              </select>
+            </div>
+            <button className="px-2 py-1 border" onClick={handleExport}>
+              Export
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/web/lib/commands.ts
+++ b/web/lib/commands.ts
@@ -72,6 +72,12 @@ export const COMMANDS: Command[] = [
     run: () => useEditorStore.getState().toggleSnapToPixel(),
   },
   {
+    id: 'view.eventLog',
+    label: 'Toggle Event Log',
+    shortcut: 'Ctrl+Alt+L',
+    run: () => window.dispatchEvent(new CustomEvent('uibuilder:toggleEventLog')),
+  },
+  {
     id: 'export',
     label: 'Export',
     shortcut: 'Ctrl+Shift+E',

--- a/web/lib/export/index.ts
+++ b/web/lib/export/index.ts
@@ -8,6 +8,12 @@ export interface ExportOptions {
   background?: 'transparent' | { color: string };
 }
 
+export type ExportFormat = 'png' | 'svg' | 'html' | 'react';
+
+export interface ExportPreset extends ExportOptions {
+  format: ExportFormat;
+}
+
 export async function exportPNG(scope: ExportScope, opts?: ExportOptions) {
   const mod = await import('./png');
   return mod.exportPNG(scope, opts);
@@ -27,3 +33,29 @@ export async function exportReact(scope: ExportScope, opts?: ExportOptions) {
   const mod = await import('./react');
   return mod.exportReact(scope, opts);
 }
+
+export async function exportMany(
+  scopes: ExportScope[],
+  opts: ExportPreset,
+) {
+  const promises = scopes.map((s) => {
+    switch (opts.format) {
+      case 'png':
+        return exportPNG(s, opts);
+      case 'svg':
+        return exportSVG(s, opts);
+      case 'html':
+        return exportHTML(s, opts);
+      case 'react':
+        return exportReact(s, opts);
+    }
+  });
+  return Promise.all(promises);
+}
+
+export const PRESETS: Record<string, ExportPreset> = {
+  png2x: { format: 'png', scale: 2 },
+  svg: { format: 'svg' },
+  html: { format: 'html' },
+  react: { format: 'react' },
+};

--- a/web/lib/keymap.ts
+++ b/web/lib/keymap.ts
@@ -30,6 +30,7 @@ export type Command =
   | 'view.toggleLayoutGrid'
   | 'view.togglePixelGrid'
   | 'view.toggleSnapToPixel'
+  | 'view.eventLog'
   | 'export'
   | 'annotation.pin'
   | 'annotation.rect'
@@ -64,6 +65,7 @@ export function getCommand(e: KeyboardEvent): Command | undefined {
     if (e.code === 'KeyB') return 'detachInstance';
     if (e.code === 'KeyS') return 'swapInstance';
     if (e.code === 'KeyH') return 'distribute.h';
+    if (e.code === 'KeyL') return 'view.eventLog';
   }
   if (mod) {
     if (e.code === 'KeyD') return 'duplicate';

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -127,6 +127,8 @@ interface EditorActions {
     w: number;
     h: number;
   } | null;
+  logDev: (entry: { ts: number; type: string; payload: any }) => void;
+  clearDevLog: () => void;
   // Variants
   defineVariantAxis: (
     componentId: string,
@@ -305,6 +307,7 @@ export const useEditorStore = create<EditorState & EditorActions>()(
           showImageBadges: true,
         },
         lastCommandId: undefined,
+        devLog: [],
         review: { status: "DRAFT", requireApprovedToShare: false },
         comments: { threads: {}, users: {} },
         styles: { text: {} },
@@ -744,6 +747,12 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         },
         setLastCommand(id) {
           set({ lastCommandId: id });
+        },
+        logDev(entry) {
+          set((state) => ({ devLog: [...(state.devLog || []), entry] }));
+        },
+        clearDevLog() {
+          set({ devLog: [] });
         },
         setCamera(cam) {
           set((state) => {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -341,6 +341,7 @@ export interface EditorState {
   textSel?: TextSelection;
   styles: { text: Record<string, TextStyleDef> };
   lastCommandId?: string;
+  devLog?: { ts: number; type: string; payload: any }[];
   review: {
     status: ReviewStatus;
     requireApprovedToShare: boolean;


### PR DESCRIPTION
## Summary
- add quick export presets and batch export support
- introduce development event log with keyboard toggle

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa86cdabc8832c9df99fbf2760f103