### PR TITLE
feat: add variant set support

### DIFF
--- a/web/components/editor/InstanceView.tsx
+++ b/web/components/editor/InstanceView.tsx
@@ -1,0 +1,46 @@
+import type { ComponentNode, InstanceNode, VariantProps } from '@/types/editor';
+import { useEditorStore } from '@/store/editorStore';
+import { resolveVariant } from '@/lib/variantResolver';
+import { applyOverrides } from '@/lib/overrideMerge';
+
+function renderNode(node: ComponentNode, components: Record<string, any>): JSX.Element {
+  if (node.type === 'Instance') {
+    const inst = node as InstanceNode;
+    const def = components[inst.componentId];
+    if (def) {
+      let resolved = resolveVariant(def, inst.variant);
+      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+      resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
+      return renderNode(resolved, components);
+    }
+  }
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: node.props?.x || 0,
+    top: node.props?.y || 0,
+    width: node.props?.w || 0,
+    height: node.props?.h || 0,
+    transform: `rotate(${node.props?.rotation || 0}deg)`,
+  };
+  if (node.props?.visible === false) style.display = 'none';
+  return (
+    <div key={node.id} style={style} className={node.props?.className}>
+      {node.props?.text}
+      {node.children?.map((c) => renderNode(c, components))}
+    </div>
+  );
+}
+
+export default function InstanceView({
+  defId,
+  props,
+}: {
+  defId: string;
+  props?: VariantProps;
+}) {
+  const components = useEditorStore((s) => s.components);
+  const def = components[defId];
+  if (!def) return null;
+  let root = resolveVariant(def, props);
+  return <div style={{ position: 'relative' }}>{renderNode(root, components)}</div>;
+}

