### PR TITLE
feat: add component panel search and usage counts

### DIFF
--- a/web/components/sidebar/ComponentsPanel.tsx
+++ b/web/components/sidebar/ComponentsPanel.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo, useState } from "react";
+import { useEditorStore } from "@/store/editorStore";
+
+type SortKey = "az" | "recent" | "usage";
+
+export default function ComponentsPanel() {
+  const components = useEditorStore((s) => s.components);
+  const createInstance = useEditorStore((s) => s.createInstance);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortKey>("az");
+
+  const items = useMemo(() => {
+    let list = Object.values(components);
+    if (query) {
+      const q = query.toLowerCase();
+      list = list.filter((c) => c.name.toLowerCase().includes(q));
+    }
+    list = list.slice();
+    switch (sort) {
+      case "recent":
+        list.sort((a, b) => (b.lastUsedAt || 0) - (a.lastUsedAt || 0));
+        break;
+      case "usage":
+        list.sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0));
+        break;
+      default:
+        list.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return list;
+  }, [components, query, sort]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-1 flex gap-1 items-center">
+        <input
+          className="border px-1 text-sm flex-1"
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <select
+          className="border text-xs"
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortKey)}
+        >
+          <option value="az">A-Z</option>
+          <option value="recent">Recent</option>
+          <option value="usage">Usage</option>
+        </select>
+      </div>
+      <div className="flex-1 overflow-auto">
+        {items.map((c) => (
+          <div
+            key={c.id}
+            className="p-1 border-b text-sm flex justify-between items-center cursor-pointer"
+            draggable
+            onDragStart={(e) => e.dataTransfer.setData("component", c.id)}
+            onDoubleClick={() => createInstance(c.id)}
+          >
+            <span>{c.name}</span>
+            <span className="text-xs opacity-70">{c.usageCount || 0}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -43,6 +43,23 @@ import { nanoid } from "nanoid";
 import { layoutText } from "@/lib/text/layout";
 import { applyRun, removeRun } from "@/lib/text/rangeOps";
 
+const updateUsageCounts = (draft: EditorState) => {
+  const counts: Record<string, number> = {};
+  const walk = (nodes: ComponentNode[]) => {
+    for (const n of nodes) {
+      if ((n as any).type === "Instance") {
+        const compId = (n as InstanceNode).componentId;
+        counts[compId] = (counts[compId] || 0) + 1;
+      }
+      if ((n as any).children) walk((n as any).children!);
+    }
+  };
+  walk(draft.tree);
+  Object.keys(draft.components).forEach((id) => {
+    draft.components[id].usageCount = counts[id] || 0;
+  });
+};
+
 interface EditorActions {
   select: (ids: string[] | ((prev: string[]) => string[])) => void;
   setHover: (id: string | null) => void;
@@ -391,15 +408,27 @@ export const useEditorStore = create<
         duplicate(ids) {
           apply((draft) => {
             const targets = ids ?? draft.selectedIds;
+            const touched = new Set<string>();
+            const collect = (n: ComponentNode) => {
+              if ((n as any).type === "Instance")
+                touched.add((n as InstanceNode).componentId);
+              if (n.children) n.children.forEach(collect);
+            };
             targets.forEach((id) => {
               const node = findNode(draft.tree, id);
               if (node) {
+                collect(node);
                 const copy: ComponentNode = JSON.parse(JSON.stringify(node));
                 copy.id = Math.random().toString(36).slice(2);
                 draft.tree.push(copy);
                 draft.selectedIds = [copy.id];
               }
             });
+            touched.forEach((cid) => {
+              const def = draft.components[cid];
+              if (def) def.lastUsedAt = Date.now();
+            });
+            updateUsageCounts(draft);
           });
         },
         remove(ids) {
@@ -413,6 +442,7 @@ export const useEditorStore = create<
               });
             draft.tree = removeRec(draft.tree);
             draft.selectedIds = [];
+            updateUsageCounts(draft);
           });
         },
         addImageAsset(meta) {
@@ -580,6 +610,8 @@ export const useEditorStore = create<
               id: compId,
               name: name || node.name || "Component",
               root: node,
+              usageCount: 0,
+              lastUsedAt: Date.now(),
             } as ComponentDefinition;
             const instId = Math.random().toString(36).slice(2);
             const instance: InstanceNode = {
@@ -591,6 +623,7 @@ export const useEditorStore = create<
             if (parent && parent.children) parent.children[index] = instance;
             else draft.tree[index] = instance;
             draft.selectedIds = [instId];
+            updateUsageCounts(draft);
           });
         },
         deleteComponent(componentId) {
@@ -606,7 +639,8 @@ export const useEditorStore = create<
         },
         createInstance(componentId, pos) {
           apply((draft) => {
-            if (!draft.components[componentId]) return;
+            const def = draft.components[componentId];
+            if (!def) return;
             const id = Math.random().toString(36).slice(2);
             const inst: InstanceNode = {
               id,
@@ -616,6 +650,8 @@ export const useEditorStore = create<
               overrides: {},
               props: { x: pos?.x || 0, y: pos?.y || 0 },
             };
+            def.usageCount = (def.usageCount || 0) + 1;
+            def.lastUsedAt = Date.now();
             draft.tree.push(inst);
             draft.selectedIds = [id];
           });
@@ -634,6 +670,7 @@ export const useEditorStore = create<
             if (res.parent && res.parent.children)
               res.parent.children[res.index] = resolved;
             else draft.tree[res.index] = resolved;
+            updateUsageCounts(draft);
           });
         },
         swapInstance(nodeId, nextComponentId) {
@@ -642,6 +679,7 @@ export const useEditorStore = create<
             if (!inst) return;
             inst.componentId = nextComponentId;
             const def = draft.components[nextComponentId];
+            if (def) def.lastUsedAt = Date.now();
             if (def?.axes) {
               inst.variant = inst.variant || {};
               // remove axes not in new component
@@ -652,6 +690,7 @@ export const useEditorStore = create<
                 if (!inst.variant![k]) inst.variant![k] = vals[0];
               });
             }
+            updateUsageCounts(draft);
           });
         },
         align(kind) {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -362,6 +362,9 @@ export interface ComponentDefinition {
   id: string;
   name: string;
   root: ComponentNode;
+  usageCount?: number;
+  /** timestamp of last instance placement */
+  lastUsedAt?: number;
   axes?: Record<string, string[]>;
   rules?: Array<{
     when: Record<string, string>;


### PR DESCRIPTION
## Summary
- add sidebar Components panel with search, sorting and usage counts
- track component usage in editor store with persistence
- extend component definitions with usage metadata

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8ca5a5dc832c85e053e2072733c9