### PR TITLE
feat: add snapshot recovery

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { CanvasTiler, type Camera, type WorldRect } from '@/lib/render/tiler'
 import { useEditorStore } from '@/store/editorStore'
+import RecoveryPrompt from '@/components/hud/RecoveryPrompt'
 
 /**
  * v13-1: タイル描画ステージ実装（MVP）
@@ -128,6 +129,7 @@ export default function CanvasStage() {
       <div className="absolute top-2 right-2 z-10 text-xs px-2 py-1 rounded bg-zinc-900/80 border border-zinc-700 text-zinc-300">
         FPS: {fps}
       </div>
+      <RecoveryPrompt />
       {/* ヒント */}
       <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 text-[11px] px-2 py-1 rounded bg-zinc-900/60 border border-zinc-700 text-zinc-400">
         Drag to pan • Wheel to zoom • Ctrl+0 reset

--- a/web/components/hud/RecoveryPrompt.tsx
+++ b/web/components/hud/RecoveryPrompt.tsx
@@ -1,0 +1,75 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { useEditorStore } from '@/store/editorStore'
+import {
+  loadLatestSnapshot,
+  hasAnySnapshot,
+  markSessionAlive,
+  clearSessionAlive,
+  wasPreviousSessionCrashed,
+} from '@/lib/persist/snapshot'
+
+export default function RecoveryPrompt() {
+  const restoreFromSnapshot = useEditorStore((s) => s.restoreFromSnapshot)
+  const [open, setOpen] = useState(false)
+  const [ts, setTs] = useState<number | null>(null)
+
+  useEffect(() => {
+    markSessionAlive()
+    const onUnload = () => clearSessionAlive()
+    window.addEventListener('pagehide', onUnload)
+    window.addEventListener('beforeunload', onUnload)
+    ;(async () => {
+      const crashed = wasPreviousSessionCrashed()
+      const has = await hasAnySnapshot()
+      if (crashed && has) {
+        const latest = await loadLatestSnapshot()
+        if (latest) {
+          setTs(latest.ts)
+          setOpen(true)
+        }
+      }
+    })()
+    return () => {
+      window.removeEventListener('pagehide', onUnload)
+      window.removeEventListener('beforeunload', onUnload)
+    }
+  }, [])
+
+  if (!open) return null
+  const dateStr = ts ? new Date(ts).toLocaleString() : ''
+
+  return (
+    <div className="fixed inset-0 z-[999] grid place-items-center bg-black/40">
+      <div className="w-[420px] max-w-[92vw] rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl p-4">
+        <div className="text-sm font-semibold mb-1">前回の編集内容を復旧しますか？</div>
+        <div className="text-xs text-zinc-300 mb-4">
+          アプリが異常終了した可能性があります。直近のスナップショット
+          {dateStr && <span>（{dateStr}）</span>}
+          から復旧できます。
+        </div>
+        <div className="flex gap-2 justify-end">
+          <button
+            className="px-3 py-1.5 rounded bg-zinc-800 border border-zinc-700 text-sm hover:bg-zinc-700"
+            onClick={() => setOpen(false)}
+          >
+            今回はスキップ
+          </button>
+          <button
+            className="px-3 py-1.5 rounded bg-sky-600 border border-sky-500 text-sm hover:bg-sky-500"
+            onClick={async () => {
+              const latest = await loadLatestSnapshot()
+              if (latest) {
+                restoreFromSnapshot(latest.doc)
+              }
+              setOpen(false)
+            }}
+          >
+            復旧する
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/web/lib/persist/snapshot.ts
+++ b/web/lib/persist/snapshot.ts
@@ -1,0 +1,117 @@
+import Dexie, { type Table } from "dexie";
+
+export type SnapshotDoc = {
+  tree: any[];
+  components: Record<string, any>;
+  prototypeLinks: Record<string, any>;
+};
+
+type SnapshotRow = {
+  id?: number;
+  ts: number;
+  enc: "raw" | "gzip";
+  data: Uint8Array;
+};
+
+class SnapshotDB extends Dexie {
+  snapshots!: Table<SnapshotRow, number>;
+  constructor() {
+    super("ui_builder_snapshots_v1");
+    this.version(1).stores({
+      snapshots: "++id, ts",
+    });
+  }
+}
+
+const db = new SnapshotDB();
+
+export async function saveLatestSnapshot(doc: SnapshotDoc): Promise<number> {
+  const ts = Date.now();
+  const payload = { v: 1, ts, doc };
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  const compressed = await tryGzip(bytes);
+  const row: SnapshotRow = {
+    ts,
+    enc: compressed ? "gzip" : "raw",
+    data: compressed ?? bytes,
+  };
+  await db.snapshots.add(row);
+  try {
+    const all = await db.snapshots.orderBy("ts").toArray();
+    const excess = Math.max(0, all.length - 5);
+    for (let i = 0; i < excess; i++) await db.snapshots.delete(all[i].id!);
+  } catch {}
+  try {
+    localStorage.setItem("ui.snapshot.latestTs", String(ts));
+  } catch {}
+  return ts;
+}
+
+export async function loadLatestSnapshot(): Promise<
+  { ts: number; doc: SnapshotDoc } | null
+> {
+  const row = await db.snapshots.orderBy("ts").last();
+  if (!row) return null;
+  const bytes = row.enc === "gzip" ? await tryGunzip(row.data) : row.data;
+  const json = new TextDecoder().decode(bytes);
+  const payload = JSON.parse(json);
+  return { ts: payload.ts, doc: payload.doc as SnapshotDoc };
+}
+
+export async function hasAnySnapshot(): Promise<boolean> {
+  try {
+    const c = await db.snapshots.count();
+    return c > 0;
+  } catch {
+    return false;
+  }
+}
+
+const SESSION_KEY = "ui.session.alive";
+export function markSessionAlive() {
+  try {
+    localStorage.setItem(SESSION_KEY, "1");
+  } catch {}
+}
+export function clearSessionAlive() {
+  try {
+    localStorage.setItem(SESSION_KEY, "0");
+  } catch {}
+}
+export function wasPreviousSessionCrashed(): boolean {
+  try {
+    const v = localStorage.getItem(SESSION_KEY);
+    return v === "1";
+  } catch {
+    return false;
+  }
+}
+
+async function tryGzip(bytes: Uint8Array): Promise<Uint8Array | null> {
+  if (typeof (globalThis as any).CompressionStream === "undefined") return null;
+  try {
+    const cs = new (globalThis as any).CompressionStream("gzip");
+    const w = cs.writable.getWriter();
+    await w.write(bytes);
+    await w.close();
+    const buf = await new Response(cs.readable).arrayBuffer();
+    return new Uint8Array(buf);
+  } catch {
+    return null;
+  }
+}
+
+async function tryGunzip(bytes: Uint8Array): Promise<Uint8Array> {
+  if (typeof (globalThis as any).DecompressionStream === "undefined") return bytes;
+  try {
+    const ds = new (globalThis as any).DecompressionStream("gzip");
+    const w = ds.writable.getWriter();
+    await w.write(bytes);
+    await w.close();
+    const buf = await new Response(ds.readable).arrayBuffer();
+    return new Uint8Array(buf);
+  } catch {
+    return bytes;
+  }
+}
+

--- a/web/store/editorStore.d.ts
+++ b/web/store/editorStore.d.ts
@@ -1,0 +1,7 @@
+declare module '@/store/editorStore' {
+  interface EditorActions {
+    snapshotNow(): Promise<void>;
+    restoreFromSnapshot(doc: import('@/lib/persist/snapshot').SnapshotDoc): void;
+  }
+}
+

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -49,6 +49,10 @@ import { nanoid } from "nanoid";
 import { layoutText } from "@/lib/text/layout";
 import { applyRun, removeRun } from "@/lib/text/rangeOps";
 import { bumpComponentUsage, loadComponentsMeta } from "@/lib/persist/componentsMeta";
+import {
+  saveLatestSnapshot,
+  type SnapshotDoc,
+} from "@/lib/persist/snapshot";
 
 const updateUsageCounts = (draft: EditorState) => {
   const counts: Record<string, number> = {};
@@ -284,6 +288,7 @@ interface EditorActions {
 interface EditorPersistState {
   saveQueue: number[];
   lastSavedAt: number | null;
+  lastSnapshotAt: number | null;
   isOffline: boolean;
 }
 
@@ -355,6 +360,7 @@ export const useEditorStore = create<
         components: {},
         componentsQuery: '',
         componentsSort: 'az',
+        prototypeLinks: {},
         guides: [],
         assets: { images: {} },
         vector: { selection: {} },
@@ -383,6 +389,7 @@ export const useEditorStore = create<
         textSel: undefined,
         saveQueue: [],
         lastSavedAt: null,
+        lastSnapshotAt: null,
         isOffline: false,
         setHover(id) {
           set({ hoverId: id });
@@ -1712,6 +1719,23 @@ swapInstanceDef(nodeId, newDefId, opts) {
         redo() {
           set((state) => redoStack(state));
         },
+        async snapshotNow() {
+          const s = get();
+          const doc: SnapshotDoc = {
+            tree: s.tree,
+            components: s.components,
+            prototypeLinks: s.prototypeLinks,
+          };
+          const ts = await saveLatestSnapshot(doc);
+          set({ lastSnapshotAt: ts });
+        },
+        restoreFromSnapshot(doc) {
+          set({
+            tree: doc.tree || [],
+            components: doc.components || {},
+            prototypeLinks: doc.prototypeLinks || {},
+          });
+        },
       };
     },
     {
@@ -1773,3 +1797,25 @@ swapInstanceDef(nodeId, newDefId, opts) {
 );
 
 initPersist(useEditorStore);
+
+// ===== v13-4: スナップショット自動保存（サブスクライブ） =====
+let _snapTimer: number | null = null;
+let _changed = false;
+const SCHEDULE_MS = 20000; // 20s ごとにまとめて保存
+useEditorStore.subscribe(() => {
+  _changed = true;
+  if (_snapTimer != null) return;
+  _snapTimer = window.setTimeout(async () => {
+    try {
+      if (_changed) {
+        _changed = false;
+        await useEditorStore.getState().snapshotNow();
+      }
+    } finally {
+      if (_snapTimer) {
+        clearTimeout(_snapTimer);
+        _snapTimer = null;
+      }
+    }
+  }, SCHEDULE_MS);
+});

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -351,6 +351,7 @@ export interface EditorState {
   components: Record<string, ComponentDef>;
   componentsQuery?: string;
   componentsSort?: 'az' | 'recent' | 'usage';
+  prototypeLinks?: Record<string, any>;
   guides: Guide[];
   assets?: { images: Record<string, AssetMeta> };
   vector?: {


### PR DESCRIPTION
## Summary
- persist editor snapshots in IndexedDB with optional gzip compression
- allow restoring from latest snapshot on startup via RecoveryPrompt HUD
- schedule autosaving snapshots in editor store

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf797dd3c832c984dd6974c8affc0