### PR TITLE
feat: add presenter hud and keyboard navigation

### DIFF
--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -1,11 +1,12 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useEditorStore } from '@/store/editorStore';
 import { findNode } from '@/lib/tree';
 import type { ComponentNode, InstanceNode, PrototypeLink } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
 import { resolveBinding } from '@/lib/binding/resolve';
+import { PresenterHUD } from '@/components/preview/PresenterHUD';
 
 function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: PrototypeLink) => void }) {
   const components = useEditorStore((s) => s.components);
@@ -63,21 +64,83 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
 
 export default function Player() {
   const tree = useEditorStore((s) => s.tree);
-  const [history, setHistory] = useState<string[]>(() => (tree[0] ? [tree[0].id] : []));
+  const frames = tree;
+  const [history, setHistory] = useState<string[]>(() => (frames[0] ? [frames[0].id] : []));
   const [overlay, setOverlay] = useState<string | null>(null);
   const currentId = history[history.length - 1];
   const current = findNode(tree, currentId) as ComponentNode | null;
+
+  const activeLinks = useMemo(() => {
+    if (!current) return [] as { node: ComponentNode; link: PrototypeLink }[];
+    const arr: { node: ComponentNode; link: PrototypeLink }[] = [];
+    const walk = (n: ComponentNode) => {
+      const link = (n as any).prototypeLink as PrototypeLink | undefined;
+      if (link) arr.push({ node: n, link });
+      if (n.children) (n.children as ComponentNode[]).forEach(walk);
+    };
+    walk(current);
+    return arr;
+  }, [current]);
+
+  const currentIndex = Math.max(0, frames.findIndex((f) => f.id === currentId));
+
+  const doBack = () => {
+    if (overlay) setOverlay(null);
+    else setHistory((h) => (h.length > 1 ? h.slice(0, -1) : h));
+  };
+
+  const goForward = () => {
+    if (overlay) {
+      setOverlay(null);
+      return;
+    }
+    const nav = activeLinks.find((x) => x.link.kind === 'navigate' && x.link.targetId);
+    if (nav?.link.targetId) {
+      setHistory((h) => [...h, nav.link.targetId!]);
+      return;
+    }
+    const ov = activeLinks.find((x) => x.link.kind === 'overlay' && x.link.targetId);
+    if (ov?.link.targetId) {
+      setOverlay(ov.link.targetId!);
+      return;
+    }
+    const idx = frames.findIndex((f) => f.id === currentId);
+    const next = frames[(idx + 1) % frames.length];
+    if (next) setHistory((h) => [...h, next.id]);
+  };
+
   const handleLink = (l: PrototypeLink) => {
     if (l.kind === 'navigate') setHistory((h) => [...h, l.targetId]);
     else if (l.kind === 'overlay') setOverlay(l.targetId);
-    else if (l.kind === 'back') {
-      if (overlay) setOverlay(null);
-      else setHistory((h) => (h.length > 1 ? h.slice(0, -1) : h));
-    }
+    else if (l.kind === 'back') doBack();
   };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' || e.key === 'Backspace') {
+        e.preventDefault();
+        doBack();
+      } else if (e.key === 'ArrowRight' || e.key === ' ') {
+        e.preventDefault();
+        goForward();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [history, overlay, frames, activeLinks]);
+
   if (!current) return null;
   return (
     <div className="relative w-full h-full">
+      <PresenterHUD
+        title={(current as any).name ?? current.id}
+        index={currentIndex}
+        total={frames.length}
+        overlayOpen={!!overlay}
+        onBack={doBack}
+        onForward={goForward}
+      />
       <NodeRenderer node={current} onLink={handleLink} />
       {overlay && (
         <div
@@ -85,10 +148,7 @@ export default function Player() {
           onClick={() => setOverlay(null)}
         >
           <div onClick={(e) => e.stopPropagation()}>
-            <NodeRenderer
-              node={findNode(tree, overlay)!}
-              onLink={handleLink}
-            />
+            <NodeRenderer node={findNode(tree, overlay)!} onLink={handleLink} />
           </div>
         </div>
       )}

--- a/web/components/preview/PresenterHUD.tsx
+++ b/web/components/preview/PresenterHUD.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React from 'react';
+
+type Props = {
+  title?: string;
+  index: number;
+  total: number;
+  overlayOpen: boolean;
+  onBack: () => void;
+  onForward: () => void;
+};
+
+/**
+ * v11-3: プレゼンターモード用 HUD
+ * - 現在フレーム名、インデックス表示
+ * - ⬅️➡️/Space/Backspace のナビを画面上のボタンでも操作可能
+ * - Overlay 開閉状態の表示
+ */
+export function PresenterHUD({
+  title,
+  index,
+  total,
+  overlayOpen,
+  onBack,
+  onForward,
+}: Props) {
+  return (
+    <div className="absolute top-2 left-1/2 -translate-x-1/2 z-30 pointer-events-none">
+      <div className="flex items-center gap-2 rounded-lg bg-zinc-900/80 border border-zinc-700 px-3 py-1.5 shadow">
+        <button
+          className="pointer-events-auto px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+          onClick={onBack}
+          title="Back (← / Backspace)"
+        >
+          ← Back
+        </button>
+        <div className="text-xs text-zinc-300">
+          <span className="font-medium">{title ?? 'Untitled'}</span>
+          <span className="mx-2 opacity-60">•</span>
+          <span>
+            {index + 1}/{total}
+          </span>
+          {overlayOpen && <span className="ml-2 text-amber-300">[Overlay]</span>}
+        </div>
+        <button
+          className="pointer-events-auto px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+          onClick={onForward}
+          title="Forward (→ / Space)"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add PresenterHUD to show frame title/index and overlay status
- support back/forward buttons and keyboard navigation in preview Player

## Testing
- `npm test` *(fails: Jest worker child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aadb3a3344832c83a8b81683ee47c0