### PR TITLE
feat: enhance components panel with usage stats

### DIFF
--- a/web/components/sidebar/ComponentsPanel.tsx
+++ b/web/components/sidebar/ComponentsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useEditorStore } from "@/store/editorStore";
 import InstanceView from "@/components/editor/InstanceView";
 import type { VariantProps } from "@/types/editor";
@@ -12,10 +12,16 @@ export default function ComponentsPanel() {
   const components = Object.values(componentsMap);
   const createInstance = useEditorStore((s) => s.createInstance);
   const placeInstance = useEditorStore((s) => s.placeInstance);
-
-  const [query, setQuery] = useState("");
-  const [sort, setSort] = useState<SortKey>("az");
+  const query = useEditorStore((s) => s.componentsQuery);
+  const sort = useEditorStore((s) => s.componentsSort as SortKey);
+  const setQuery = useEditorStore((s) => s.setComponentsQuery);
+  const setSort = useEditorStore((s) => s.setComponentsSort);
+  const hydrate = useEditorStore((s) => s.hydrateComponentsMeta);
   const [propsByComp, setPropsByComp] = useState<Record<string, VariantProps>>({});
+
+  useEffect(() => {
+    hydrate?.();
+  }, [hydrate]);
 
   const items = useMemo(() => {
     let list = components;
@@ -81,8 +87,17 @@ export default function ComponentsPanel() {
               }}
             >
               <div className="flex justify-between items-center mb-1">
-                <span className="font-medium">{c.name}</span>
-                <span className="text-xs opacity-70">{c.usageCount || 0}</span>
+                <span className="font-medium truncate">{c.name}</span>
+                <span className="text-xs opacity-70 flex items-center gap-2">
+                  <span title="使用数">↻ {c.usageCount ?? 0}</span>
+                  {c.lastUsedAt ? (
+                    <time dateTime={new Date(c.lastUsedAt).toISOString()}>
+                      {formatRelative(c.lastUsedAt)}
+                    </time>
+                  ) : (
+                    <span className="opacity-60">未使用</span>
+                  )}
+                </span>
               </div>
 
               {c.variantSet && (
@@ -115,4 +130,15 @@ export default function ComponentsPanel() {
       </div>
     </div>
   );
+}
+
+function formatRelative(ts: number) {
+  const diff = Date.now() - ts;
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return "たった今";
+  if (m < 60) return `${m}分前`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}時間前`;
+  const d = Math.floor(h / 24);
+  return `${d}日前`;
 }

--- a/web/lib/persist/componentsMeta.ts
+++ b/web/lib/persist/componentsMeta.ts
@@ -1,0 +1,58 @@
+import Dexie, { type Table } from 'dexie';
+
+type ComponentMeta = {
+  id: string;
+  usageCount: number;
+  lastUsedAt: number;
+};
+
+class UIBDb extends Dexie {
+  componentsMeta!: Table<ComponentMeta, string>;
+  constructor() {
+    super('uiBuilder');
+    this.version(1).stores({
+      componentsMeta: 'id',
+    });
+  }
+}
+
+const db = new UIBDb();
+
+export async function loadComponentsMeta(): Promise<
+  Record<string, { usageCount: number; lastUsedAt: number }>
+> {
+  try {
+    const rows = await db.componentsMeta.toArray();
+    const out: Record<string, { usageCount: number; lastUsedAt: number }> = {};
+    for (const r of rows) out[r.id] = { usageCount: r.usageCount, lastUsedAt: r.lastUsedAt };
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export async function bumpComponentUsage(id: string) {
+  const now = Date.now();
+  const cur = await db.componentsMeta.get(id);
+  const next: ComponentMeta = {
+    id,
+    usageCount: (cur?.usageCount ?? 0) + 1,
+    lastUsedAt: now,
+  };
+  await db.componentsMeta.put(next);
+  return next;
+}
+
+export async function writeComponentMeta(
+  id: string,
+  meta: Partial<Omit<ComponentMeta, 'id'>>,
+) {
+  const cur = await db.componentsMeta.get(id);
+  const next: ComponentMeta = {
+    id,
+    usageCount: meta.usageCount ?? cur?.usageCount ?? 0,
+    lastUsedAt: meta.lastUsedAt ?? cur?.lastUsedAt ?? 0,
+  };
+  await db.componentsMeta.put(next);
+  return next;
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -48,6 +48,7 @@ import { computeDominantColor } from "@/lib/color/dominant";
 import { nanoid } from "nanoid";
 import { layoutText } from "@/lib/text/layout";
 import { applyRun, removeRun } from "@/lib/text/rangeOps";
+import { bumpComponentUsage, loadComponentsMeta } from "@/lib/persist/componentsMeta";
 
 const updateUsageCounts = (draft: EditorState) => {
   const counts: Record<string, number> = {};
@@ -119,6 +120,9 @@ interface EditorActions {
   placeInstance: (componentId: string, pos?: { x: number; y: number }) => void;
   detachInstance: (nodeId: string) => void;
   swapInstance: (nodeId: string, nextComponentId: string) => void;
+  setComponentsQuery: (q: string) => void;
+  setComponentsSort: (m: 'az' | 'recent' | 'usage') => void;
+  hydrateComponentsMeta: () => Promise<void>;
   // Props
   addComponentProp: (componentId: string, prop: ComponentProp) => void;
   setInstanceProp: (nodeId: string, propId: string, value: any) => void;
@@ -349,6 +353,8 @@ export const useEditorStore = create<
         camera: { x: 0, y: 0, zoom: 1 },
         meta: { version: 1, updatedAt: Date.now() },
         components: {},
+        componentsQuery: '',
+        componentsSort: 'az',
         guides: [],
         assets: { images: {} },
         vector: { selection: {} },
@@ -664,56 +670,41 @@ export const useEditorStore = create<
           apply((draft) => {
             const def = draft.components[componentId];
             if (!def) return;
-            const id = Math.random().toString(36).slice(2);
+            const id = nanoid();
             const inst: InstanceNode = {
               id,
               type: "Instance",
               componentId,
+              props: {
+                x: pos?.x || 0,
+                y: pos?.y || 0,
+                w: def.root.props?.w || 100,
+                h: def.root.props?.h || 100,
+              },
+              children: [],
               variant: {},
               overrides: {},
-              props: { x: pos?.x || 0, y: pos?.y || 0 },
               propValues: {},
             };
-createInstance(componentId, pos) {
-  apply((draft) => {
-    const def = draft.components[componentId];
-    if (!def) return;
-    const id = nanoid();
-    const inst: InstanceNode = {
-      id,
-      type: "Instance",
-      componentId,
-      props: {
-        x: pos?.x || 0,
-        y: pos?.y || 0,
-        w: def.root.props?.w || 100,
-        h: def.root.props?.h || 100,
-      },
-      children: [],
-      variant: {},
-      overrides: {},
-      propValues: {},
-    };
 
-    // props のデフォルト値を埋める
-    def.props?.forEach((p) => {
-      inst.propValues![p.id] = p.defaultValue;
-    });
+            def.props?.forEach((p) => {
+              inst.propValues![p.id] = p.defaultValue;
+            });
 
-    // usage 情報更新
-    def.usageCount = (def.usageCount || 0) + 1;
-    def.lastUsedAt = Date.now();
+            def.usageCount = (def.usageCount || 0) + 1;
+            def.lastUsedAt = Date.now();
 
-    draft.tree.push(inst);
-    draft.selectedIds = [id];
-  });
-},
+            draft.tree.push(inst);
+            draft.selectedIds = [id];
+          });
+          bumpComponentUsage(componentId).catch(() => {});
+        },
 
-placeInstance(componentId, pos) {
-  get().createInstance(componentId, pos);
-},
+        placeInstance(componentId, pos) {
+          get().createInstance(componentId, pos);
+        },
 
-detachInstance(nodeId) {
+        detachInstance(nodeId) {
   apply((draft) => {
     const res = findNodeWithParent(draft.tree, nodeId);
     if (!res) return;
@@ -768,6 +759,24 @@ swapInstance(nodeId, nextComponentId) {
     }
 
     updateUsageCounts(draft);
+  });
+},
+
+setComponentsQuery(q) {
+  set({ componentsQuery: q });
+},
+setComponentsSort(m) {
+  set({ componentsSort: m });
+},
+async hydrateComponentsMeta() {
+  const meta = await loadComponentsMeta();
+  apply((draft) => {
+    for (const [id, m] of Object.entries(meta)) {
+      const def = draft.components[id];
+      if (!def) continue;
+      def.usageCount = m.usageCount;
+      def.lastUsedAt = m.lastUsedAt;
+    }
   });
 },
 

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -324,6 +324,8 @@ export interface EditorState {
   camera: Camera;
   meta: { version: number; updatedAt: number };
   components: Record<string, ComponentDef>;
+  componentsQuery?: string;
+  componentsSort?: 'az' | 'recent' | 'usage';
   guides: Guide[];
   assets?: { images: Record<string, AssetMeta> };
   vector?: {


### PR DESCRIPTION
## Summary
- add searchable Components panel with persistent sort options
- track component usage with Dexie and hydrate stats
- expose query and sort state in editor store

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aad777a774832c85f59b7d78cdcd20