### PR TITLE
feat: support component props with binding

### DIFF
--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -18,8 +18,9 @@ function renderNode(
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
+      if (inst.propValues)
+        resolved = resolveBinding(resolved, def.props, inst.propValues || {});
       if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
-      if (inst.propValues) resolved = resolveBinding(resolved, inst.propValues);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
       return renderNode(resolved, components);
     }

--- a/web/app/s/[id]/page.tsx
+++ b/web/app/s/[id]/page.tsx
@@ -14,8 +14,9 @@ function renderNode(node: ComponentNode, components: Record<string, any>): JSX.E
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
+      if (inst.propValues)
+        resolved = resolveBinding(resolved, def.props, inst.propValues || {});
       if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
-      if (inst.propValues) resolved = resolveBinding(resolved, inst.propValues);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
       return renderNode(resolved, components);
     }

--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -47,9 +47,9 @@ function NodeView({
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
-      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
       if (inst.propValues)
-        resolved = resolveBinding(resolved, inst.propValues);
+        resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+      if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
       return (
         <NodeView

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -85,7 +85,7 @@ export default function RightPane() {
       id,
       name,
       type,
-      default: defVal,
+      defaultValue: defVal,
     });
   };
 
@@ -106,7 +106,7 @@ export default function RightPane() {
               {p.type === "boolean" ? (
                 <input
                   type="checkbox"
-                  checked={inst.propValues?.[p.id] ?? p.default ?? false}
+                  checked={inst.propValues?.[p.id] ?? p.defaultValue ?? false}
                   onChange={(e) =>
                     setInstanceProp(inst.id, p.id, e.target.checked)
                   }
@@ -115,7 +115,7 @@ export default function RightPane() {
                 <input
                   type="number"
                   className="w-full bg-gray-700 p-1 text-white"
-                  value={inst.propValues?.[p.id] ?? p.default ?? 0}
+                  value={inst.propValues?.[p.id] ?? p.defaultValue ?? 0}
                   onChange={(e) =>
                     setInstanceProp(inst.id, p.id, Number(e.target.value))
                   }
@@ -123,7 +123,7 @@ export default function RightPane() {
               ) : p.type === "color" ? (
                 <input
                   type="color"
-                  value={inst.propValues?.[p.id] ?? p.default ?? "#000000"}
+                  value={inst.propValues?.[p.id] ?? p.defaultValue ?? "#000000"}
                   onChange={(e) =>
                     setInstanceProp(inst.id, p.id, e.target.value)
                   }
@@ -132,7 +132,7 @@ export default function RightPane() {
                 <input
                   type="text"
                   className="w-full bg-gray-700 p-1 text-white"
-                  value={inst.propValues?.[p.id] ?? p.default ?? ""}
+                  value={inst.propValues?.[p.id] ?? p.defaultValue ?? ""}
                   onChange={(e) =>
                     setInstanceProp(inst.id, p.id, e.target.value)
                   }

--- a/web/lib/binding/resolve.ts
+++ b/web/lib/binding/resolve.ts
@@ -1,32 +1,29 @@
-import type { ComponentNode } from '@/types/editor';
+import type { ComponentNode, ComponentProp } from '@/types/editor'
 
+// Apply component prop values to the cloned node tree
 export function resolveBinding(
   root: ComponentNode,
-  props: Record<string, any> = {}
+  props: ComponentProp[] | undefined,
+  values: Record<string, any> = {},
 ): ComponentNode {
-  const clone: ComponentNode = JSON.parse(JSON.stringify(root));
-  const apply = (node: any) => {
-    if (node.bindings) {
-      Object.entries(node.bindings).forEach(([key, b]: any) => {
-        try {
-          const fn = new Function('props', `return (${b.expr});`);
-          const val = fn(props);
-          if (key === 'text') node.text = val;
-          else if (key === 'visible')
-            node.props = { ...(node.props || {}), visible: val };
-          else node.props = { ...(node.props || {}), [key]: val };
-        } catch (e) {
-          if (b.fallback !== undefined) {
-            if (key === 'text') node.text = b.fallback;
-            else if (key === 'visible')
-              node.props = { ...(node.props || {}), visible: b.fallback };
-            else node.props = { ...(node.props || {}), [key]: b.fallback };
-          }
-        }
-      });
-    }
-    if (node.children) node.children.forEach(apply);
-  };
-  apply(clone);
-  return clone;
+  const clone: ComponentNode = JSON.parse(JSON.stringify(root))
+  if (!props) return clone
+  for (const p of props) {
+    if (!p.targetPath) continue
+    const val = values[p.id] ?? p.defaultValue
+    if (val === undefined) continue
+    setByPath(clone, p.targetPath, val)
+  }
+  return clone
 }
+
+function setByPath(obj: any, path: string, value: any) {
+  const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.')
+  let cur = obj
+  for (let i = 0; i < keys.length - 1; i++) {
+    if (cur == null) return
+    cur = cur[keys[i]]
+  }
+  if (cur) cur[keys[keys.length - 1]] = value
+}
+

--- a/web/lib/override/resolve.ts
+++ b/web/lib/override/resolve.ts
@@ -1,5 +1,6 @@
 import type { ComponentNode, EditorState, InstanceNode, OverrideMap } from '@/types/editor'
 import { deepCloneNodeTree, findNode } from '@/lib/tree'
+import { resolveBinding } from '@/lib/binding/resolve'
 
 export function resolveOverrides(root: ComponentNode, overrides: OverrideMap = {}): ComponentNode {
   const clone = deepCloneNodeTree(root)
@@ -38,6 +39,8 @@ export function resolveInstance(state: EditorState, inst: InstanceNode): Compone
   const baseRoot = findNode(state.tree, def.rootId)
   if (!baseRoot) return null
   let root = deepCloneNodeTree(baseRoot)
+  if (def.props)
+    root = resolveBinding(root, def.props, inst.propValues || {})
   if (inst.overrides) root = resolveOverrides(root, inst.overrides)
   ;(root as any).props = { ...(root as any).props, ...(inst as any).props }
   ;(root as any).opacity = (inst as any).opacity ?? (root as any).opacity

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -697,7 +697,7 @@ createInstance(componentId, pos) {
 
     // props のデフォルト値を埋める
     def.props?.forEach((p) => {
-      inst.propValues![p.id] = p.default;
+      inst.propValues![p.id] = p.defaultValue;
     });
 
     // usage 情報更新
@@ -721,11 +721,11 @@ detachInstance(nodeId) {
     const def = draft.components[inst.componentId];
     if (!def) return;
     let resolved = resolveVariant(def, inst.variant);
+    if (inst.propValues) {
+      resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+    }
     if (inst.overrides) {
       resolved = resolveOverrides(resolved, inst.overrides);
-    }
-    if (inst.propValues) {
-      resolved = resolveBinding(resolved, inst.propValues);
     }
     if (res.parent && res.parent.children)
       res.parent.children[res.index] = resolved;
@@ -760,7 +760,7 @@ swapInstance(nodeId, nextComponentId) {
       if (def.props) {
         inst.propValues = {};
         def.props.forEach((p) => {
-          inst.propValues![p.id] = p.default;
+          inst.propValues![p.id] = p.defaultValue;
         });
       } else {
         inst.propValues = {};
@@ -782,7 +782,7 @@ addComponentProp(componentId, prop) {
           const inst = n as InstanceNode;
           inst.propValues = {
             ...(inst.propValues || {}),
-            [prop.id]: prop.default,
+            [prop.id]: prop.defaultValue,
           };
         }
         if (n.children) addToInstances(n.children);

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -368,7 +368,8 @@ export interface ComponentProp {
   id: string;
   name: string;
   type: "boolean" | "text" | "number" | "color";
-  default?: any;
+  defaultValue?: any;
+  targetPath?: string;
 }
 
 // Variant Props & Definitions


### PR DESCRIPTION
## Summary
- add target-path-based component props with defaults
- apply instance prop bindings before overrides
- wire up prop editing UI to new defaultValue field

## Testing
- `npm test` *(fails: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aad2648d60832cb30bb47a8c82dc44