### PR TITLE
feat: add instance overrides

### DIFF
--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -2,7 +2,7 @@
 import { useEditorStore } from '@/store/editorStore';
 import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
-import { applyOverrides } from '@/lib/overrideMerge';
+import { resolveOverrides } from '@/lib/override/resolve';
 import { DEVICE_PRESETS } from '@/lib/devicePresets';
 import AnnotationsOverlay from '@/components/editor/AnnotationsOverlay';
 import { useSearchParams } from 'next/navigation';
@@ -17,7 +17,7 @@ function renderNode(
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
-      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+      if (inst.overrides) resolved = resolveOverrides(resolved, inst.overrides);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
       return renderNode(resolved, components);
     }

--- a/web/app/s/[id]/page.tsx
+++ b/web/app/s/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { deserialize } from '@/lib/deserialize';
 import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
-import { applyOverrides } from '@/lib/overrideMerge';
+import { resolveOverrides } from '@/lib/override/resolve';
 import AnnotationsOverlay from '@/components/editor/AnnotationsOverlay';
 
 function renderNode(node: ComponentNode, components: Record<string, any>): JSX.Element {
@@ -13,7 +13,7 @@ function renderNode(node: ComponentNode, components: Record<string, any>): JSX.E
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
-      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+      if (inst.overrides) resolved = resolveOverrides(resolved, inst.overrides);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
       return renderNode(resolved, components);
     }

--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -12,7 +12,7 @@ import ImageCropOverlay from './ImageCropOverlay';
 import type { ComponentNode, InstanceNode, PathNode, ImageNode, TextNode } from '@/types/editor';
 import { sizeStyle } from '@/lib/flex';
 import { resolveVariant } from '@/lib/variantResolver';
-import { applyOverrides } from '@/lib/overrideMerge';
+import { resolveOverrides } from '@/lib/override/resolve';
 import ZoomControls from './ZoomControls';
 import { wheelRouter } from '@/lib/input/wheelRouter';
 import * as zoom from '@/lib/zoom';
