### PR TITLE
feat: swap instance definition with variant and override mapping

### DIFF
--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { nanoid } from "nanoid";
 import { useEditorStore } from "@/store/editorStore";
-import type { InstanceNode, ComponentProp } from "@/types/editor";
-import { isCompatible } from "@/lib/override/compat";
+import type { InstanceNode, ComponentProp, VariantPropDef } from "@/types/editor";
+import { mapNodesForSwap } from "@/lib/override/compat";
 import { listOverridable } from "@/lib/override/util";
 import { findNode } from "@/lib/tree";
 
@@ -31,11 +31,38 @@ export default function RightPane() {
   }, [component, tree]);
 
   const [targetId, setTargetId] = useState<string>(overrideTargets[0]?.id || "");
+  const [swapId, setSwapId] = useState(inst.defId || inst.componentId);
+  const [variantProps, setVariantProps] = useState<Record<string, any>>({});
+  const variantSets = useEditorStore((s) => s.variantSets);
 
   const curr = component;
-  const opts = Object.values(components).filter(
-    (c) => curr && isCompatible(curr, c),
-  );
+  const opts = useMemo(() => {
+    if (!curr) return [] as typeof components[keyof typeof components][];
+    const state = useEditorStore.getState();
+    return Object.values(components).filter((c) =>
+      mapNodesForSwap(state, curr.rootId, c.rootId).ok,
+    );
+  }, [components, curr]);
+
+  const currSet = curr?.variantSetId ? variantSets[curr.variantSetId] : null;
+  const nextDef = components[swapId];
+  const nextSet = nextDef?.variantSetId
+    ? variantSets[nextDef.variantSetId]
+    : null;
+  const sharedPropDefs = useMemo<VariantPropDef[]>(() => {
+    if (!currSet || !nextSet) return [];
+    const currNames = new Set(currSet.propDefs.map((p) => p.name));
+    return nextSet.propDefs.filter((p) => currNames.has(p.name));
+  }, [currSet, nextSet]);
+  useEffect(() => {
+    const next: Record<string, any> = {};
+    sharedPropDefs.forEach((p) => {
+      if (inst.variantProps && inst.variantProps[p.name] !== undefined)
+        next[p.name] = inst.variantProps[p.name];
+      else if (p.default !== undefined) next[p.name] = p.default;
+    });
+    setVariantProps(next);
+  }, [swapId, inst.variantProps, sharedPropDefs]);
 
   const handleAdd = () => {
     const name = prompt("Prop name?");
@@ -120,21 +147,78 @@ export default function RightPane() {
       )}
 
       <div>
