### PR TITLE
feat: add auto-save indicator

### DIFF
--- a/web/components/hud/SaveIndicator.tsx
+++ b/web/components/hud/SaveIndicator.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEditorStore } from '@/store/editorStore';
+
+export default function SaveIndicator() {
+  const { saveQueue, lastSavedAt, isOffline } = useEditorStore((s) => ({
+    saveQueue: s.saveQueue,
+    lastSavedAt: s.lastSavedAt,
+    isOffline: s.isOffline,
+  }));
+  let text = 'All changes saved';
+  if (isOffline) text = 'Offline';
+  else if (saveQueue.length > 0) text = 'Saving…';
+  return <div className="text-xs text-gray-500">{text}</div>;
+}

--- a/web/lib/persist.ts
+++ b/web/lib/persist.ts
@@ -1,0 +1,58 @@
+import type { StoreApi } from 'zustand';
+import type { EditorState } from '@/types/editor';
+import { idbStorage } from './idb';
+
+interface PersistState {
+  saveQueue: number[];
+  lastSavedAt: number | null;
+  isOffline: boolean;
+}
+
+let store: StoreApi<EditorState & PersistState> | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+const KEY = 'uibuilder:save-queue';
+
+export function initPersist(s: StoreApi<EditorState & PersistState>) {
+  store = s;
+  if (typeof window === 'undefined') return;
+  window.addEventListener('online', flush);
+  window.addEventListener('offline', () => {
+    store?.setState({ isOffline: true });
+  });
+  // load any pending queue from idb
+  idbStorage.getItem(KEY).then((raw) => {
+    if (!raw) return;
+    try {
+      const q = JSON.parse(raw) as number[];
+      if (q.length) {
+        store?.setState({ saveQueue: q, isOffline: true });
+        flush();
+      }
+    } catch {
+      /* ignore */
+    }
+  });
+}
+
+export function schedulePersist() {
+  if (!store) return;
+  store.setState((s) => ({ saveQueue: [...s.saveQueue, Date.now()] }));
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(flush, 500);
+}
+
+async function flush() {
+  if (!store) return;
+  const s = store.getState();
+  if (!navigator.onLine) {
+    await idbStorage.setItem(KEY, JSON.stringify(s.saveQueue));
+    store.setState({ isOffline: true });
+    return;
+  }
+  if (s.saveQueue.length === 0) {
+    store.setState({ isOffline: false });
+    return;
+  }
+  await idbStorage.removeItem(KEY).catch(() => {});
+  store.setState({ saveQueue: [], lastSavedAt: Date.now(), isOffline: false });
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -26,6 +26,7 @@ import type {
   TextRun,
 } from "@/types/editor";
 import { idbStorage } from "@/lib/idb";
+import { initPersist, schedulePersist } from "@/lib/persist";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
 import { resolveVariant } from "@/lib/variantResolver";
 import { applyOverrides } from "@/lib/overrideMerge";
@@ -224,6 +225,12 @@ interface EditorActions {
   ) => void;
 }
 
+interface EditorPersistState {
+  saveQueue: number[];
+  lastSavedAt: number | null;
+  isOffline: boolean;
+}
+
 export interface CropDraft {
   nodeId: string;
   rect: { x: number; y: number; w: number; h: number };
@@ -270,13 +277,16 @@ function lerp(
   return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
 }
 
-export const useEditorStore = create<EditorState & EditorActions>()(
+export const useEditorStore = create<
+  EditorState & EditorActions & EditorPersistState
+>()(
   persist(
     (set, get) => {
       const apply = (recipe: (draft: EditorState) => void) => {
         const [next, patches, inverse] = produceWithPatches(get(), recipe);
         push(patches, inverse);
         set(next);
+        schedulePersist();
       };
 
       return {
@@ -309,6 +319,9 @@ export const useEditorStore = create<EditorState & EditorActions>()(
         comments: { threads: {}, users: {} },
         styles: { text: {} },
         textSel: undefined,
+        saveQueue: [],
+        lastSavedAt: null,
+        isOffline: false,
         setHover(id) {
           set({ hoverId: id });
         },
@@ -1457,3 +1470,5 @@ export const useEditorStore = create<EditorState & EditorActions>()(
     },
   ),
 );
+
+initPersist(useEditorStore);


### PR DESCRIPTION
## Summary
- add persistence helper to debounce saves and flush pending changes when back online
- track save queue and offline status in editor store
- show saving/offline state via new HUD SaveIndicator

## Testing
- `npm test` (fails: Jest worker encountered 4 child process exceptions)


------
https://chatgpt.com/codex/tasks/task_e_68aa86c0bdb4832ca6645fe824072c61