@@ -45,7 +45,7 @@ function NodeView({
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
-      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+      if (inst.overrides) resolved = resolveOverrides(resolved, inst.overrides);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
       return (
         <NodeView

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -19,6 +19,23 @@ export default function RightPane() {
   const prefs = useEditorStore((s) => s.prefs);
   const setPrefs = useEditorStore((s) => s.setPrefs);
   const ensureDominantColor = useEditorStore((s) => s.ensureDominantColor);
+  const clearAllOverrides = useEditorStore((s) => s.clearAllOverrides);
+
+  if (node && node.type === "Instance") {
+    return (
+      <div className="bg-gray-800 p-2 space-y-2 text-xs">
+        <div className="font-bold flex items-center">
+          Overrides
+          <button
+            className="ml-auto px-1 bg-gray-700"
+            onClick={() => clearAllOverrides(node.id)}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   useEffect(() => {
     if (node && node.type === "Image") {

--- a/web/lib/override/resolve.ts
+++ b/web/lib/override/resolve.ts
@@ -1,0 +1,51 @@
+import type { ComponentNode, OverrideMap, TextNode, ImageNode } from '@/types/editor';
+
+function findNode(node: ComponentNode, id: string): ComponentNode | null {
+  if (node.id === id) return node;
+  if (node.children) {
+    for (const c of node.children) {
+      const r = findNode(c, id);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
+export function resolveOverrides(root: ComponentNode, overrides: OverrideMap): ComponentNode {
+  const clone: ComponentNode = JSON.parse(JSON.stringify(root));
+  if (!overrides) return clone;
+
+  if (overrides.text) {
+    Object.entries(overrides.text).forEach(([id, text]) => {
+      const n = findNode(clone, id);
+      if (n && n.type === 'Text') {
+        (n as TextNode).props = { ...(n.props || {}), text };
+      }
+    });
+  }
+  if (overrides.image) {
+    Object.entries(overrides.image).forEach(([id, assetId]) => {
+      const n = findNode(clone, id);
+      if (n && n.type === 'Image') {
+        (n as ImageNode).props = { ...(n.props || {}), assetId };
+      }
+    });
+  }
+  if (overrides.visible) {
+    Object.entries(overrides.visible).forEach(([id, hidden]) => {
+      const n = findNode(clone, id);
+      if (n) {
+        n.props = { ...(n.props || {}), visible: !hidden };
+      }
+    });
+  }
+  if (overrides.style) {
+    Object.entries(overrides.style).forEach(([id, style]) => {
+      const n = findNode(clone, id);
+      if (n) {
+        n.props = { ...(n.props || {}), ...style } as any;
+      }
+    });
+  }
+  return clone;
+}

--- a/web/lib/zoom.ts
+++ b/web/lib/zoom.ts
@@ -29,10 +29,10 @@ export function animateZoomTo(
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const duration =
-    opts?.duration ??
-    parseFloat(
-      getComputedStyle(document.documentElement).getPropertyValue('--motion-base')
-    ) || 200;
+    (opts?.duration ??
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--motion-base')
+      )) || 200;
   if (prefersReduce || duration === 0) {
     store.setCamera(to);
     return Promise.resolve();

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -29,7 +29,7 @@ import { idbStorage } from "@/lib/idb";
 import { initPersist, schedulePersist } from "@/lib/persist";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
 import { resolveVariant } from "@/lib/variantResolver";
-import { applyOverrides } from "@/lib/overrideMerge";
+import { resolveOverrides } from "@/lib/override/resolve";
 import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
 import { reflectHandle } from "@/lib/vector/bezier";
 import { flattenPath } from "@/lib/vector/flatten";
@@ -150,12 +150,9 @@ interface EditorActions {
   removeVariantRule: (componentId: string, index: number) => void;
   setInstanceVariant: (nodeId: string, axis: string, value: string) => void;
   // Overrides
-  setInstanceOverride: (
-    nodeId: string,
-    targetId: string,
-    patch: Partial<ComponentNode>,
-  ) => void;
-  resetInstanceOverride: (nodeId: string, targetId?: string) => void;
+  setOverride: (nodeId: string, path: string, value: any) => void;
+  clearOverride: (nodeId: string, path: string) => void;
+  clearAllOverrides: (nodeId: string) => void;
   // v5 comments and review
   startPinAnnotation: () => void;
   startRectAnnotation: () => void;
@@ -629,7 +626,7 @@ export const useEditorStore = create<
             if (!def) return;
             let resolved = resolveVariant(def, inst.variant);
             if (inst.overrides) {
-              resolved = applyOverrides(resolved, inst.overrides);
+              resolved = resolveOverrides(resolved, inst.overrides);
             }
             if (res.parent && res.parent.children)
               res.parent.children[res.index] = resolved;
@@ -782,6 +779,7 @@ export const useEditorStore = create<
         },
         clearDevLog() {
           set({ devLog: [] });
+        },
         addRecentCommand(id) {
           set((state) => ({
             recentCommands: [id, ...state.recentCommands.filter((c) => c !== id)].slice(0, 10),
@@ -878,21 +876,40 @@ export const useEditorStore = create<
             inst.variant[axis] = value;
           });
         },
-        setInstanceOverride(nodeId, targetId, patch) {
+        setOverride(nodeId, path, value) {
           apply((draft) => {
             const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
             if (!inst) return;
-            inst.overrides = inst.overrides || {};
-            const prev = inst.overrides[targetId] || {};
-            inst.overrides[targetId] = { ...prev, ...patch };
+            inst.overrides = inst.overrides || {} as any;
+            const parts = path.split('.');
+            let obj: any = inst.overrides;
+            for (let i = 0; i < parts.length - 1; i++) {
+              const k = parts[i];
+              obj[k] = obj[k] || {};
+              obj = obj[k];
+            }
+            obj[parts[parts.length - 1]] = value;
           });
         },
-        resetInstanceOverride(nodeId, targetId) {
+        clearOverride(nodeId, path) {
           apply((draft) => {
             const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
             if (!inst || !inst.overrides) return;
-            if (targetId) delete inst.overrides[targetId];
-            else inst.overrides = {};
+            const parts = path.split('.');
+            let obj: any = inst.overrides;
+            for (let i = 0; i < parts.length - 1; i++) {
+              const k = parts[i];
+              if (!obj[k]) return;
+              obj = obj[k];
+            }
+            delete obj[parts[parts.length - 1]];
+          });
+        },
+        clearAllOverrides(nodeId) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst) return;
+            inst.overrides = {};
           });
         },
         // --- v5 comments & review ---

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -370,11 +370,18 @@ export interface ComponentDefinition {
   }>;
 }
 
+export interface OverrideMap {
+  text?: Record<string, string>;
+  image?: Record<string, string>;
+  visible?: Record<string, boolean>;
+  style?: Record<string, { fill?: string; stroke?: string }>;
+}
+
 export interface InstanceNode extends ComponentNode {
   type: "Instance";
   componentId: string;
   variant?: Record<string, string>;
-  overrides?: Record<string, Partial<ComponentNode>>;
+  overrides?: OverrideMap;
 }
 
 // v6 data binding and action types


### PR DESCRIPTION
## Summary
- introduce typed OverrideMap and expose override actions
- apply overrides when rendering instances and in shared/preview pages
- add simple Overrides panel for instances

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: 'layoutText' not exported & tailwind `@layer base` requires `@tailwind base` directive)


------
https://chatgpt.com/codex/tasks/task_e_68aa8c3620bc832c9f998543ec75d808