### PR TITLE
feat: implement instance overrides

### DIFF
--- a/web/components/editor/InstanceView.tsx
+++ b/web/components/editor/InstanceView.tsx
@@ -1,8 +1,7 @@
 'use client';
-import type { InstanceNode, ComponentNode } from '@/types/editor';
-import { useEditorStore } from '@/store/editorStore';
-import { resolveVariant } from '@/lib/variantResolver';
-import { applyOverrides } from '@/lib/overrideMerge';
+import type { InstanceNode, ComponentNode } from '@/types/editor'
+import { useEditorStore } from '@/store/editorStore'
+import { resolveInstance } from '@/lib/override/resolve'
 
 interface InstanceViewProps {
   node: InstanceNode;
@@ -10,46 +9,30 @@ interface InstanceViewProps {
   render?: (node: ComponentNode, components: Record<string, any>) => React.ReactNode;
 }
 
-function defaultRender(node: ComponentNode, components: Record<string, any>): JSX.Element {
-  if (node.type === 'Instance') {
-    const inst = node as InstanceNode;
-    const def = components[inst.componentId];
-    if (def) {
-      let resolved = resolveVariant(def, inst.variant);
-      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
-      resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
-      return defaultRender(resolved, components);
-    }
-  }
+function defaultRender(node: ComponentNode, components: Record<string, any>): JSX.Element | null {
+  if ((node as any).hidden) return null
   const style: React.CSSProperties = {
     position: 'absolute',
     left: node.props?.x || 0,
     top: node.props?.y || 0,
     width: node.props?.w || 0,
     height: node.props?.h || 0,
-    transform: `rotate(${node.props?.rotation || 0}deg)`,
-  };
-  if (node.props?.visible === false) style.display = 'none';
+    transform: `rotate(${node.props?.rotation || 0}deg)`
+  }
+  if (node.props?.visible === false) style.display = 'none'
   return (
     <div key={node.id} style={style} className={node.props?.className}>
       {node.props?.text}
       {node.children?.map((c) => defaultRender(c, components))}
     </div>
-  );
+  )
 }
 
 export default function InstanceView({ node, components, render }: InstanceViewProps) {
-  const storeComponents = useEditorStore((s) => s.components);
-  const compMap = components || storeComponents;
-  const def = compMap[node.componentId];
-  if (!def) return null;
-
-  let resolved = resolveVariant(def, node.variant);
-  if (node.overrides) {
-    resolved = applyOverrides(resolved, node.overrides);
-  }
-  resolved.props = { ...(resolved.props || {}), ...(node.props || {}) };
-
-  const renderer = render || defaultRender;
-  return <>{renderer(resolved, compMap)}</>;
+  const state = useEditorStore.getState()
+  const resolved = resolveInstance(state as any, node)
+  if (!resolved) return null
+  const compMap = components || state.components
+  const renderer = render || defaultRender
+  return <>{renderer(resolved, compMap)}</>
 }

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,128 +1,244 @@
-  if (node && node.type === "Instance") {
-    const inst = node as InstanceNode;
-    const componentId = inst.componentId;
-    const component = useEditorStore((s) =>
-      componentId ? s.components[componentId] : undefined,
-    );
-    const components = useEditorStore((s) => s.components);
-    const swap = useEditorStore((s) => s.swapInstanceDef);
-    const clearAllOverrides = useEditorStore((s) => s.clearAllOverrides);
-    const addComponentProp = useEditorStore((s) => s.addComponentProp);
-    const setInstanceProp = useEditorStore((s) => s.setInstanceProp);
+"use client";
 
-    const handleAdd = () => {
-      const name = prompt("Prop name?");
-      if (!name) return;
-      const type =
-        (prompt(
-          "Type (boolean,text,number,color)",
-          "text",
-        ) as ComponentProp["type"]) || "text";
-      const id = nanoid();
-      const defVal =
-        type === "boolean"
-          ? false
-          : type === "number"
-          ? 0
-          : type === "color"
-          ? "#000000"
-          : "";
-      addComponentProp(inst.componentId, {
-        id,
-        name,
-        type,
-        default: defVal,
-      });
-    };
+import { useMemo, useState } from "react";
+import { nanoid } from "nanoid";
+import { useEditorStore } from "@/store/editorStore";
+import type { InstanceNode, ComponentProp } from "@/types/editor";
+import { isCompatible } from "@/lib/override/compat";
+import { listOverridable } from "@/lib/override/util";
+import { findNode } from "@/lib/tree";
 
-    const curr = components[inst.componentId];
-    const opts = Object.values(components).filter(
-      (c) => curr && isCompatible(curr, c),
-    );
+export default function RightPane() {
+  const selectedId = useEditorStore((s) => s.selectedIds[0]);
+  const node = useEditorStore((s) => findNode(s.tree, selectedId || ""));
+  if (!node || node.type !== "Instance") return null;
 
-    return (
-      <div className="bg-gray-800 p-2 space-y-4 text-xs">
-        {/* Props */}
-        {component && (
-          <div>
-            <div className="font-bold">Props</div>
-            {component.props?.map((p) => (
-              <div key={p.id} className="flex items-center gap-1">
-                <label className="flex-1">{p.name}</label>
-                {p.type === "boolean" ? (
-                  <input
-                    type="checkbox"
-                    checked={inst.propValues?.[p.id] ?? p.default ?? false}
-                    onChange={(e) =>
-                      setInstanceProp(inst.id, p.id, e.target.checked)
-                    }
-                  />
-                ) : p.type === "number" ? (
-                  <input
-                    type="number"
-                    className="w-full bg-gray-700 p-1 text-white"
-                    value={inst.propValues?.[p.id] ?? p.default ?? 0}
-                    onChange={(e) =>
-                      setInstanceProp(inst.id, p.id, Number(e.target.value))
-                    }
-                  />
-                ) : p.type === "color" ? (
-                  <input
-                    type="color"
-                    value={inst.propValues?.[p.id] ?? p.default ?? "#000000"}
-                    onChange={(e) =>
-                      setInstanceProp(inst.id, p.id, e.target.value)
-                    }
-                  />
-                ) : (
-                  <input
-                    type="text"
-                    className="w-full bg-gray-700 p-1 text-white"
-                    value={inst.propValues?.[p.id] ?? p.default ?? ""}
-                    onChange={(e) =>
-                      setInstanceProp(inst.id, p.id, e.target.value)
-                    }
-                  />
-                )}
-              </div>
-            ))}
-            <button className="p-1 bg-gray-700" onClick={handleAdd}>
-              + Prop
-            </button>
-          </div>
-        )}
+  const inst = node as InstanceNode;
+  const components = useEditorStore((s) => s.components);
+  const component = components[inst.defId || inst.componentId];
+  const swap = useEditorStore((s) => s.swapInstanceDef);
+  const addComponentProp = useEditorStore((s) => s.addComponentProp);
+  const setInstanceProp = useEditorStore((s) => s.setInstanceProp);
+  const setOverride = useEditorStore((s) => s.setOverride);
+  const clearOverride = useEditorStore((s) => s.clearOverride);
+  const clearAllOverrides = useEditorStore((s) => s.clearAllOverrides);
+  const tree = useEditorStore((s) => s.tree);
 
-        {/* Swap */}
+  const overrideTargets = useMemo(() => {
+    if (!component) return [] as { id: string; type: string; name?: string }[];
+    const root = findNode(tree, component.rootId);
+    return root ? listOverridable(root) : [];
+  }, [component, tree]);
+
+  const [targetId, setTargetId] = useState<string>(overrideTargets[0]?.id || "");
+
+  const curr = component;
+  const opts = Object.values(components).filter(
+    (c) => curr && isCompatible(curr, c),
+  );
+
+  const handleAdd = () => {
+    const name = prompt("Prop name?");
+    if (!name) return;
+    const type =
+      (prompt(
+        "Type (boolean,text,number,color)",
+        "text",
+      ) as ComponentProp["type"]) || "text";
+    const id = nanoid();
+    const defVal =
+      type === "boolean"
+        ? false
+        : type === "number"
+        ? 0
+        : type === "color"
+        ? "#000000"
+        : "";
+    addComponentProp(inst.defId || inst.componentId, {
+      id,
+      name,
+      type,
+      default: defVal,
+    });
+  };
+
+  const targetType = overrideTargets.find((o) => o.id === targetId)?.type;
+  const textVal = inst.overrides?.text?.[targetId]?.text || "";
+  const imageVal = inst.overrides?.image?.[targetId]?.assetId || "";
+  const visibleVal = !(inst.overrides?.visible?.[targetId] ?? false);
+  const colorVal = inst.overrides?.style?.[targetId]?.fill || "#000000";
+
+  return (
+    <div className="bg-gray-800 p-2 space-y-4 text-xs">
+      {component && (
         <div>
-          <div className="font-bold">Instance</div>
-          <label className="block">
-            Swap
+          <div className="font-bold">Props</div>
+          {component.props?.map((p) => (
+            <div key={p.id} className="flex items-center gap-1">
+              <label className="flex-1">{p.name}</label>
+              {p.type === "boolean" ? (
+                <input
+                  type="checkbox"
+                  checked={inst.propValues?.[p.id] ?? p.default ?? false}
+                  onChange={(e) =>
+                    setInstanceProp(inst.id, p.id, e.target.checked)
+                  }
+                />
+              ) : p.type === "number" ? (
+                <input
+                  type="number"
+                  className="w-full bg-gray-700 p-1 text-white"
+                  value={inst.propValues?.[p.id] ?? p.default ?? 0}
+                  onChange={(e) =>
+                    setInstanceProp(inst.id, p.id, Number(e.target.value))
+                  }
+                />
+              ) : p.type === "color" ? (
+                <input
+                  type="color"
+                  value={inst.propValues?.[p.id] ?? p.default ?? "#000000"}
+                  onChange={(e) =>
+                    setInstanceProp(inst.id, p.id, e.target.value)
+                  }
+                />
+              ) : (
+                <input
+                  type="text"
+                  className="w-full bg-gray-700 p-1 text-white"
+                  value={inst.propValues?.[p.id] ?? p.default ?? ""}
+                  onChange={(e) =>
+                    setInstanceProp(inst.id, p.id, e.target.value)
+                  }
+                />
+              )}
+            </div>
+          ))}
+          <button className="p-1 bg-gray-700" onClick={handleAdd}>
+            + Prop
+          </button>
+        </div>
+      )}
+
+      <div>
+        <div className="font-bold">Instance</div>
+        <label className="block">
+          Swap
+          <select
+            className="w-full bg-gray-700 p-1 text-white"
+            value={inst.defId || inst.componentId}
+            onChange={(e) => swap(inst.id, e.target.value)}
+          >
+            {opts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div>
+        <div className="font-bold flex items-center">
+          Overrides
+          <button
+            className="ml-auto px-1 bg-gray-700"
+            onClick={() => clearAllOverrides(inst.id)}
+          >
+            Reset All
+          </button>
+        </div>
+        {overrideTargets.length > 0 && (
+          <div className="space-y-1 mt-1">
             <select
               className="w-full bg-gray-700 p-1 text-white"
-              value={inst.componentId}
-              onChange={(e) => swap(inst.id, e.target.value)}
+              value={targetId}
+              onChange={(e) => setTargetId(e.target.value)}
             >
-              {opts.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
+              {overrideTargets.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.type}
+                  {o.name ? `: ${o.name}` : ""}
                 </option>
               ))}
             </select>
-          </label>
-        </div>
 
-        {/* Overrides */}
-        <div>
-          <div className="font-bold flex items-center">
-            Overrides
-            <button
-              className="ml-auto px-1 bg-gray-700"
-              onClick={() => clearAllOverrides(inst.id)}
-            >
-              Reset
-            </button>
+            {targetType === "Text" && (
+              <div className="flex items-center gap-1">
+                <input
+                  type="text"
+                  className="flex-1 bg-gray-700 p-1 text-white"
+                  value={textVal}
+                  onChange={(e) =>
+                    setOverride(inst.id, "text", targetId, { text: e.target.value })
+                  }
+                />
+                <button
+                  className="px-1 bg-gray-700"
+                  onClick={() => clearOverride(inst.id, "text", targetId)}
+                >
+                  Reset
+                </button>
+              </div>
+            )}
+
+            {targetType === "Image" && (
+              <div className="flex items-center gap-1">
+                <input
+                  type="text"
+                  className="flex-1 bg-gray-700 p-1 text-white"
+                  value={imageVal}
+                  onChange={(e) =>
+                    setOverride(inst.id, "image", targetId, {
+                      assetId: e.target.value,
+                    })
+                  }
+                />
+                <button
+                  className="px-1 bg-gray-700"
+                  onClick={() => clearOverride(inst.id, "image", targetId)}
+                >
+                  Reset
+                </button>
+              </div>
+            )}
+
+            <div className="flex items-center gap-1">
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={visibleVal}
+                  onChange={(e) =>
+                    setOverride(inst.id, "visible", targetId, !e.target.checked)
+                  }
+                />
+                Visible
+              </label>
+              <button
+                className="px-1 bg-gray-700"
+                onClick={() => clearOverride(inst.id, "visible", targetId)}
+              >
+                Reset
+              </button>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <input
+                type="color"
+                value={colorVal}
+                onChange={(e) =>
+                  setOverride(inst.id, "style", targetId, { fill: e.target.value })
+                }
+              />
+              <button
+                className="px-1 bg-gray-700"
+                onClick={() => clearOverride(inst.id, "style", targetId)}
+              >
+                Reset
+              </button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
-    );
-  }
+    </div>
+  );
+}

--- a/web/lib/override/resolve.ts
+++ b/web/lib/override/resolve.ts
@@ -1,51 +1,46 @@
-import type { ComponentNode, OverrideMap, TextNode, ImageNode } from '@/types/editor';
+import type { ComponentNode, EditorState, InstanceNode, OverrideMap } from '@/types/editor'
+import { deepCloneNodeTree, findNode } from '@/lib/tree'
 
-function findNode(node: ComponentNode, id: string): ComponentNode | null {
-  if (node.id === id) return node;
-  if (node.children) {
-    for (const c of node.children) {
-      const r = findNode(c, id);
-      if (r) return r;
+export function resolveOverrides(root: ComponentNode, overrides: OverrideMap = {}): ComponentNode {
+  const clone = deepCloneNodeTree(root)
+  const ov = overrides || {}
+
+  if (ov.visible) {
+    for (const [id, hidden] of Object.entries(ov.visible)) {
+      const n = findNode(clone, id)
+      if (n) (n as any).hidden = !!hidden
     }
   }
-  return null;
+  if (ov.text) {
+    for (const [id, v] of Object.entries(ov.text)) {
+      const n = findNode(clone, id)
+      if (n && (n as any).type === 'Text') (n as any).text = v.text
+    }
+  }
+  if (ov.image) {
+    for (const [id, v] of Object.entries(ov.image)) {
+      const n = findNode(clone, id)
+      if (n && (n as any).type === 'Image') (n as any).assetId = v.assetId
+    }
+  }
+  if (ov.style) {
+    for (const [id, s] of Object.entries(ov.style)) {
+      const n = findNode(clone, id)
+      if (n) Object.assign(((n as any).style ??= {}), s)
+    }
+  }
+  return clone
 }
 
-export function resolveOverrides(root: ComponentNode, overrides: OverrideMap): ComponentNode {
-  const clone: ComponentNode = JSON.parse(JSON.stringify(root));
-  if (!overrides) return clone;
-
-  if (overrides.text) {
-    Object.entries(overrides.text).forEach(([id, text]) => {
-      const n = findNode(clone, id);
-      if (n && n.type === 'Text') {
-        (n as TextNode).props = { ...(n.props || {}), text };
-      }
-    });
-  }
-  if (overrides.image) {
-    Object.entries(overrides.image).forEach(([id, assetId]) => {
-      const n = findNode(clone, id);
-      if (n && n.type === 'Image') {
-        (n as ImageNode).props = { ...(n.props || {}), assetId };
-      }
-    });
-  }
-  if (overrides.visible) {
-    Object.entries(overrides.visible).forEach(([id, hidden]) => {
-      const n = findNode(clone, id);
-      if (n) {
-        n.props = { ...(n.props || {}), visible: !hidden };
-      }
-    });
-  }
-  if (overrides.style) {
-    Object.entries(overrides.style).forEach(([id, style]) => {
-      const n = findNode(clone, id);
-      if (n) {
-        n.props = { ...(n.props || {}), ...style } as any;
-      }
-    });
-  }
-  return clone;
+export function resolveInstance(state: EditorState, inst: InstanceNode): ComponentNode | null {
+  const def = state.components[inst.defId || (inst as any).componentId]
+  if (!def) return null
+  const baseRoot = findNode(state.tree, def.rootId)
+  if (!baseRoot) return null
+  let root = deepCloneNodeTree(baseRoot)
+  if (inst.overrides) root = resolveOverrides(root, inst.overrides)
+  ;(root as any).props = { ...(root as any).props, ...(inst as any).props }
+  ;(root as any).opacity = (inst as any).opacity ?? (root as any).opacity
+  ;(root as any).r = (inst as any).r ?? (root as any).r
+  return root
 }

--- a/web/lib/override/util.ts
+++ b/web/lib/override/util.ts
@@ -1,0 +1,13 @@
+import type { ComponentNode } from '@/types/editor'
+
+export function listOverridable(root: ComponentNode): { id: string; type: string; name?: string }[] {
+  const out: { id: string; type: string; name?: string }[] = []
+  const walk = (n: ComponentNode) => {
+    if (['Text', 'Image', 'Path', 'Frame'].includes(n.type)) {
+      out.push({ id: n.id, type: n.type, name: n.name })
+    }
+    ;(n.children || []).forEach((c) => walk(c))
+  }
+  walk(root)
+  return out
+}

--- a/web/lib/tree.ts
+++ b/web/lib/tree.ts
@@ -1,0 +1,24 @@
+import type { ComponentNode } from '@/types/editor'
+
+export function findNode(nodes: ComponentNode[] | ComponentNode | undefined, id: string): ComponentNode | null {
+  if (!nodes) return null
+  if (Array.isArray(nodes)) {
+    for (const n of nodes) {
+      const r = findNode(n, id)
+      if (r) return r
+    }
+    return null
+  }
+  if (nodes.id === id) return nodes
+  if (nodes.children) {
+    for (const c of nodes.children) {
+      const r = findNode(c, id)
+      if (r) return r
+    }
+  }
+  return null
+}
+
+export function deepCloneNodeTree<T extends ComponentNode>(node: T): T {
+  return JSON.parse(JSON.stringify(node)) as T
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -27,6 +27,7 @@ import type {
   ComponentProp,
   VariantSet,
   VariantProps,
+  OverrideMap,
 } from "@/types/editor";
 import { idbStorage } from "@/lib/idb";
 import { initPersist, schedulePersist } from "@/lib/persist";
@@ -187,8 +188,17 @@ interface EditorActions {
     props: VariantProps,
   ) => void;
   // Overrides
-  setOverride: (nodeId: string, path: string, value: any) => void;
-  clearOverride: (nodeId: string, path: string) => void;
+  setOverride: (
+    nodeId: string,
+    kind: keyof OverrideMap,
+    targetNodeId: string,
+    payload: any,
+  ) => void;
+  clearOverride: (
+    nodeId: string,
+    kind: keyof OverrideMap,
+    targetNodeId: string,
+  ) => void;
   clearAllOverrides: (nodeId: string) => void;
   // v5 comments and review
   startPinAnnotation: () => void;
@@ -1076,56 +1086,32 @@ swapInstanceDef(nodeId, newDefId) {
             }
           });
         },
-        setOverride(nodeId, path, value) {
+        setOverride(nodeId, kind, targetNodeId, payload) {
           apply((draft) => {
-            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
-            if (!inst) return;
-            inst.overrides = inst.overrides || ({} as any);
-            const parts = path.split(".");
-            let obj: any = inst.overrides;
-            for (let i = 0; i < parts.length - 1; i++) {
-              const k = parts[i];
-              obj[k] = obj[k] || {};
-              obj = obj[k];
-            }
-            obj[parts[parts.length - 1]] = value;
-          });
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null
+            if (!inst) return
+            ;(inst.overrides ||= {} as any)
+            const bucket: any = (inst.overrides as any)[kind] || {}
+            bucket[targetNodeId] = payload
+            ;(inst.overrides as any)[kind] = bucket
+          })
         },
-
+        clearOverride(nodeId, kind, targetNodeId) {
           apply((draft) => {
-            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
-            if (!inst) return;
-            inst.overrides = inst.overrides || {} as any;
-            const parts = path.split('.');
-            let obj: any = inst.overrides;
-            for (let i = 0; i < parts.length - 1; i++) {
-              const k = parts[i];
-              obj[k] = obj[k] || {};
-              obj = obj[k];
-            }
-            obj[parts[parts.length - 1]] = value;
-          });
-        },
-        clearOverride(nodeId, path) {
-          apply((draft) => {
-            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
-            if (!inst || !inst.overrides) return;
-            const parts = path.split('.');
-            let obj: any = inst.overrides;
-            for (let i = 0; i < parts.length - 1; i++) {
-              const k = parts[i];
-              if (!obj[k]) return;
-              obj = obj[k];
-            }
-            delete obj[parts[parts.length - 1]];
-          });
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null
+            if (!inst || !inst.overrides) return
+            const bucket: any = (inst.overrides as any)[kind]
+            if (!bucket) return
+            delete bucket[targetNodeId]
+            if (Object.keys(bucket).length === 0) delete (inst.overrides as any)[kind]
+          })
         },
         clearAllOverrides(nodeId) {
           apply((draft) => {
-            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
-            if (!inst) return;
-            inst.overrides = {};
-          });
+            const inst = findNode(draft.tree, nodeId) as InstanceNode | null
+            if (!inst) return
+            inst.overrides = {}
+          })
         },
         // --- v5 comments & review ---
         startPinAnnotation() {

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -406,10 +406,15 @@ export interface ComponentDefinition {
 export type ComponentDef = ComponentDefinition;
 
 // Simple override map (details to be defined in later versions)
-export type OverrideMap = Record<string, unknown>;
+export type OverrideMap = {
+  text?: Record<string, { text: string }>;
+  image?: Record<string, { assetId: string }>;
+  visible?: Record<string, boolean>;
+  style?: Record<string, { fill?: string; stroke?: string; opacity?: number }>;
+};
 
-export interface InstanceNode extends ComponentNode {
-  type: "Instance";
+export interface InstanceNode extends FrameNode {
+  type: 'Instance';
   /** component definition id */
   defId: string;
   /** legacy alias */


### PR DESCRIPTION
## Summary
- support structured override maps on instances
- apply overrides when rendering and expose override editing UI
- add utilities for resolving and enumerating overridable nodes

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aacb07949c832cbca50a7450a8e175