### PR TITLE
feat: add trigger options for prototype links

### DIFF
--- a/web/components/editor/HotspotOverlay.tsx
+++ b/web/components/editor/HotspotOverlay.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useMemo } from 'react';
 import { useEditorStore } from '@/store/editorStore';
-import type { ComponentNode } from '@/types/editor';
+import type { ComponentNode, PrototypeLink } from '@/types/editor';
 
 function collect(nodes: ComponentNode[], out: ComponentNode[]) {
   for (const n of nodes) {
@@ -10,7 +10,9 @@ function collect(nodes: ComponentNode[], out: ComponentNode[]) {
   }
 }
 
-export default function HotspotOverlay() {
+export default function HotspotOverlay(props: {
+  onHover?: (nodeId: string, link: PrototypeLink) => void;
+} = {}) {
   const tree = useEditorStore((s) => s.tree);
   const hotspots = useMemo(() => {
     const arr: ComponentNode[] = [];
@@ -22,11 +24,17 @@ export default function HotspotOverlay() {
     <>
       {hotspots.map((n) => {
         const { x = 0, y = 0, w = 0, h = 0 } = n.props || {};
+        const link = (n as any).prototypeLink as PrototypeLink | undefined;
+        const pe = props.onHover ? 'pointer-events-auto' : 'pointer-events-none';
         return (
           <div
             key={n.id}
-            className="absolute border border-sky-400/60 bg-sky-400/10 pointer-events-none"
+            className={`absolute border border-sky-400/60 bg-sky-400/10 ${pe}`}
             style={{ left: x, top: y, width: w, height: h }}
+            onMouseEnter={() => {
+              if (props.onHover && link?.trigger?.type === 'hover')
+                props.onHover(n.id, link);
+            }}
           />
         );
       })}

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -33,22 +33,56 @@ export default function RightPane() {
   const link = inst.prototypeLink;
   const [linkKind, setLinkKind] = useState(link?.kind || "");
   const [linkTarget, setLinkTarget] = useState(link?.targetId || "");
+  const [triggerType, setTriggerType] = useState(link?.trigger?.type || 'click');
+  const [triggerMs, setTriggerMs] = useState(link?.trigger?.ms ?? 300);
   useEffect(() => {
     setLinkKind(link?.kind || "");
     setLinkTarget(link?.targetId || "");
-  }, [link?.kind, link?.targetId]);
+    setTriggerType(link?.trigger?.type || 'click');
+    setTriggerMs(link?.trigger?.ms ?? 300);
+  }, [link?.kind, link?.targetId, link?.trigger?.type, link?.trigger?.ms]);
+  const triggerObj = () =>
+    ({ type: triggerType as any, ...(triggerType === 'delay' ? { ms: triggerMs } : {}) });
   const handleKindChange = (k: string) => {
     setLinkKind(k);
     if (!k) updateNode(inst.id, { prototypeLink: undefined });
     else
       updateNode(inst.id, {
-        prototypeLink: { kind: k as PrototypeLink["kind"], targetId: linkTarget },
+        prototypeLink: {
+          kind: k as PrototypeLink["kind"],
+          targetId: linkTarget,
+          trigger: triggerObj(),
+        },
       });
   };
   const handleTargetChange = (t: string) => {
     setLinkTarget(t);
     updateNode(inst.id, {
-      prototypeLink: { kind: linkKind as PrototypeLink["kind"], targetId: t },
+      prototypeLink: {
+        kind: linkKind as PrototypeLink["kind"],
+        targetId: t,
+        trigger: triggerObj(),
+      },
+    });
+  };
+  const handleTriggerChange = (t: string) => {
+    setTriggerType(t);
+    updateNode(inst.id, {
+      prototypeLink: {
+        kind: linkKind as PrototypeLink['kind'],
+        targetId: linkTarget,
+        trigger: { type: t as any, ...(t === 'delay' ? { ms: triggerMs } : {}) },
+      },
+    });
+  };
+  const handleTriggerMsChange = (ms: number) => {
+    setTriggerMs(ms);
+    updateNode(inst.id, {
+      prototypeLink: {
+        kind: linkKind as PrototypeLink['kind'],
+        targetId: linkTarget,
+        trigger: { type: 'delay', ms },
+      },
     });
   };
 
@@ -274,6 +308,29 @@ export default function RightPane() {
             ))}
           </select>
         )}
+        <div className="mt-1">
+          <label className="block">Trigger</label>
+          <div className="flex items-center gap-1">
+            <select
+              className="flex-1 bg-gray-700 p-1 text-white"
+              value={triggerType}
+              onChange={(e) => handleTriggerChange(e.target.value)}
+            >
+              <option value="click">click</option>
+              <option value="hover">hover</option>
+              <option value="delay">delay</option>
+            </select>
+            {triggerType === 'delay' && (
+              <input
+                type="number"
+                min={0}
+                className="w-16 bg-gray-700 p-1 text-white"
+                value={triggerMs}
+                onChange={(e) => handleTriggerMsChange(Number(e.target.value))}
+              />
+            )}
+          </div>
+        </div>
       </div>
 
       <div>

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -36,26 +36,55 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
   if (node.props?.w !== undefined) style.width = node.props.w;
   if (node.props?.h !== undefined) style.height = node.props.h;
   const link = node.prototypeLink;
-  const handle = (e: any) => {
+  const handleClick = (e: any) => {
+    if (!link) return;
     e.stopPropagation();
-    if (link) onLink(link);
+    const trig = link.trigger?.type || 'click';
+    if (trig === 'click') onLink(link);
   };
+  const handleHover = (e: any) => {
+    if (!link) return;
+    if (link.trigger?.type === 'hover') {
+      e.stopPropagation();
+      onLink(link);
+    }
+  };
+  useEffect(() => {
+    if (!link || link.trigger?.type !== 'delay') return;
+    const id = setTimeout(() => onLink(link), link.trigger.ms ?? 300);
+    return () => clearTimeout(id);
+  }, [link, onLink]);
   if (node.type === 'Image') {
     return (
-      <div style={style} onClick={handle} className={link ? 'cursor-pointer' : undefined}>
+      <div
+        style={style}
+        onClick={handleClick}
+        onMouseEnter={handleHover}
+        className={link ? 'cursor-pointer' : undefined}
+      >
         <div className="w-full h-full bg-gray-300" />
       </div>
     );
   }
   if (node.type === 'Text') {
     return (
-      <div style={style} onClick={handle} className={link ? 'cursor-pointer' : undefined}>
+      <div
+        style={style}
+        onClick={handleClick}
+        onMouseEnter={handleHover}
+        className={link ? 'cursor-pointer' : undefined}
+      >
         {node.props?.text}
       </div>
     );
   }
   return (
-    <div style={style} onClick={handle} className={link ? 'cursor-pointer' : undefined}>
+    <div
+      style={style}
+      onClick={handleClick}
+      onMouseEnter={handleHover}
+      className={link ? 'cursor-pointer' : undefined}
+    >
       {node.children?.map((c) => (
         <NodeRenderer key={c.id} node={c} onLink={onLink} />
       ))}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -317,10 +317,29 @@ export interface PropBinding {
   fallback?: string;
 }
 
+export type PrototypeTrigger =
+  | { type: 'click' }
+  | { type: 'hover' }
+  | { type: 'delay'; ms?: number };
+
 export type PrototypeLink =
-  | { kind: 'navigate'; targetId: string; animation?: 'instant' }
-  | { kind: 'overlay'; targetId: string; animation?: 'instant' }
-  | { kind: 'back'; animation?: 'instant' };
+  | {
+      kind: 'navigate';
+      targetId: string;
+      animation?: 'instant' | 'dissolve';
+      trigger?: PrototypeTrigger;
+    }
+  | {
+      kind: 'overlay';
+      targetId: string;
+      animation?: 'instant' | 'dissolve';
+      trigger?: PrototypeTrigger;
+    }
+  | {
+      kind: 'back';
+      animation?: 'instant' | 'dissolve';
+      trigger?: PrototypeTrigger;
+    };
 
 export interface EditorState {
   tree: ComponentNode[];


### PR DESCRIPTION
## Summary
- expand `PrototypeLink` with `PrototypeTrigger` to support click, hover, and delay triggers
- allow editing trigger type and delay in RightPane
- handle new trigger types in preview Player and hotspot overlay

## Testing
- `npm test` (fails: Jest worker encountered child process exceptions)

------
https://chatgpt.com/codex/tasks/task_e_68aade870290832cb9f5d8008bce50be