-        <div className="font-bold">Instance</div>
-        <label className="block">
-          Swap
-          <select
-            className="w-full bg-gray-700 p-1 text-white"
-            value={inst.defId || inst.componentId}
-            onChange={(e) => swap(inst.id, e.target.value)}
-          >
-            {opts.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
+        <div className="font-bold">Swap</div>
+        <select
+          className="w-full bg-gray-700 p-1 text-white"
+          value={swapId}
+          onChange={(e) => setSwapId(e.target.value)}
+        >
+          {opts.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        {sharedPropDefs.length > 0 && (
+          <div className="mt-1 space-y-1">
+            {sharedPropDefs.map((p) => (
+              <label key={p.name} className="block">
+                {p.name}
+                {p.type === 'BOOLEAN' ? (
+                  <input
+                    type="checkbox"
+                    className="ml-1"
+                    checked={!!variantProps[p.name]}
+                    onChange={(e) =>
+                      setVariantProps({ ...variantProps, [p.name]: e.target.checked })
+                    }
+                  />
+                ) : p.type === 'NUMBER' ? (
+                  <input
+                    type="number"
+                    className="w-full bg-gray-700 p-1 text-white"
+                    value={variantProps[p.name] ?? ''}
+                    onChange={(e) =>
+                      setVariantProps({
+                        ...variantProps,
+                        [p.name]: Number(e.target.value),
+                      })
+                    }
+                  />
+                ) : p.type === 'ENUM' && p.options ? (
+                  <select
+                    className="w-full bg-gray-700 p-1 text-white"
+                    value={variantProps[p.name] ?? ''}
+                    onChange={(e) =>
+                      setVariantProps({ ...variantProps, [p.name]: e.target.value })
+                    }
+                  >
+                    {p.options.map((o) => (
+                      <option key={o} value={o}>
+                        {o}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    className="w-full bg-gray-700 p-1 text-white"
+                    value={variantProps[p.name] ?? ''}
+                    onChange={(e) =>
+                      setVariantProps({ ...variantProps, [p.name]: e.target.value })
+                    }
+                  />
+                )}
+              </label>
             ))}
-          </select>
-        </label>
+          </div>
+        )}
+        <button
+          className="mt-1 px-1 bg-gray-700"
+          onClick={() => swap(inst.id, swapId, { variantProps })}
+        >
+          Swap
+        </button>
       </div>
 
       <div>

--- a/web/lib/override/compat.ts
+++ b/web/lib/override/compat.ts
@@ -1,58 +1,62 @@
-import type { ComponentDefinition, ComponentNode } from "@/types/editor";
+import { EditorState, ComponentNode } from '@/types/editor'
+import { findNode } from '@/lib/tree'
 
-function collect(node: ComponentNode, acc: Record<string, ComponentNode>) {
-  acc[node.id] = node;
-  if (node.children) {
-    for (const c of node.children) collect(c, acc);
+export interface CompatReport {
+  ok: boolean
+  reason?: string
+  map: Record<string, string>
+}
+
+/**
+ * Build mapping from old node ids to new node ids based on stableKey or name.
+ */
+export function mapNodesForSwap(
+  state: EditorState,
+  oldRootId: string,
+  newRootId: string,
+): CompatReport {
+  const oldRoot = findNode(state.tree, oldRootId) as any
+  const newRoot = findNode(state.tree, newRootId) as any
+  if (!oldRoot || !newRoot) return { ok: false, reason: 'root missing', map: {} }
+
+  const map: Record<string, string> = {}
+  const indexByKey = new Map<string, string>() // key -> newId
+  const indexByName = new Map<string, string[]>() // name -> newIds
+
+  const walk = (n: ComponentNode | undefined) => {
+    if (!n) return
+    const key = (n as any).stableKey
+    if (key) indexByKey.set(key, n.id)
+    if (n.name) {
+      const arr = indexByName.get(n.name) || []
+      arr.push(n.id)
+      indexByName.set(n.name, arr)
+    }
+    for (const c of n.children || []) walk(c as any)
   }
+  walk(newRoot)
+
+  const walkOld = (n: ComponentNode | undefined) => {
+    if (!n) return
+    let target: string | undefined
+    const key = (n as any).stableKey
+    if (key) target = indexByKey.get(key)
+    if (!target && n.name) {
+      const arr = indexByName.get(n.name)
+      if (arr && arr.length) target = arr.shift()
+    }
+    if (target) map[n.id] = target
+    for (const c of n.children || []) walkOld(c as any)
+  }
+  walkOld(oldRoot)
+
+  return { ok: true, map }
 }
 
 export function isCompatible(
-  a: ComponentDefinition,
-  b: ComponentDefinition,
+  state: EditorState,
+  oldRootId: string,
+  newRootId: string,
 ): boolean {
-  const mapA: Record<string, ComponentNode> = {};
-  const mapB: Record<string, ComponentNode> = {};
-  collect(a.root, mapA);
-  collect(b.root, mapB);
-  for (const id of Object.keys(mapA)) {
-    if (mapB[id] && mapB[id].type !== mapA[id].type) return false;
-  }
-  return true;
-}
-
-export function migrateOverrides(
-  overrides: Record<string, Partial<ComponentNode>> | undefined,
-  from: ComponentDefinition,
-  to: ComponentDefinition,
-): Record<string, Partial<ComponentNode>> | undefined {
-  if (!overrides) return undefined;
-  const mapFrom: Record<string, ComponentNode> = {};
-  const mapTo: Record<string, ComponentNode> = {};
-  collect(from.root, mapFrom);
-  collect(to.root, mapTo);
-  const res: Record<string, Partial<ComponentNode>> = {};
-  Object.entries(overrides).forEach(([id, patch]) => {
-    const src = mapFrom[id];
-    const dst = mapTo[id];
-    if (!src || !dst || src.type !== dst.type) return;
-    const out: Partial<ComponentNode> = {};
-    if ("text" in patch) (out as any).text = (patch as any).text;
-    if (patch.props) {
-      const props: any = {};
-      ["visible", "fill", "stroke", "color", "text"].forEach((k) => {
-        if (patch.props && (patch.props as any)[k] !== undefined)
-          props[k] = (patch.props as any)[k];
-      });
-      if (Object.keys(props).length) out.props = props;
-    }
-    if ((patch as any).style) {
-      const style: any = {};
-      if ((patch as any).style.color !== undefined)
-        style.color = (patch as any).style.color;
-      if (Object.keys(style).length) (out as any).style = style;
-    }
-    if (Object.keys(out).length) res[id] = out;
-  });
-  return Object.keys(res).length ? res : undefined;
+  return mapNodesForSwap(state, oldRootId, newRootId).ok
 }

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -34,7 +34,7 @@ import { initPersist, schedulePersist } from "@/lib/persist";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
 import { resolveVariantRoot } from "@/lib/variant/resolve";
 import { resolveBinding } from "@/lib/binding/resolve";
-import { migrateOverrides } from "@/lib/override/compat";
+import { mapNodesForSwap } from "@/lib/override/compat";
 import { resolveOverrides } from "@/lib/override/resolve";
 import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
 import { reflectHandle } from "@/lib/vector/bezier";
@@ -123,7 +123,11 @@ interface EditorActions {
   addComponentProp: (componentId: string, prop: ComponentProp) => void;
   setInstanceProp: (nodeId: string, propId: string, value: any) => void;
   // Instance Swap (new API)
-  swapInstanceDef: (nodeId: string, newDefId: string) => void;
+  swapInstanceDef: (
+    nodeId: string,
+    newDefId: string,
+    opts?: { variantProps?: Record<string, any> },
+  ) => void;
 }
 
   // v3 additions
@@ -796,27 +800,57 @@ setInstanceProp(nodeId, propId, value) {
   });
 },
 
-swapInstanceDef(nodeId, newDefId) {
+swapInstanceDef(nodeId, newDefId, opts) {
   apply((draft) => {
     const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
     if (!inst) return;
-    const prev = draft.components[inst.componentId];
-    const next = draft.components[newDefId];
-    if (!prev || !next) return;
-    inst.overrides = migrateOverrides(inst.overrides, prev, next);
-    inst.componentId = newDefId;
+    const prevDef = draft.components[inst.defId || inst.componentId];
+    const nextDef = draft.components[newDefId];
+    if (!prevDef || !nextDef) return;
 
-    if (next?.axes) {
-      inst.variant = inst.variant || {};
-      Object.keys(inst.variant).forEach((k) => {
-        if (!next.axes || !next.axes[k]) delete inst.variant![k];
-      });
-      Object.entries(next.axes).forEach(([k, vals]) => {
-        if (!inst.variant![k]) inst.variant![k] = vals[0];
-      });
-    } else {
-      delete inst.variant;
+    const { map } = mapNodesForSwap(draft, prevDef.rootId, nextDef.rootId);
+
+    if (inst.overrides) {
+      const mapped: OverrideMap = {};
+      (['text', 'image', 'visible', 'style'] as (keyof OverrideMap)[]).forEach(
+        (kind) => {
+          const src = inst.overrides![kind];
+          if (!src) return;
+          Object.entries(src).forEach(([id, payload]) => {
+            const targetId = map[id];
+            if (!targetId) return;
+            if (!mapped[kind]) mapped[kind] = {} as any;
+            (mapped[kind] as any)[targetId] = payload;
+          });
+        },
+      );
+      inst.overrides = Object.keys(mapped).length ? mapped : undefined;
     }
+
+    let vProps: Record<string, any> | undefined = undefined;
+    if (nextDef.variantSetId) {
+      const set = draft.variantSets[nextDef.variantSetId];
+      if (set) {
+        vProps = {};
+        const names = set.propDefs.map((p) => p.name);
+        names.forEach((name) => {
+          if (inst.variantProps && inst.variantProps[name] !== undefined) {
+            vProps![name] = inst.variantProps[name];
+          }
+        });
+        if (opts?.variantProps) {
+          Object.entries(opts.variantProps).forEach(([k, v]) => {
+            if (names.includes(k)) vProps![k] = v;
+          });
+        }
+        if (!Object.keys(vProps).length) vProps = undefined;
+      }
+    }
+    if (vProps) inst.variantProps = vProps;
+    else delete inst.variantProps;
+
+    inst.defId = newDefId;
+    inst.componentId = newDefId;
   });
 },
 

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -260,6 +260,8 @@ export interface ComponentNode {
   id: string;
   type: string; // 'Frame' | 'Rect' | 'Text' | 'Instance' etc
   name?: string;
+  /** Stable identifier for swap/override mapping */
+  stableKey?: string;
   props?: {
     x?: number;
     y?: number;


### PR DESCRIPTION
## Summary
- add `stableKey` to component nodes for reliable mapping
- map nodes by key/name to migrate overrides during instance swaps
- support swapping instances with variant prop carryover and UI controls

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aaced73df0832c9f43048c524e32b1