--- a/web/components/sidebar/ComponentsPanel.tsx
+++ b/web/components/sidebar/ComponentsPanel.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useEditorStore } from '@/store/editorStore';
+import InstanceView from '@/components/editor/InstanceView';
+import type { VariantProps } from '@/types/editor';
+
+export default function ComponentsPanel() {
+  const components = useEditorStore((s) => s.components);
+  const createInstance = useEditorStore((s) => s.createInstance);
+  const [propsByComp, setPropsByComp] = useState<Record<string, VariantProps>>({});
+  return (
+    <div className="p-2 space-y-4 overflow-y-auto">
+      {Object.values(components).map((c) => {
+        const vp = propsByComp[c.id] || {};
+        const setProp = (k: string, v: string) =>
+          setPropsByComp((prev) => ({ ...prev, [c.id]: { ...vp, [k]: v } }));
+        return (
+          <div key={c.id} className="border p-2 rounded">
+            <div className="mb-2 font-medium text-xs">{c.name}</div>
+            {c.variantSet && (
+              <div className="mb-2 space-y-1">
+                {Object.entries(c.variantSet.props).map(([prop, values]) => (
+                  <select
+                    key={prop}
+                    value={vp[prop] || values[0]}
+                    onChange={(e) => setProp(prop, e.target.value)}
+                    className="block w-full border rounded p-1 text-xs">
+                    {values.map((v) => (
+                      <option key={v} value={v}>
+                        {v}
+                      </option>
+                    ))}
+                  </select>
+                ))}
+              </div>
+            )}
+            <div
+              onClick={() => createInstance(c.id)}
+              className="cursor-pointer border relative">
+              <InstanceView defId={c.id} props={vp} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/lib/variantResolver.ts
+++ b/web/lib/variantResolver.ts
@@ -1,4 +1,8 @@
-import type { ComponentDefinition, ComponentNode } from '@/types/editor';
+import type {
+  ComponentDefinition,
+  ComponentNode,
+  VariantProps,
+} from '@/types/editor';
 
 function findNode(node: ComponentNode, id: string): ComponentNode | null {
   if (node.id === id) return node;
@@ -21,13 +25,20 @@ function applyPatch(target: ComponentNode, patch: Partial<ComponentNode>) {
 
 export function resolveVariant(
   def: ComponentDefinition,
-  variant?: Record<string, string>
+  variant?: VariantProps,
 ): ComponentNode {
+  if (def.variantSet) {
+    const match = def.variantSet.defs.find((d) =>
+      Object.entries(variant || {}).every(([k, v]) => d.props[k] === v),
+    );
+    const chosen = match || def.variantSet.defs[0];
+    return JSON.parse(JSON.stringify(chosen.root));
+  }
   const root: ComponentNode = JSON.parse(JSON.stringify(def.root));
   if (!def.rules) return root;
   def.rules.forEach((r) => {
     const ok = Object.entries(r.when).every(
-      ([k, v]) => variant && variant[k] === v
+      ([k, v]) => variant && (variant as any)[k] === v,
     );
     if (ok) {
       const target = findNode(root, r.node);

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -24,6 +24,8 @@ import type {
   TextStyleDef,
   TextSelection,
   TextRun,
+  VariantSet,
+  VariantProps,
 } from "@/types/editor";
 import { idbStorage } from "@/lib/idb";
 import { initPersist, schedulePersist } from "@/lib/persist";
@@ -134,6 +136,7 @@ interface EditorActions {
   logDev: (entry: { ts: number; type: string; payload: any }) => void;
   clearDevLog: () => void;
   // Variants
+  createVariantSet: (componentId: string, set: VariantSet) => void;
   defineVariantAxis: (
     componentId: string,
     axis: string,
@@ -149,6 +152,10 @@ interface EditorActions {
   ) => void;
   removeVariantRule: (componentId: string, index: number) => void;
   setInstanceVariant: (nodeId: string, axis: string, value: string) => void;
+  setInstanceVariantProps: (
+    nodeId: string,
+    props: VariantProps,
+  ) => void;
   // Overrides
   setInstanceOverride: (
     nodeId: string,
@@ -848,6 +855,13 @@ export const useEditorStore = create<
           const y2 = Math.max(...boxes.map((b) => b.y + b.h));
           return { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
         },
+        createVariantSet(componentId, set) {
+          apply((draft) => {
+            const c = draft.components[componentId];
+            if (!c) return;
+            c.variantSet = set;
+          });
+        },
         defineVariantAxis(componentId, axis, values) {
           apply((draft) => {
             const c = draft.components[componentId];
@@ -876,6 +890,27 @@ export const useEditorStore = create<
             if (!inst) return;
             inst.variant = inst.variant || {};
             inst.variant[axis] = value;
+          });
+        },
+        setInstanceVariantProps(nodeId, props) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst) return;
+            inst.variant = { ...(inst.variant || {}), ...props };
+            const def = draft.components[inst.componentId];
+            if (def) {
+              const root = resolveVariant(def, inst.variant);
+              if (inst.overrides) {
+                const ids = new Set<string>();
+                (function collect(n: ComponentNode) {
+                  ids.add(n.id);
+                  n.children?.forEach(collect);
+                })(root);
+                Object.keys(inst.overrides).forEach((id) => {
+                  if (!ids.has(id)) delete inst.overrides![id];
+                });
+              }
+            }
           });
         },
         setInstanceOverride(nodeId, targetId, patch) {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -358,6 +358,19 @@ export interface EditorState {
   };
 }
 
+export type VariantProps = Record<string, string>;
+
+export interface VariantDef {
+  id: string;
+  props: VariantProps;
+  root: ComponentNode;
+}
+
+export interface VariantSet {
+  props: Record<string, string[]>;
+  defs: VariantDef[];
+}
+
 export interface ComponentDefinition {
   id: string;
   name: string;
@@ -368,12 +381,13 @@ export interface ComponentDefinition {
     node: string;
     patch: Partial<ComponentNode>;
   }>;
+  variantSet?: VariantSet;
 }
 
 export interface InstanceNode extends ComponentNode {
   type: "Instance";
   componentId: string;
-  variant?: Record<string, string>;
+  variant?: VariantProps;
   overrides?: Record<string, Partial<ComponentNode>>;
 }
 


### PR DESCRIPTION
## Summary
- add VariantSet types and link to component definitions
- allow instances to set variant props with override cleanup
- display and select component variants in sidebar panel

## Testing
- `npm test` *(fails: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8c4c2a00832c88414d3594510ea4