### PR TITLE
feat: add asset map export

### DIFF
--- a/web/components/editor/TokensExportPanel.tsx
+++ b/web/components/editor/TokensExportPanel.tsx
@@ -1,7 +1,8 @@
 'use client'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useEditorStore } from '@/store/editorStore'
 import { extractTokensFromTree, tokensToJSON, tokensToTS } from '@/lib/export/tokens'
+import { buildAssetMapJSON } from '@/lib/export'
 
 /**
  * v12-2: Design Tokens Export Panel
@@ -10,6 +11,8 @@ import { extractTokensFromTree, tokensToJSON, tokensToTS } from '@/lib/export/to
 export default function TokensExportPanel() {
   const tree = useEditorStore((s) => s.tree)
   const tokens = useMemo(() => extractTokensFromTree(tree), [tree])
+  const [assetStats, setAssetStats] = useState<{ total: number; unique: number; duplicates: number } | null>(null)
+  const [busy, setBusy] = useState(false)
 
   const download = (filename: string, content: string, type = 'application/json') => {
     const blob = new Blob([content], { type })
@@ -21,6 +24,19 @@ export default function TokensExportPanel() {
     a.click()
     URL.revokeObjectURL(url)
     a.remove()
+  }
+
+  const handleDownloadAssetMap = async () => {
+    try {
+      setBusy(true)
+      const { json, map } = await buildAssetMapJSON(tree)
+      download('asset-map.json', json)
+      setAssetStats(map.stats)
+    } catch {
+      // no-op
+    } finally {
+      setBusy(false)
+    }
   }
 
   return (
@@ -77,6 +93,33 @@ export default function TokensExportPanel() {
               {tokens.spacing.space.join(', ') || '—'}
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* v12-3: Asset Map */}
+      <div className="rounded-lg border border-zinc-700 p-3 bg-zinc-900/50">
+        <div className="text-sm font-medium mb-2">Asset Map</div>
+        <p className="text-xs text-zinc-400 mb-3">
+          画像アセットをハッシュで重複判定し、参照先一覧とともに <code>asset-map.json</code> を出力します。
+          <br />
+          <span className="text-[11px]">
+            data:URL は <b>SHA-256</b>、それ以外のURLは <b>FNV-1a(文字列)</b> でハッシュ化（MVP）。
+          </span>
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm disabled:opacity-60"
+            onClick={handleDownloadAssetMap}
+            disabled={busy}
+          >
+            {busy ? 'Building…' : 'Build & Download Map'}
+          </button>
+          {assetStats && (
+            <span className="text-xs text-zinc-400">
+              total: {assetStats.total} / unique: {assetStats.unique}{' '}
+              {assetStats.duplicates > 0 && <>(dup: {assetStats.duplicates})</>}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/web/lib/assets.ts
+++ b/web/lib/assets.ts
@@ -118,3 +118,141 @@ export async function duplicates(): Promise<Record<string, AssetMeta[]>> {
 export async function touchAsset(id: string): Promise<void> {
   await db.images.update(id, { lastUsedAt: Date.now() });
 }
+
+/**
+ * v12-3: アセットマップ & 重複排除（書き出し連携）
+ * - ツリーを走査して画像アセット参照を抽出
+ * - ハッシュ（優先: data: のバイト→SHA-256, それ以外は FNV-1a 文字列ハッシュ）で重複をグルーピング
+ * - map.json 用の構造を返す
+ * 依存追加なし。ブラウザ標準 WebCrypto があれば SHA-256 を使用。
+ */
+
+export type AssetRef = {
+  /** 参照元ノードID */
+  nodeId: string;
+  /** 参照属性（例: src / backgroundImage(url)） */
+  attr: 'src' | 'backgroundImage';
+  /** 画像の参照先。data:URL か http(s) URL を想定 */
+  src: string;
+};
+
+export type AssetMapItem = {
+  hash: string;
+  assetIds: string[]; // "nodeId.attr" 形式
+  example: string; // 代表 src
+};
+export type AssetMap = {
+  hashAlgorithm: 'sha256' | 'fnv1a-32';
+  items: AssetMapItem[];
+  stats: { total: number; unique: number; duplicates: number };
+};
+
+/** ツリーから画像アセットを抽出 */
+export function extractAssetsFromTree(tree: any[]): AssetRef[] {
+  const out: AssetRef[] = [];
+  traverse(tree, (n: any) => {
+    const nodeId = n?.id;
+    if (!nodeId) return;
+    const p = n?.props ?? {};
+    const style = n?.style ?? {};
+    // 典型: 画像ノード props.src / imageSrc
+    const src = p.src ?? p.imageSrc;
+    if (typeof src === 'string' && src) {
+      out.push({ nodeId, attr: 'src', src });
+    }
+    // background-image: url("...") から抽出
+    const bg = style.backgroundImage;
+    if (typeof bg === 'string') {
+      const m = bg.match(/url\((['"]?)(.+?)\1\)/i);
+      if (m?.[2]) out.push({ nodeId, attr: 'backgroundImage', src: m[2] });
+    }
+  });
+  return out;
+}
+
+/** data:URL → Uint8Array へ（BASE64 のみ対応） */
+function dataUrlToBytes(dataUrl: string): Uint8Array | null {
+  if (!dataUrl.startsWith('data:')) return null;
+  const comma = dataUrl.indexOf(',');
+  if (comma < 0) return null;
+  const meta = dataUrl.slice(5, comma); // e.g. "image/png;base64"
+  const payload = dataUrl.slice(comma + 1);
+  if (!/;base64$/i.test(meta)) return null;
+  try {
+    const bin = atob(payload);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/** FNV-1a 32bit 文字列ハッシュ（依存なし・安定） */
+function fnv1a32(str: string): string {
+  let h = 0x811c9dc5 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+async function sha256(bytes: Uint8Array): Promise<string> {
+  if (typeof crypto !== 'undefined' && (crypto as any).subtle) {
+    const buf = await (crypto as any).subtle.digest('SHA-256', bytes);
+    const arr = new Uint8Array(buf);
+    return [...arr].map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  // フォールバック：バイト列を文字列化して FNV-1a
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return fnv1a32(s);
+}
+
+/** 単一アセットのハッシュ計算。戻り値: {hash, algo} */
+export async function hashAssetRef(a: AssetRef): Promise<{ hash: string; algo: 'sha256' | 'fnv1a-32' }> {
+  if (a.src.startsWith('data:')) {
+    const bytes = dataUrlToBytes(a.src);
+    if (bytes) {
+      return { hash: await sha256(bytes), algo: 'sha256' };
+    }
+  }
+  // NOTE: CORS を避けるため、http(s) は URL 文字列を FNV-1a でハッシュ化（MVP）
+  return { hash: fnv1a32(a.src), algo: 'fnv1a-32' };
+}
+
+/** アセットリストをハッシュでグルーピングして map を返す */
+export async function buildAssetMap(assets: AssetRef[]): Promise<AssetMap> {
+  const groups = new Map<string, { algo: 'sha256' | 'fnv1a-32'; items: AssetRef[] }>();
+  let algo: AssetMap['hashAlgorithm'] = 'sha256';
+  for (const a of assets) {
+    const { hash, algo: al } = await hashAssetRef(a);
+    if (al === 'fnv1a-32') algo = 'fnv1a-32'; // 混在時はフォールバック扱い
+    const g = groups.get(hash) ?? { algo: al, items: [] };
+    g.items.push(a);
+    groups.set(hash, g);
+  }
+  const items: AssetMapItem[] = [];
+  for (const [hash, g] of groups.entries()) {
+    items.push({
+      hash,
+      assetIds: g.items.map((x) => `${x.nodeId}.${x.attr}`),
+      example: g.items[0]?.src ?? '',
+    });
+  }
+  const total = assets.length;
+  const unique = items.length;
+  const duplicates = total - unique;
+  return { hashAlgorithm: algo, items: items.sort((a, b) => a.hash.localeCompare(b.hash)), stats: { total, unique, duplicates } };
+}
+
+// ========== internal ==========
+function traverse(nodes: any[], fn: (n: any) => void) {
+  for (const n of nodes ?? []) {
+    fn(n);
+    const ch = (n as any)?.children;
+    if (ch && Array.isArray(ch)) traverse(ch, fn);
+  }
+}
+

--- a/web/lib/export/index.ts
+++ b/web/lib/export/index.ts
@@ -1,17 +1,29 @@
+export { extractTokensFromTree, tokensToJSON, tokensToTS } from './tokens'
+export type { Tokens } from './tokens'
+
+import { buildAssetMap, extractAssetsFromTree, type AssetMap } from '@/lib/assets'
+
+/** ツリーからアセットマップ(JSON文字列)を生成して返す */
+export async function buildAssetMapJSON(tree: any[]): Promise<{ json: string; map: AssetMap }> {
+  const assets = extractAssetsFromTree(tree)
+  const map = await buildAssetMap(assets)
+  return { json: JSON.stringify(map, null, 2), map }
+}
+
 export interface ExportScope {
-  mode: 'selection' | 'frame' | 'page';
-  id?: string;
+  mode: 'selection' | 'frame' | 'page'
+  id?: string
 }
 
 export interface ExportOptions {
-  scale?: number; // 1..4, default 1
-  background?: 'transparent' | { color: string };
+  scale?: number // 1..4, default 1
+  background?: 'transparent' | { color: string }
 }
 
-export type ExportFormat = 'png' | 'svg' | 'html' | 'react';
+export type ExportFormat = 'png' | 'svg' | 'html' | 'react'
 
 export interface ExportPreset extends ExportOptions {
-  format: ExportFormat;
+  format: ExportFormat
 }
 
 export async function exportPNG(scope: ExportScope, opts?: ExportOptions) {


### PR DESCRIPTION
## Summary
- group image assets by hash to build asset map JSON
- expose asset map builder via export utilities
- allow Tokens Export panel to generate and download asset-map.json

## Testing
- `npm test` *(fails: Jest worker encountered exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aae19a8324832ca6b1413ecd5f5834