### PR TITLE
feat: scaffold variant infrastructure

### DIFF
--- a/web/lib/variant/resolve.ts
+++ b/web/lib/variant/resolve.ts
@@ -1,0 +1,21 @@
+import { EditorState, InstanceNode, VariantDef } from '@/types/editor'
+import { findNode } from '@/lib/tree'
+
+export function resolveVariantRoot(state:EditorState, inst:InstanceNode){
+  const def = state.components[inst.defId]
+  if(!def) return null
+  const set = def.variantSetId ? state.variantSets?.[def.variantSetId] : null
+  if(!set) return findNode(state.tree, def.rootId)
+  const props = inst.variantProps || {}
+  let best: {score:number; v:VariantDef}|null = null
+  for(const v of set.variants){
+    let score = 0; let ok = true
+    for(const [k,val] of Object.entries(v.props)){
+      if(props[k]===undefined){ ok = false; break }
+      if(props[k]===val) score+=2; else ok=false
+    }
+    if(ok && (!best || score>best.score)) best = {score, v}
+  }
+  const rootId = best?.v.rootId ?? def.rootId
+  return findNode(state.tree, rootId)
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -26,14 +26,13 @@ import type {
   TextRun,
   ComponentProp,
   VariantSet,
-  VariantProps,
+  VariantPropDef,
   OverrideMap,
 } from "@/types/editor";
 import { idbStorage } from "@/lib/idb";
 import { initPersist, schedulePersist } from "@/lib/persist";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
-import { resolveVariant } from "@/lib/variantResolver";
-import { applyOverrides } from "@/lib/overrideMerge";
+import { resolveVariantRoot } from "@/lib/variant/resolve";
 import { resolveBinding } from "@/lib/binding/resolve";
 import { migrateOverrides } from "@/lib/override/compat";
 import { resolveOverrides } from "@/lib/override/resolve";
@@ -167,25 +166,15 @@ interface EditorActions {
   logDev: (entry: { ts: number; type: string; payload: any }) => void;
   clearDevLog: () => void;
   // Variants
-  createVariantSet: (componentId: string, set: VariantSet) => void;
-  defineVariantAxis: (
-    componentId: string,
-    axis: string,
-    values: string[],
-  ) => void;
-  setVariantRule: (
-    componentId: string,
-    rule: {
-      when: Record<string, string>;
-      node: string;
-      patch: Partial<ComponentNode>;
-    },
-  ) => void;
-  removeVariantRule: (componentId: string, index: number) => void;
-  setInstanceVariant: (nodeId: string, axis: string, value: string) => void;
+  createVariantSet: (defId: string, propDefs: VariantPropDef[]) => string;
+  addVariant: (
+    setId: string,
+    v: { name: string; props: Record<string, string | number | boolean>; rootId: string },
+  ) => string;
+  renameVariant: (setId: string, varId: string, name: string) => void;
   setInstanceVariantProps: (
-    nodeId: string,
-    props: VariantProps,
+    instId: string,
+    patch: Record<string, string | number | boolean>,
   ) => void;
   // Overrides
   setOverride: (
@@ -1028,60 +1017,48 @@ swapInstanceDef(nodeId, newDefId) {
           const y2 = Math.max(...boxes.map((b) => b.y + b.h));
           return { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
         },
-        createVariantSet(componentId, set) {
+        createVariantSet(defId, propDefs) {
+          const id = nanoid();
           apply((draft) => {
-            const c = draft.components[componentId];
-            if (!c) return;
-            c.variantSet = set;
+            draft.variantSets[id] = { id, defId, propDefs, variants: [] } as VariantSet;
+            const c = draft.components[defId];
+            if (c) c.variantSetId = id;
+          });
+          return id;
+        },
+        addVariant(setId, v) {
+          const id = nanoid();
+          apply((draft) => {
+            const set = draft.variantSets[setId];
+            if (!set) return;
+            set.variants.push({ id, name: v.name, props: v.props, rootId: v.rootId });
+          });
+          return id;
+        },
+        renameVariant(setId, varId, name) {
+          apply((draft) => {
+            const set = draft.variantSets[setId];
+            const vr = set?.variants.find((vv) => vv.id === varId);
+            if (vr) vr.name = name;
           });
         },
-        defineVariantAxis(componentId, axis, values) {
+        setInstanceVariantProps(instId, patch) {
           apply((draft) => {
-            const c = draft.components[componentId];
-            if (!c) return;
-            c.axes = c.axes || {};
-            c.axes[axis] = values;
-          });
-        },
-        setVariantRule(componentId, rule) {
-          apply((draft) => {
-            const c = draft.components[componentId];
-            if (!c) return;
-            c.rules = c.rules || [];
-            c.rules.push(rule);
-          });
-        },
-        removeVariantRule(componentId, index) {
-          apply((draft) => {
-            const c = draft.components[componentId];
-            if (c?.rules) c.rules.splice(index, 1);
-          });
-        },
-        setInstanceVariant(nodeId, axis, value) {
-          apply((draft) => {
-            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
+            const inst = findNode(draft.tree, instId) as InstanceNode | null;
             if (!inst) return;
-            inst.variant = inst.variant || {};
-            inst.variant[axis] = value;
-          });
-        },
-        setInstanceVariantProps(nodeId, props) {
-          apply((draft) => {
-            const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
-            if (!inst) return;
-            inst.variant = { ...(inst.variant || {}), ...props };
-            const def = draft.components[inst.componentId];
-            if (def) {
-              const root = resolveVariant(def, inst.variant);
-              if (inst.overrides) {
-                const ids = new Set<string>();
-                (function collect(n: ComponentNode) {
-                  ids.add(n.id);
-                  n.children?.forEach(collect);
-                })(root);
-                Object.keys(inst.overrides).forEach((id) => {
-                  if (!ids.has(id)) delete inst.overrides![id];
-                });
+            inst.variantProps = { ...(inst.variantProps || {}), ...patch };
+            const root = resolveVariantRoot(draft as EditorState, inst);
+            if (inst.overrides && root) {
+              const ids = new Set<string>();
+              (function collect(n: ComponentNode) {
+                ids.add(n.id);
+                n.children?.forEach(collect);
+              })(root);
+              for (const bucket of Object.values(inst.overrides)) {
+                if (!bucket) continue;
+                for (const id of Object.keys(bucket as any)) {
+                  if (!ids.has(id)) delete (bucket as any)[id];
+                }
               }
             }
           });

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -358,6 +358,7 @@ export interface EditorState {
     draft?: { anchor?: Anchor; text?: string };
     filter?: { status?: ThreadStatus[]; onlySelection?: boolean };
   };
+  variantSets: Record<string, VariantSet>;
 }
 
 // Component Props (ユーザー定義プロパティ)
@@ -369,17 +370,27 @@ export interface ComponentProp {
 }
 
 // Variant Props & Definitions
-export type VariantProps = Record<string, string>;
+export type VariantPropType = 'TEXT' | 'BOOLEAN' | 'NUMBER' | 'ENUM'
+
+export interface VariantPropDef {
+  name: string
+  type: VariantPropType
+  options?: string[]
+  default?: string | number | boolean
+}
 
 export interface VariantDef {
-  id: string;
-  props: VariantProps;
-  root: ComponentNode;
+  id: string
+  name: string
+  props: Record<string, string | number | boolean>
+  rootId: string
 }
 
 export interface VariantSet {
-  props: Record<string, string[]>;
-  defs: VariantDef[];
+  id: string
+  defId: string
+  propDefs: VariantPropDef[]
+  variants: VariantDef[]
 }
 
 export interface ComponentDefinition {
@@ -401,7 +412,7 @@ export interface ComponentDefinition {
     node: string;
     patch: Partial<ComponentNode>;
   }>;
-  variantSet?: VariantSet; // variant 設定
+  variantSetId?: string; // variant 設定
 }
 export type ComponentDef = ComponentDefinition;
 
@@ -419,7 +430,7 @@ export interface InstanceNode extends FrameNode {
   defId: string;
   /** legacy alias */
   componentId?: string;
-  variant?: VariantProps; // バリアント
+  variantProps?: Record<string, string | number | boolean>; // バリアント
   overrides?: OverrideMap; // オーバーライド
   propValues?: Record<string, any>; // ComponentProp の値
 }


### PR DESCRIPTION
## Summary
- add types for variant props and sets
- introduce resolver to pick variant root by props
- wire store with basic variant set CRUD

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aacd0a9328832cb2f94160298a22be