### PR TITLE
chore: update usage stats after instance swap

### DIFF
--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -851,6 +851,10 @@ swapInstanceDef(nodeId, newDefId, opts) {
 
     inst.defId = newDefId;
     inst.componentId = newDefId;
+
+    // bump usage counts and last used timestamp for components
+    nextDef.lastUsedAt = Date.now();
+    updateUsageCounts(draft);
   });
 },
 


### PR DESCRIPTION
## Summary
- update swapInstanceDef to bump usage counts and last used timestamp after swapping an instance's definition

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aad09c2a48832c82db609a20817c14