### PR TITLE
feat: add basic component and instance management

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -9,10 +9,9 @@ import ImageView from './ImageView';
 import TextView from './TextView';
 import TextEditor from './TextEditor';
 import ImageCropOverlay from './ImageCropOverlay';
+import InstanceView from './InstanceView';
 import type { ComponentNode, InstanceNode, PathNode, ImageNode, TextNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
-import { resolveVariant } from '@/lib/variantResolver';
-import { applyOverrides } from '@/lib/overrideMerge';
 import ZoomControls from './ZoomControls';
 import { wheelRouter } from '@/lib/input/wheelRouter';
 import * as zoom from '@/lib/zoom';
@@ -42,20 +41,20 @@ function NodeView({
   }
   if (node.type === 'Instance') {
     const inst = node as InstanceNode;
-    const def = components[inst.componentId];
-    if (def) {
-      let resolved = resolveVariant(def, inst.variant);
-      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
-      resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
-      return (
-        <NodeView
-          node={resolved}
-          components={components}
-          parentLayout={parentLayout}
-          parentAxis={parentAxis}
-        />
-      );
-    }
+    return (
+      <InstanceView
+        node={inst}
+        components={components}
+        render={(resolved) => (
+          <NodeView
+            node={resolved}
+            components={components}
+            parentLayout={parentLayout}
+            parentAxis={parentAxis}
+          />
+        )}
+      />
+    );
   }
   const style: any = {
     transition: 'opacity var(--motion-fast) var(--easing-standard), transform var(--motion-fast) var(--easing-standard)',

--- a/web/components/editor/InstanceView.tsx
+++ b/web/components/editor/InstanceView.tsx
@@ -1,0 +1,21 @@
+'use client';
+import type { InstanceNode, ComponentNode } from '@/types/editor';
+import { resolveVariant } from '@/lib/variantResolver';
+import { applyOverrides } from '@/lib/overrideMerge';
+
+interface InstanceViewProps {
+  node: InstanceNode;
+  components: Record<string, any>;
+  render: (node: ComponentNode) => React.ReactNode;
+}
+
+export default function InstanceView({ node, components, render }: InstanceViewProps) {
+  const def = components[node.componentId];
+  if (!def) return null;
+  let resolved = resolveVariant(def, node.variant);
+  if (node.overrides) {
+    resolved = applyOverrides(resolved, node.overrides);
+  }
+  resolved.props = { ...(resolved.props || {}), ...(node.props || {}) };
+  return <>{render(resolved)}</>;
+}

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -10,6 +10,8 @@ export default function TopBar() {
     const togglePreferences = useEditorStore((s) => s.togglePreferences);
     const selection = useEditorStore((s) => s.selectedIds);
     const tree = useEditorStore((s) => s.tree);
+  const createComponent = useEditorStore((s) => s.createComponent);
+  const detachInstance = useEditorStore((s) => s.detachInstance);
   const toggleMask = useEditorStore((s) => s.toggleMask);
   const combine = useEditorStore((s) => s.booleanCombine);
   const startCrop = useEditorStore((s) => s.startCrop);
@@ -71,6 +73,18 @@ export default function TopBar() {
       </div>
         <div className="flex items-center gap-4">
           <button>Group</button>
+          <button
+            disabled={selection.length !== 1}
+            onClick={() => createComponent()}
+          >
+            Create Component
+          </button>
+          <button
+            disabled={selection.length !== 1}
+            onClick={() => detachInstance(selection[0])}
+          >
+            Detach
+          </button>
           <button onClick={() => window.dispatchEvent(new CustomEvent('uibuilder:export'))}>
             Export
           </button>

--- a/web/components/sidebar/ComponentsPanel.tsx
+++ b/web/components/sidebar/ComponentsPanel.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useEditorStore } from '@/store/editorStore';
+
+export default function ComponentsPanel() {
+  const components = useEditorStore((s) => Object.values(s.components));
+  const placeInstance = useEditorStore((s) => s.placeInstance);
+
+  return (
+    <div className="p-2 space-y-1 text-xs">
+      {components.map((c) => (
+        <div
+          key={c.id}
+          className="cursor-pointer hover:bg-gray-700 px-1 py-0.5 rounded"
+          onClick={() => placeInstance(c.id)}
+        >
+          {c.name}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -88,10 +88,12 @@ interface EditorActions {
     value?: number,
   ) => void;
   // Components
+  createComponent: (name?: string) => void;
   createComponentFromSelection: (name?: string) => void;
   deleteComponent: (componentId: string) => void;
   renameComponent: (componentId: string, name: string) => void;
   createInstance: (componentId: string, pos?: { x: number; y: number }) => void;
+  placeInstance: (componentId: string, pos?: { x: number; y: number }) => void;
   detachInstance: (nodeId: string) => void;
   swapInstance: (nodeId: string, nextComponentId: string) => void;
   // v3 additions
@@ -569,6 +571,9 @@ export const useEditorStore = create<
             }
           });
         },
+        createComponent(name) {
+          get().createComponentFromSelection(name);
+        },
         createComponentFromSelection(name) {
           apply((draft) => {
             const sel = draft.selectedIds[0];
@@ -619,6 +624,9 @@ export const useEditorStore = create<
             draft.tree.push(inst);
             draft.selectedIds = [id];
           });
+        },
+        placeInstance(componentId, pos) {
+          get().createInstance(componentId, pos);
         },
         detachInstance(nodeId) {
           apply((draft) => {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -370,11 +370,15 @@ export interface ComponentDefinition {
   }>;
 }
 
+// v10-1 component definitions
+export type ComponentDef = ComponentDefinition;
+export type OverrideMap = Record<string, any>;
+
 export interface InstanceNode extends ComponentNode {
   type: "Instance";
   componentId: string;
   variant?: Record<string, string>;
-  overrides?: Record<string, Partial<ComponentNode>>;
+  overrides?: OverrideMap;
 }
 
 // v6 data binding and action types


### PR DESCRIPTION
## Summary
- add component panel and instance view
- expose create/place/detach actions in editor store
- enable component creation and detachment from top bar

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8bfa4138832c80cce5d3b535dc05