### PR TITLE
feat: add smart animate cross-fade

### DIFF
--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useEditorStore } from '@/store/editorStore';
 import { findNode } from '@/lib/tree';
 import type { ComponentNode, InstanceNode, PrototypeLink } from '@/types/editor';
@@ -7,6 +7,7 @@ import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
 import { resolveBinding } from '@/lib/binding/resolve';
 import { PresenterHUD } from '@/components/preview/PresenterHUD';
+import { buildPoseMap, diffPoses, easeStandard } from '@/lib/animate/smart';
 
 function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: PrototypeLink) => void }) {
   const components = useEditorStore((s) => s.components);
@@ -67,6 +68,11 @@ export default function Player() {
   const frames = tree;
   const [history, setHistory] = useState<string[]>(() => (frames[0] ? [frames[0].id] : []));
   const [overlay, setOverlay] = useState<string | null>(null);
+  const [tr, setTr] = useState<
+    | { fromId: string; toId: string; kind: 'instant' | 'dissolve'; t0: number; dur: number }
+    | null
+  >(null);
+  const rafRef = useRef<number | null>(null);
   const currentId = history[history.length - 1];
   const current = findNode(tree, currentId) as ComponentNode | null;
 
@@ -84,19 +90,29 @@ export default function Player() {
 
   const currentIndex = Math.max(0, frames.findIndex((f) => f.id === currentId));
 
-  const doBack = () => {
+  const doBack = (kind: 'instant' | 'dissolve' = 'dissolve') => {
     if (overlay) setOverlay(null);
-    else setHistory((h) => (h.length > 1 ? h.slice(0, -1) : h));
+    else
+      setHistory((h) => {
+        if (h.length <= 1) return h;
+        startTransition(h[h.length - 1], h[h.length - 2], kind);
+        return h.slice(0, -1);
+      });
   };
 
-  const goForward = () => {
+  const goForward = (kind: 'instant' | 'dissolve') => {
     if (overlay) {
       setOverlay(null);
       return;
     }
     const nav = activeLinks.find((x) => x.link.kind === 'navigate' && x.link.targetId);
     if (nav?.link.targetId) {
-      setHistory((h) => [...h, nav.link.targetId!]);
+      setHistory((h) => {
+        const fromId = h[h.length - 1];
+        const anim = nav.link.animation === 'instant' ? 'instant' : kind;
+        startTransition(fromId, nav.link.targetId!, anim);
+        return [...h, nav.link.targetId!];
+      });
       return;
     }
     const ov = activeLinks.find((x) => x.link.kind === 'overlay' && x.link.targetId);
@@ -106,23 +122,56 @@ export default function Player() {
     }
     const idx = frames.findIndex((f) => f.id === currentId);
     const next = frames[(idx + 1) % frames.length];
-    if (next) setHistory((h) => [...h, next.id]);
+    if (next)
+      setHistory((h) => {
+        const fromId = h[h.length - 1];
+        startTransition(fromId, next.id, kind);
+        return [...h, next.id];
+      });
   };
 
   const handleLink = (l: PrototypeLink) => {
-    if (l.kind === 'navigate') setHistory((h) => [...h, l.targetId]);
+    if (l.kind === 'navigate')
+      setHistory((h) => {
+        const fromId = h[h.length - 1];
+        const anim = l.animation === 'instant' ? 'instant' : 'dissolve';
+        startTransition(fromId, l.targetId, anim);
+        return [...h, l.targetId];
+      });
     else if (l.kind === 'overlay') setOverlay(l.targetId);
-    else if (l.kind === 'back') doBack();
+    else if (l.kind === 'back') doBack(l.animation === 'instant' ? 'instant' : 'dissolve');
   };
+
+  function startTransition(fromId: string, toId: string, kind: 'instant' | 'dissolve') {
+    if (kind === 'instant') {
+      setTr(null);
+      return;
+    }
+    try {
+      const fromNode = findNode(tree, fromId);
+      const toNode = findNode(tree, toId);
+      if (fromNode && toNode) {
+        const before = buildPoseMap(fromNode);
+        const after = buildPoseMap(toNode);
+        // Future use: per-node interpolation
+        void diffPoses(before, after);
+      }
+    } catch {
+      // ignore errors
+    }
+    setTr({ fromId, toId, kind, t0: performance.now(), dur: 200 });
+  }
+
+  const progress = useTransitionProgress(tr);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'ArrowLeft' || e.key === 'Backspace') {
         e.preventDefault();
-        doBack();
+        doBack('dissolve');
       } else if (e.key === 'ArrowRight' || e.key === ' ') {
         e.preventDefault();
-        goForward();
+        goForward('dissolve');
       }
     };
     window.addEventListener('keydown', onKey);
@@ -138,10 +187,17 @@ export default function Player() {
         index={currentIndex}
         total={frames.length}
         overlayOpen={!!overlay}
-        onBack={doBack}
-        onForward={goForward}
+        onBack={() => doBack('dissolve')}
+        onForward={() => goForward('dissolve')}
       />
-      <NodeRenderer node={current} onLink={handleLink} />
+      {tr && tr.kind === 'dissolve' && (
+        <div className="absolute inset-0 pointer-events-none" style={{ opacity: 1 - progress }}>
+          <NodeRenderer node={findNode(tree, tr.fromId)!} onLink={handleLink} />
+        </div>
+      )}
+      <div className="absolute inset-0" style={{ opacity: tr?.kind === 'dissolve' ? progress : 1 }}>
+        <NodeRenderer node={current} onLink={handleLink} />
+      </div>
       {overlay && (
         <div
           className="absolute inset-0 bg-black/50 flex items-center justify-center"
@@ -154,4 +210,29 @@ export default function Player() {
       )}
     </div>
   );
+}
+
+function useTransitionProgress(tr: { t0: number; dur: number; kind: 'instant' | 'dissolve' } | null) {
+  const [p, setP] = useState(1);
+  const raf = useRef<number | null>(null);
+  useEffect(() => {
+    if (!tr || tr.kind === 'instant') {
+      setP(1);
+      return;
+    }
+    const loop = () => {
+      const now = performance.now();
+      const raw = Math.min(1, (now - tr.t0) / tr.dur);
+      const eased = easeStandard(raw);
+      setP(eased);
+      if (raw < 1) raf.current = requestAnimationFrame(loop);
+      else if (raf.current) cancelAnimationFrame(raf.current);
+    };
+    setP(0);
+    raf.current = requestAnimationFrame(loop);
+    return () => {
+      if (raf.current) cancelAnimationFrame(raf.current);
+    };
+  }, [tr]);
+  return p;
 }

--- a/web/lib/animate/smart.ts
+++ b/web/lib/animate/smart.ts
@@ -1,0 +1,120 @@
+/**
+ * v11-2: Smart Animate (MVP)
+ * - Interpolates x/y/scale/rotation/opacity between nodes with same id
+ * - Unmatched nodes are treated as fade in/out
+ * - Pure functions only, no dependencies
+ */
+
+export type Pose = {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+  rotation: number; // deg
+  opacity: number; // 0..1
+};
+
+export type PoseDiff = {
+  id: string;
+  from: Pose | null; // null = new (fade in)
+  to: Pose | null; // null = removed (fade out)
+};
+
+const DEFAULT_POSE: Pose = {
+  x: 0,
+  y: 0,
+  scaleX: 1,
+  scaleY: 1,
+  rotation: 0,
+  opacity: 1,
+};
+
+/** Extract nodeId -> Pose map from a tree (best-effort guess). */
+export function buildPoseMap(root: any): Record<string, Pose> {
+  const map: Record<string, Pose> = {};
+  traverse([root], (n: any) => {
+    const id = n?.id;
+    if (!id) return;
+    const p = n?.props ?? {};
+    const style = n?.style ?? {};
+    const pose: Pose = {
+      x: pickNum(p.x, style.left, 0),
+      y: pickNum(p.y, style.top, 0),
+      scaleX: pickNum(p.scaleX, style.scaleX, 1),
+      scaleY: pickNum(p.scaleY, style.scaleY, 1),
+      rotation: pickNum(p.rotation, style.rotate, 0),
+      opacity: clamp01(pickNum(p.opacity, style.opacity, 1)),
+    };
+    map[id] = pose;
+  });
+  return map;
+}
+
+/** Build diff list from before/after pose maps. */
+export function diffPoses(
+  before: Record<string, Pose>,
+  after: Record<string, Pose>
+): PoseDiff[] {
+  const ids = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const out: PoseDiff[] = [];
+  ids.forEach((id) => {
+    const a = before[id];
+    const b = after[id];
+    if (!a && b) out.push({ id, from: null, to: b });
+    else if (a && !b) out.push({ id, from: a, to: null });
+    else if (a && b) out.push({ id, from: a, to: b });
+  });
+  return out;
+}
+
+/** Simple ease (approximation of Bezier 0.2, 0, 0, 1). */
+export function easeStandard(t: number) {
+  return t * (2 - t);
+}
+
+/** Linear interpolation */
+export function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+/** Interpolate between poses (null treated as fade). */
+export function mixPose(from: Pose | null, to: Pose | null, t: number): Pose {
+  if (!from && to) {
+    return { ...to, opacity: to.opacity * t };
+  }
+  if (from && !to) {
+    return { ...from, opacity: from.opacity * (1 - t) };
+  }
+  const A = from ?? DEFAULT_POSE;
+  const B = to ?? DEFAULT_POSE;
+  return {
+    x: lerp(A.x, B.x, t),
+    y: lerp(A.y, B.y, t),
+    scaleX: lerp(A.scaleX, B.scaleX, t),
+    scaleY: lerp(A.scaleY, B.scaleY, t),
+    rotation: lerp(A.rotation, B.rotation, t),
+    opacity: clamp01(lerp(A.opacity, B.opacity, t)),
+  };
+}
+
+// ===== helpers =====
+function traverse(nodes: any[], fn: (n: any) => void) {
+  for (const n of nodes ?? []) {
+    fn(n);
+    const ch = (n as any)?.children;
+    if (ch && Array.isArray(ch)) traverse(ch, fn);
+  }
+}
+
+function pickNum(...vals: Array<any>): number {
+  for (const v of vals) {
+    const n = Number(v);
+    if (!Number.isNaN(n)) return n;
+  }
+  return 0;
+}
+
+function clamp01(v: number) {
+  return Math.max(0, Math.min(1, v));
+}
+


### PR DESCRIPTION
## Summary
- add pose utilities for smart animate transitions
- implement dissolve cross-fade and transition tracking in preview Player

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aadd939dd4832c8c94765247382e40