### PR TITLE
feat: add design token export

### DIFF
--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -12,6 +12,7 @@ import type {
 import { mapNodesForSwap } from "@/lib/override/compat";
 import { listOverridable } from "@/lib/override/util";
 import { findNode } from "@/lib/tree";
+import TokensExportPanel from "@/components/editor/TokensExportPanel";
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedIds[0]);
@@ -434,6 +435,10 @@ export default function RightPane() {
             </div>
           </div>
         )}
+      </div>
+      {/* v12-2: Export（Design Tokens） */}
+      <div className="pt-2 border-t border-zinc-800">
+        <TokensExportPanel />
       </div>
     </div>
   );

--- a/web/components/editor/TokensExportPanel.tsx
+++ b/web/components/editor/TokensExportPanel.tsx
@@ -1,0 +1,84 @@
+'use client'
+import React, { useMemo } from 'react'
+import { useEditorStore } from '@/store/editorStore'
+import { extractTokensFromTree, tokensToJSON, tokensToTS } from '@/lib/export/tokens'
+
+/**
+ * v12-2: Design Tokens Export Panel
+ * - 現在のドキュメント（tree）から tokens を抽出し、JSON / TS としてダウンロード
+ */
+export default function TokensExportPanel() {
+  const tree = useEditorStore((s) => s.tree)
+  const tokens = useMemo(() => extractTokensFromTree(tree), [tree])
+
+  const download = (filename: string, content: string, type = 'application/json') => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    URL.revokeObjectURL(url)
+    a.remove()
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs uppercase tracking-wider text-zinc-400">Export</div>
+      <div className="rounded-lg border border-zinc-700 p-3 bg-zinc-900/50">
+        <div className="text-sm font-medium mb-2">Design Tokens</div>
+        <p className="text-xs text-zinc-400 mb-3">
+          現在のドキュメントから <code>colors / typography / spacing</code> を抽出します。
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <button
+            className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+            onClick={() => download('tokens.json', tokensToJSON(tokens))}
+          >
+            Download JSON
+          </button>
+          <button
+            className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+            onClick={() => download('tokens.ts', tokensToTS(tokens))}
+          >
+            Download TS
+          </button>
+        </div>
+        {/* プレビュー（抜粋） */}
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <div>
+            <div className="text-xs mb-1 text-zinc-400">Colors</div>
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(tokens.colors).slice(0, 8).map(([k, v]) => (
+                <div key={k} className="flex items-center gap-2">
+                  <span className="inline-block w-4 h-4 rounded-sm" style={{ background: v }} />
+                  <span className="text-xs">{k}</span>
+                </div>
+              ))}
+              {Object.keys(tokens.colors).length === 0 && (
+                <div className="text-xs text-zinc-500">—</div>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs mb-1 text-zinc-400">Typography</div>
+            <div className="text-xs text-zinc-300 space-y-1">
+              <div>fonts: {tokens.typography.fonts.join(', ') || '—'}</div>
+              <div>fontSizes(px): {tokens.typography.fontSizes.join(', ') || '—'}</div>
+              <div>lineHeights(px): {tokens.typography.lineHeights.join(', ') || '—'}</div>
+              <div>letterSpacing(px): {tokens.typography.letterSpacing.join(', ') || '—'}</div>
+              <div>fontWeights: {tokens.typography.fontWeights.join(', ') || '—'}</div>
+            </div>
+          </div>
+          <div className="col-span-2">
+            <div className="text-xs mb-1 text-zinc-400">Spacing(px)</div>
+            <div className="text-xs text-zinc-300">
+              {tokens.spacing.space.join(', ') || '—'}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/lib/export/tokens.ts
+++ b/web/lib/export/tokens.ts
@@ -1,0 +1,227 @@
+/**
+ * v12-2: Design Tokens 書き出し（色/タイポ/間隔）
+ * 依存追加なし。Editor の現在ツリーを走査し、よく使う見た目属性から
+ * colors / typography / spacing の簡易トークンを抽出する。
+ */
+
+export type Tokens = {
+  colors: Record<string, string>; // e.g. { 'color-1': '#0ea5e9' }
+  typography: {
+    fonts: string[]; // unique family（引用符込み）
+    fontSizes: number[]; // px
+    lineHeights: number[]; // px
+    letterSpacing: number[]; // px
+    fontWeights: number[]; // numeric
+  };
+  spacing: {
+    space: number[]; // px（gap/padding/margin/borderRadius から抽出）
+  };
+};
+
+// ===== 抽出のメインAPI =====
+export function extractTokensFromTree(tree: any[]): Tokens {
+  const colors = new Set<string>();
+  const fonts = new Set<string>();
+  const fontSizes = new Set<number>();
+  const lineHeights = new Set<number>();
+  const letterSpacing = new Set<number>();
+  const fontWeights = new Set<number>();
+  const space = new Set<number>();
+
+  traverse(tree, (n) => {
+    const p = (n as any)?.props ?? {};
+    const style = (n as any)?.style ?? {};
+
+    // Colors
+    for (const val of [
+      p.fill,
+      p.stroke,
+      style.color,
+      style.backgroundColor,
+      style.borderColor,
+      style.fill,
+      style.stroke,
+    ]) {
+      const c = normalizeColor(val);
+      if (c) colors.add(c);
+    }
+
+    // Typography
+    const ff = style.fontFamily ?? p.fontFamily;
+    if (typeof ff === 'string' && ff.trim()) {
+      fonts.add(quoteIfNeeded(ff.trim()));
+    }
+    const fs = pickNum(style.fontSize, p.fontSize);
+    if (isFiniteNum(fs)) fontSizes.add(round1(fs));
+    const lh = normalizeLineHeight(style.lineHeight ?? p.lineHeight);
+    if (isFiniteNum(lh)) lineHeights.add(round1(lh));
+    const ls = normalizeLetterSpacing(style.letterSpacing ?? p.letterSpacing);
+    if (isFiniteNum(ls)) letterSpacing.add(round2(ls));
+    const fw = pickNum(style.fontWeight, p.fontWeight);
+    if (isFiniteNum(fw)) fontWeights.add(Math.round(fw));
+
+    // Spacing（px換算して集約）
+    const spacingCandidates = [
+      style.gap,
+      style.rowGap,
+      style.columnGap,
+      style.padding,
+      style.paddingTop,
+      style.paddingRight,
+      style.paddingBottom,
+      style.paddingLeft,
+      style.margin,
+      style.marginTop,
+      style.marginRight,
+      style.marginBottom,
+      style.marginLeft,
+      style.borderRadius,
+      style.borderTopLeftRadius,
+      style.borderTopRightRadius,
+      style.borderBottomRightRadius,
+      style.borderBottomLeftRadius,
+      p.radius,
+    ];
+    spacingCandidates.forEach((v) => {
+      const px = toPx(v);
+      if (isFiniteNum(px)) space.add(round1(px));
+    });
+  });
+
+  // 並び替え・整形
+  const colorMap = buildSequentialMap([...colors].sort(hexSort), 'color');
+  const tokens: Tokens = {
+    colors: colorMap,
+    typography: {
+      fonts: [...fonts].sort(),
+      fontSizes: sortNum([...fontSizes]),
+      lineHeights: sortNum([...lineHeights]),
+      letterSpacing: sortNum([...letterSpacing]),
+      fontWeights: sortNum([...fontWeights]),
+    },
+    spacing: {
+      space: sortNum([...space]),
+    },
+  };
+  return tokens;
+}
+
+// ===== 書き出し（JSON / TS） =====
+export function tokensToJSON(tokens: Tokens): string {
+  return JSON.stringify(tokens, null, 2);
+}
+
+export function tokensToTS(tokens: Tokens, exportName = 'tokens'): string {
+  return `/* eslint-disable */\n` +
+    `// v12-2: Generated Design Tokens\n` +
+    `export type Tokens = {\n` +
+    `  colors: Record<string, string>\n` +
+    `  typography: { fonts: string[]; fontSizes: number[]; lineHeights: number[]; letterSpacing: number[]; fontWeights: number[] }\n` +
+    `  spacing: { space: number[] }\n` +
+    `}\n\n` +
+    `export const ${exportName} = ${JSON.stringify(tokens, null, 2)} as const;\n`;
+}
+
+// ===== Utils =====
+function traverse(nodes: any[], fn: (n: any) => void) {
+  for (const n of nodes ?? []) {
+    fn(n);
+    const ch = (n as any)?.children;
+    if (ch && Array.isArray(ch)) traverse(ch, fn);
+  }
+}
+
+function isFiniteNum(n: any): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+function pickNum(...vals: any[]): number | undefined {
+  for (const v of vals) {
+    const x = Number(v);
+    if (!Number.isNaN(x)) return x;
+  }
+  return undefined;
+}
+function round1(n: number) {
+  return Math.round(n * 10) / 10;
+}
+function round2(n: number) {
+  return Math.round(n * 100) / 100;
+}
+function sortNum(arr: number[]) {
+  return arr.sort((a, b) => a - b);
+}
+
+// 色正規化: rgb/rgba/hsl/HEX を HEX #rrggbb に寄せる（簡易）
+function normalizeColor(v: any): string | null {
+  if (typeof v !== 'string') return null;
+  const s = v.trim();
+  // #RGB / #RRGGBB
+  if (/^#([0-9a-f]{3})$/i.test(s)) {
+    const m = s.slice(1);
+    return `#${m[0]}${m[0]}${m[1]}${m[1]}${m[2]}${m[2]}`.toLowerCase();
+  }
+  if (/^#([0-9a-f]{6})$/i.test(s)) return s.toLowerCase();
+  // rgb / rgba
+  const rgb = s.match(/^rgba?\((\s*\d+\s*),(\s*\d+\s*),(\s*\d+\s*)(?:,\s*[\d.]+\s*)?\)$/i);
+  if (rgb) {
+    const r = clamp255(Number(rgb[1]));
+    const g = clamp255(Number(rgb[2]));
+    const b = clamp255(Number(rgb[3]));
+    return toHex(r, g, b);
+  }
+  // hsl（簡易: 近似→Canvasを使わずに概算は難しいので未対応）
+  return null;
+}
+function clamp255(n: number) {
+  return Math.max(0, Math.min(255, Math.round(n)));
+}
+function toHex(r: number, g: number, b: number) {
+  return (
+    '#' +
+    [r, g, b]
+      .map((x) => x.toString(16).padStart(2, '0'))
+      .join('')
+      .toLowerCase()
+  );
+}
+function hexSort(a: string, b: string) {
+  return a.localeCompare(b);
+}
+function buildSequentialMap(values: string[], prefix: string) {
+  const out: Record<string, string> = {};
+  values.forEach((v, i) => (out[`${prefix}-${i + 1}`] = v));
+  return out;
+}
+function quoteIfNeeded(family: string) {
+  // 既に "..." or '...' ならそのまま。スペースを含む場合は "" で包む。
+  if (/^["'].+["']$/.test(family)) return family;
+  if (/\s/.test(family)) return `"${family}"`;
+  return family;
+}
+function normalizeLineHeight(v: any): number | undefined {
+  if (v == null) return undefined;
+  // number → pxとみなす
+  if (typeof v === 'number') return v;
+  const s = String(v).trim();
+  if (/^\d+(\.\d+)?px$/.test(s)) return Number(s.replace('px', ''));
+  if (/^\d+(\.\d+)?$/.test(s)) return Number(s); // 単位なし（倍率ではなくpx想定）
+  return undefined;
+}
+function normalizeLetterSpacing(v: any): number | undefined {
+  if (v == null) return undefined;
+  const s = String(v).trim();
+  if (/^\d+(\.\d+)?px$/.test(s)) return Number(s.replace('px', ''));
+  if (/^-?\d+(\.\d+)?$/.test(s)) return Number(s);
+  return undefined;
+}
+function toPx(v: any): number | undefined {
+  if (v == null) return undefined;
+  if (typeof v === 'number') return v;
+  const s = String(v).trim();
+  if (/^-?\d+(\.\d+)?px$/.test(s)) return Number(s.replace('px', ''));
+  // rem/em は簡易換算（1rem=16px/1em=16px と仮定）
+  if (/^-?\d+(\.\d+)?rem$/.test(s)) return Number(s.replace('rem', '')) * 16;
+  if (/^-?\d+(\.\d+)?em$/.test(s)) return Number(s.replace('em', '')) * 16;
+  if (/^-?\d+(\.\d+)?$/.test(s)) return Number(s);
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- add utilities to extract colors, typography, and spacing tokens from editor tree
- add panel to preview and download design tokens as JSON or TypeScript
- expose design token export panel in right-side editor pane

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*


------
https://chatgpt.com/codex/tasks/task_e_68aae039a6d0832c9f24c170577f4eaf