### PR TITLE
feat: swap instance definitions with override migration

### DIFF
--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,9 +1,18 @@
 "use client";
 import { useEffect } from "react";
 import { useEditorStore } from "@/store/editorStore";
-import type { PathNode, ImageNode, ImageAdjustments, BlendMode, TextNode, TextResizeMode } from "@/types/editor";
+import type {
+  PathNode,
+  ImageNode,
+  ImageAdjustments,
+  BlendMode,
+  TextNode,
+  TextResizeMode,
+  InstanceNode,
+} from "@/types/editor";
 import { normalizeAdjustments, DEFAULT_ADJ } from "@/lib/image/filters";
 import { getScaleInfo } from "@/lib/image/metrics";
+import { isCompatible } from "@/lib/override/compat";
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedIds[0]);
@@ -19,6 +28,8 @@ export default function RightPane() {
   const prefs = useEditorStore((s) => s.prefs);
   const setPrefs = useEditorStore((s) => s.setPrefs);
   const ensureDominantColor = useEditorStore((s) => s.ensureDominantColor);
+  const components = useEditorStore((s) => s.components);
+  const swap = useEditorStore((s) => s.swapInstanceDef);
 
   useEffect(() => {
     if (node && node.type === "Image") {
@@ -26,6 +37,32 @@ export default function RightPane() {
       if (meta && !meta.dominant) ensureDominantColor(meta.id);
     }
   }, [node, assets, ensureDominantColor]);
+  if (node && node.type === "Instance") {
+    const inst = node as InstanceNode;
+    const curr = components[inst.componentId];
+    const opts = Object.values(components).filter(
+      (c) => curr && isCompatible(curr, c),
+    );
+    return (
+      <div className="bg-gray-800 p-2 space-y-2 text-xs">
+        <div className="font-bold">Instance</div>
+        <label className="block">
+          Swap
+          <select
+            className="w-full bg-gray-700 p-1 text-white"
+            value={inst.componentId}
+            onChange={(e) => swap(inst.id, e.target.value)}
+          >
+            {opts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    );
+  }
   if (node && (node as ImageNode).type === "Image") {
     const img = node as ImageNode;
     const meta = assets[img.props.assetId];

--- a/web/lib/override/compat.ts
+++ b/web/lib/override/compat.ts
@@ -1,0 +1,58 @@
+import type { ComponentDefinition, ComponentNode } from "@/types/editor";
+
+function collect(node: ComponentNode, acc: Record<string, ComponentNode>) {
+  acc[node.id] = node;
+  if (node.children) {
+    for (const c of node.children) collect(c, acc);
+  }
+}
+
+export function isCompatible(
+  a: ComponentDefinition,
+  b: ComponentDefinition,
+): boolean {
+  const mapA: Record<string, ComponentNode> = {};
+  const mapB: Record<string, ComponentNode> = {};
+  collect(a.root, mapA);
+  collect(b.root, mapB);
+  for (const id of Object.keys(mapA)) {
+    if (mapB[id] && mapB[id].type !== mapA[id].type) return false;
+  }
+  return true;
+}
+
+export function migrateOverrides(
+  overrides: Record<string, Partial<ComponentNode>> | undefined,
+  from: ComponentDefinition,
+  to: ComponentDefinition,
+): Record<string, Partial<ComponentNode>> | undefined {
+  if (!overrides) return undefined;
+  const mapFrom: Record<string, ComponentNode> = {};
+  const mapTo: Record<string, ComponentNode> = {};
+  collect(from.root, mapFrom);
+  collect(to.root, mapTo);
+  const res: Record<string, Partial<ComponentNode>> = {};
+  Object.entries(overrides).forEach(([id, patch]) => {
+    const src = mapFrom[id];
+    const dst = mapTo[id];
+    if (!src || !dst || src.type !== dst.type) return;
+    const out: Partial<ComponentNode> = {};
+    if ("text" in patch) (out as any).text = (patch as any).text;
+    if (patch.props) {
+      const props: any = {};
+      ["visible", "fill", "stroke", "color", "text"].forEach((k) => {
+        if (patch.props && (patch.props as any)[k] !== undefined)
+          props[k] = (patch.props as any)[k];
+      });
+      if (Object.keys(props).length) out.props = props;
+    }
+    if ((patch as any).style) {
+      const style: any = {};
+      if ((patch as any).style.color !== undefined)
+        style.color = (patch as any).style.color;
+      if (Object.keys(style).length) (out as any).style = style;
+    }
+    if (Object.keys(out).length) res[id] = out;
+  });
+  return Object.keys(res).length ? res : undefined;
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -30,6 +30,7 @@ import { initPersist, schedulePersist } from "@/lib/persist";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
 import { resolveVariant } from "@/lib/variantResolver";
 import { applyOverrides } from "@/lib/overrideMerge";
+import { migrateOverrides } from "@/lib/override/compat";
 import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
 import { reflectHandle } from "@/lib/vector/bezier";
 import { flattenPath } from "@/lib/vector/flatten";
@@ -94,6 +95,7 @@ interface EditorActions {
   createInstance: (componentId: string, pos?: { x: number; y: number }) => void;
   detachInstance: (nodeId: string) => void;
   swapInstance: (nodeId: string, nextComponentId: string) => void;
+  swapInstanceDef: (nodeId: string, newDefId: string) => void;
   // v3 additions
   align: (
     kind: "left" | "right" | "top" | "bottom" | "centerH" | "centerV",
@@ -651,6 +653,28 @@ export const useEditorStore = create<
               Object.entries(def.axes).forEach(([k, vals]) => {
                 if (!inst.variant![k]) inst.variant![k] = vals[0];
               });
+            }
+          });
+        },
+        swapInstanceDef(nodeId, newDefId) {
+          apply((draft) => {
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            if (!inst) return;
+            const prev = draft.components[inst.componentId];
+            const next = draft.components[newDefId];
+            if (!prev || !next) return;
+            inst.overrides = migrateOverrides(inst.overrides, prev, next);
+            inst.componentId = newDefId;
+            if (next?.axes) {
+              inst.variant = inst.variant || {};
+              Object.keys(inst.variant).forEach((k) => {
+                if (!next.axes || !next.axes[k]) delete inst.variant![k];
+              });
+              Object.entries(next.axes).forEach(([k, vals]) => {
+                if (!inst.variant![k]) inst.variant![k] = vals[0];
+              });
+            } else {
+              delete inst.variant;
             }
           });
         },


### PR DESCRIPTION
## Summary
- allow swapping an instance to another compatible component definition
- migrate text/visibility/color overrides during swaps
- add Instance swap control in the editor right pane

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8c660f90832c8c1ec710e3de7611