### PR TITLE
v11-1: Frameリンク／Back／Overlay（遷移MVP）

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -23,6 +23,7 @@ import { saveImageMulti } from '@/lib/assets';
 import DropOverlay from './DropOverlay';
 import MarqueeZoom from './MarqueeZoom';
 import Minimap from '@/components/hud/Minimap';
+import HotspotOverlay from './HotspotOverlay';
 
 function NodeView({
   node,
@@ -344,6 +345,7 @@ export default function CanvasStage() {
       )}
       {selected.length === 1 && <SelectionOutline />}
       {selected.length === 1 && <ResizeHandles />}
+      <HotspotOverlay />
       <div className="absolute top-2 right-2"><ZoomControls /></div>
       <div className="minimap"><Minimap /></div>
     </div>

--- a/web/components/editor/HotspotOverlay.tsx
+++ b/web/components/editor/HotspotOverlay.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useMemo } from 'react';
+import { useEditorStore } from '@/store/editorStore';
+import type { ComponentNode } from '@/types/editor';
+
+function collect(nodes: ComponentNode[], out: ComponentNode[]) {
+  for (const n of nodes) {
+    if ((n as any).prototypeLink) out.push(n);
+    if (n.children) collect(n.children as ComponentNode[], out);
+  }
+}
+
+export default function HotspotOverlay() {
+  const tree = useEditorStore((s) => s.tree);
+  const hotspots = useMemo(() => {
+    const arr: ComponentNode[] = [];
+    collect(tree, arr);
+    return arr;
+  }, [tree]);
+  if (!hotspots.length) return null;
+  return (
+    <>
+      {hotspots.map((n) => {
+        const { x = 0, y = 0, w = 0, h = 0 } = n.props || {};
+        return (
+          <div
+            key={n.id}
+            className="absolute border border-sky-400/60 bg-sky-400/10 pointer-events-none"
+            style={{ left: x, top: y, width: w, height: h }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -3,7 +3,12 @@
 import { useMemo, useState, useEffect } from "react";
 import { nanoid } from "nanoid";
 import { useEditorStore } from "@/store/editorStore";
-import type { InstanceNode, ComponentProp, VariantPropDef } from "@/types/editor";
+import type {
+  InstanceNode,
+  ComponentProp,
+  VariantPropDef,
+  PrototypeLink,
+} from "@/types/editor";
 import { mapNodesForSwap } from "@/lib/override/compat";
 import { listOverridable } from "@/lib/override/util";
 import { findNode } from "@/lib/tree";
@@ -23,6 +28,29 @@ export default function RightPane() {
   const clearOverride = useEditorStore((s) => s.clearOverride);
   const clearAllOverrides = useEditorStore((s) => s.clearAllOverrides);
   const tree = useEditorStore((s) => s.tree);
+  const updateNode = useEditorStore((s) => s.updateNode);
+  const frames = useEditorStore((s) => s.tree.filter((n) => n.type === "Frame"));
+  const link = inst.prototypeLink;
+  const [linkKind, setLinkKind] = useState(link?.kind || "");
+  const [linkTarget, setLinkTarget] = useState(link?.targetId || "");
+  useEffect(() => {
+    setLinkKind(link?.kind || "");
+    setLinkTarget(link?.targetId || "");
+  }, [link?.kind, link?.targetId]);
+  const handleKindChange = (k: string) => {
+    setLinkKind(k);
+    if (!k) updateNode(inst.id, { prototypeLink: undefined });
+    else
+      updateNode(inst.id, {
+        prototypeLink: { kind: k as PrototypeLink["kind"], targetId: linkTarget },
+      });
+  };
+  const handleTargetChange = (t: string) => {
+    setLinkTarget(t);
+    updateNode(inst.id, {
+      prototypeLink: { kind: linkKind as PrototypeLink["kind"], targetId: t },
+    });
+  };
 
   const overrideTargets = useMemo(() => {
     if (!component) return [] as { id: string; type: string; name?: string }[];
@@ -219,6 +247,33 @@ export default function RightPane() {
         >
           Swap
         </button>
+      </div>
+
+      <div>
+        <div className="font-bold">Link</div>
+        <select
+          className="w-full bg-gray-700 p-1 text-white"
+          value={linkKind}
+          onChange={(e) => handleKindChange(e.target.value)}
+        >
+          <option value="">None</option>
+          <option value="navigate">Link To</option>
+          <option value="overlay">Overlay</option>
+          <option value="back">Back</option>
+        </select>
+        {(linkKind === "navigate" || linkKind === "overlay") && (
+          <select
+            className="w-full bg-gray-700 p-1 text-white mt-1"
+            value={linkTarget}
+            onChange={(e) => handleTargetChange(e.target.value)}
+          >
+            {frames.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.name || f.id}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       <div>

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -1,0 +1,97 @@
+'use client';
+import { useState } from 'react';
+import { useEditorStore } from '@/store/editorStore';
+import { findNode } from '@/lib/tree';
+import type { ComponentNode, InstanceNode, PrototypeLink } from '@/types/editor';
+import { resolveVariant } from '@/lib/variantResolver';
+import { applyOverrides } from '@/lib/overrideMerge';
+import { resolveBinding } from '@/lib/binding/resolve';
+
+function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: PrototypeLink) => void }) {
+  const components = useEditorStore((s) => s.components);
+  if (node.type === 'Instance') {
+    const inst = node as InstanceNode;
+    const def = components[inst.defId || inst.componentId];
+    if (!def) return null;
+    let resolved = resolveVariant(def, inst.variantProps);
+    if (inst.propValues)
+      resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+    if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
+    resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
+    return <NodeRenderer node={resolved} onLink={onLink} />;
+  }
+  const layout = node.props?.layout || 'free';
+  const style: any = {};
+  if (layout === 'auto') {
+    style.display = 'flex';
+    style.flexDirection = node.props?.axis === 'horizontal' ? 'row' : 'column';
+    if (node.props?.gap !== undefined) style.gap = node.props.gap;
+  } else {
+    style.position = 'absolute';
+    style.left = node.props?.x || 0;
+    style.top = node.props?.y || 0;
+  }
+  if (node.props?.w !== undefined) style.width = node.props.w;
+  if (node.props?.h !== undefined) style.height = node.props.h;
+  const link = node.prototypeLink;
+  const handle = (e: any) => {
+    e.stopPropagation();
+    if (link) onLink(link);
+  };
+  if (node.type === 'Image') {
+    return (
+      <div style={style} onClick={handle} className={link ? 'cursor-pointer' : undefined}>
+        <div className="w-full h-full bg-gray-300" />
+      </div>
+    );
+  }
+  if (node.type === 'Text') {
+    return (
+      <div style={style} onClick={handle} className={link ? 'cursor-pointer' : undefined}>
+        {node.props?.text}
+      </div>
+    );
+  }
+  return (
+    <div style={style} onClick={handle} className={link ? 'cursor-pointer' : undefined}>
+      {node.children?.map((c) => (
+        <NodeRenderer key={c.id} node={c} onLink={onLink} />
+      ))}
+    </div>
+  );
+}
+
+export default function Player() {
+  const tree = useEditorStore((s) => s.tree);
+  const [history, setHistory] = useState<string[]>(() => (tree[0] ? [tree[0].id] : []));
+  const [overlay, setOverlay] = useState<string | null>(null);
+  const currentId = history[history.length - 1];
+  const current = findNode(tree, currentId) as ComponentNode | null;
+  const handleLink = (l: PrototypeLink) => {
+    if (l.kind === 'navigate') setHistory((h) => [...h, l.targetId]);
+    else if (l.kind === 'overlay') setOverlay(l.targetId);
+    else if (l.kind === 'back') {
+      if (overlay) setOverlay(null);
+      else setHistory((h) => (h.length > 1 ? h.slice(0, -1) : h));
+    }
+  };
+  if (!current) return null;
+  return (
+    <div className="relative w-full h-full">
+      <NodeRenderer node={current} onLink={handleLink} />
+      {overlay && (
+        <div
+          className="absolute inset-0 bg-black/50 flex items-center justify-center"
+          onClick={() => setOverlay(null)}
+        >
+          <div onClick={(e) => e.stopPropagation()}>
+            <NodeRenderer
+              node={findNode(tree, overlay)!}
+              onLink={handleLink}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -297,6 +297,7 @@ export interface ComponentNode {
     layoutGrids?: LayoutGrid[];
   };
   bindings?: Record<string, PropBinding>;
+  prototypeLink?: PrototypeLink;
   variants?: {
     hover?: { className?: string };
     active?: { className?: string };
@@ -315,6 +316,11 @@ export interface PropBinding {
   path: string;
   fallback?: string;
 }
+
+export type PrototypeLink =
+  | { kind: 'navigate'; targetId: string; animation?: 'instant' }
+  | { kind: 'overlay'; targetId: string; animation?: 'instant' }
+  | { kind: 'back'; animation?: 'instant' };
 
 export interface EditorState {
   tree: ComponentNode[];


### PR DESCRIPTION
## Summary
- add PrototypeLink type and editor UI to assign navigation/overlay/back links
- visualize linked hotspots and integrate preview Player for navigation

## Testing
- `npm test` *(fails: Jest worker exceeded retry limit)*

------
https://chatgpt.com/codex/tasks/task_e_68aad8f79448832c936b2a2d3627d381