### PR TITLE
feat: add offline commit queue with retry

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { CanvasTiler, type Camera, type WorldRect } from '@/lib/render/tiler'
 import { useEditorStore } from '@/store/editorStore'
 import RecoveryPrompt from '@/components/hud/RecoveryPrompt'
+import SaveIndicator from '@/components/hud/SaveIndicator'
 
 /**
  * v13-1: タイル描画ステージ実装（MVP）
@@ -128,6 +129,10 @@ export default function CanvasStage() {
       {/* HUD: FPS */}
       <div className="absolute top-2 right-2 z-10 text-xs px-2 py-1 rounded bg-zinc-900/80 border border-zinc-700 text-zinc-300">
         FPS: {fps}
+      </div>
+      <div className="absolute top-2 left-2 z-10">
+        {/* v13-5: 保存状態 */}
+        <SaveIndicator />
       </div>
       <RecoveryPrompt />
       {/* ヒント */}

--- a/web/components/hud/SaveIndicator.tsx
+++ b/web/components/hud/SaveIndicator.tsx
@@ -1,15 +1,40 @@
-'use client';
-
-import { useEditorStore } from '@/store/editorStore';
+'use client'
+import React from 'react'
+import { useEditorStore } from '@/store/editorStore'
 
 export default function SaveIndicator() {
-  const { saveQueue, lastSavedAt, isOffline } = useEditorStore((s) => ({
-    saveQueue: s.saveQueue,
-    lastSavedAt: s.lastSavedAt,
-    isOffline: s.isOffline,
-  }));
-  let text = 'All changes saved';
-  if (isOffline) text = 'Offline';
-  else if (saveQueue.length > 0) text = 'Saving…';
-  return <div className="text-xs text-gray-500">{text}</div>;
+  const pending = useEditorStore((s) => s.pendingVersion)
+  const committed = useEditorStore((s) => s.committedVersion)
+  const state = useEditorStore((s) => s.commitState)
+  const lastAt = useEditorStore((s) => s.lastCommittedAt)
+  const err = useEditorStore((s) => s.lastCommitError)
+
+  let label = 'Committed'
+  let cls = 'text-emerald-300 border-emerald-600'
+  if (state === 'committing') {
+    label = 'Committing…'
+    cls = 'text-sky-300 border-sky-600'
+  } else if (pending > committed) {
+    label = 'Pending'
+    cls = 'text-amber-300 border-amber-600'
+  }
+  if (state === 'error') {
+    label = 'Error — retrying…'
+    cls = 'text-red-300 border-red-600'
+  }
+
+  return (
+    <div
+      className={`px-2 py-1 rounded bg-zinc-900/80 border ${cls} text-xs`}
+      title={
+        state === 'error'
+          ? err ?? 'commit error'
+          : lastAt
+          ? `Last committed: ${new Date(lastAt).toLocaleString()}`
+          : ''
+      }
+    >
+      {label}
+    </div>
+  )
 }

--- a/web/lib/persist/commit.ts
+++ b/web/lib/persist/commit.ts
@@ -1,0 +1,51 @@
+/**
+ * v13-5: 二段階コミット保存（pending→committed）
+ * - IndexedDB(Dexie) を「サーバー擬き」のコミット先として利用（MVP）
+ * - リトライ（指数バックオフ＋ジッター）、重複防止（最新版のみコミット）
+ */
+import Dexie, { type Table } from 'dexie'
+
+type CommitRow = { k: string; ts: number; data: any }
+
+class CommitDB extends Dexie {
+  commits!: Table<CommitRow, string>
+  constructor() {
+    super('ui_builder_commits_v1')
+    this.version(1).stores({
+      commits: '&k',
+    })
+  }
+}
+const db = new CommitDB()
+
+/** サーバー相当：最新版として保存（id=k:'latest'） */
+export async function putCommitToIndexedDB(doc: any) {
+  await db.commits.put({ k: 'latest', ts: Date.now(), data: doc })
+}
+
+export type RetryOpts = { maxAttempts?: number; baseDelayMs?: number }
+
+export async function commitWithRetry(
+  doc: any,
+  opts: RetryOpts = { maxAttempts: 5, baseDelayMs: 600 },
+): Promise<void> {
+  const max = Math.max(1, opts.maxAttempts ?? 5)
+  const base = Math.max(100, opts.baseDelayMs ?? 600)
+  let lastErr: any = null
+  for (let i = 0; i < max; i++) {
+    try {
+      await putCommitToIndexedDB(doc)
+      return
+    } catch (e) {
+      lastErr = e
+      const jitter = Math.random() * 150
+      const backoff = base * Math.pow(2, i) + jitter
+      await delay(backoff)
+    }
+  }
+  throw lastErr ?? new Error('commit failed')
+}
+
+function delay(ms: number) {
+  return new Promise((res) => setTimeout(res, ms))
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -53,6 +53,7 @@ import {
   saveLatestSnapshot,
   type SnapshotDoc,
 } from "@/lib/persist/snapshot";
+import { commitWithRetry } from "@/lib/persist/commit";
 
 const updateUsageCounts = (draft: EditorState) => {
   const counts: Record<string, number> = {};
@@ -344,10 +345,14 @@ export const useEditorStore = create<
   persist(
     (set, get) => {
       const apply = (recipe: (draft: EditorState) => void) => {
-        const [next, patches, inverse] = produceWithPatches(get(), recipe);
+        const [next, patches, inverse] = produceWithPatches(get(), (draft) => {
+          recipe(draft);
+          draft.pendingVersion++;
+        });
         push(patches, inverse);
         set(next);
         schedulePersist();
+        scheduleCommit();
       };
 
       return {
@@ -387,6 +392,13 @@ export const useEditorStore = create<
         comments: { threads: {}, users: {} },
         styles: { text: {} },
         textSel: undefined,
+        dirtyNodes: {},
+        lastExportAt: null,
+        pendingVersion: 0,
+        committedVersion: 0,
+        commitState: 'idle',
+        lastCommittedAt: null,
+        lastCommitError: null,
         saveQueue: [],
         lastSavedAt: null,
         lastSnapshotAt: null,
@@ -703,6 +715,7 @@ export const useEditorStore = create<
 
             draft.tree.push(inst);
             draft.selectedIds = [id];
+            draft.dirtyNodes[id] = Date.now();
           });
           bumpComponentUsage(componentId).catch(() => {});
         },
@@ -813,6 +826,7 @@ setInstanceProp(nodeId, propId, value) {
     const inst = findNode(draft.tree, nodeId) as InstanceNode | null;
     if (!inst) return;
     inst.propValues = { ...(inst.propValues || {}), [propId]: value };
+    draft.dirtyNodes[nodeId] = Date.now();
   });
 },
 
@@ -1797,6 +1811,47 @@ swapInstanceDef(nodeId, newDefId, opts) {
 );
 
 initPersist(useEditorStore);
+
+// ===== v13-5: コミットキュー（単一並列・最新版のみ） =====
+let _commitTimer: number | null = null;
+let _commitScheduledAt = 0;
+const DEBOUNCE_MS = 700;
+const RETRY_AFTER_MS = 3000;
+
+function scheduleCommit() {
+  if (_commitTimer) clearTimeout(_commitTimer);
+  _commitTimer = window.setTimeout(runCommit, DEBOUNCE_MS);
+  _commitScheduledAt = Date.now();
+}
+
+async function runCommit() {
+  _commitTimer = null;
+  const s = useEditorStore.getState();
+  if (s.pendingVersion <= s.committedVersion) return;
+  if (s.commitState === 'committing') return;
+  const payload: SnapshotDoc = {
+    tree: s.tree,
+    components: s.components,
+    prototypeLinks: s.prototypeLinks,
+  };
+  useEditorStore.setState({ commitState: 'committing', lastCommitError: null });
+  try {
+    await commitWithRetry(payload, { maxAttempts: 4, baseDelayMs: 700 });
+    const committedVersion = useEditorStore.getState().pendingVersion;
+    useEditorStore.setState({
+      commitState: 'idle',
+      committedVersion,
+      lastCommittedAt: Date.now(),
+      lastCommitError: null,
+    });
+    if (useEditorStore.getState().pendingVersion > committedVersion) {
+      scheduleCommit();
+    }
+  } catch (e: any) {
+    useEditorStore.setState({ commitState: 'error', lastCommitError: String(e?.message || e) });
+    setTimeout(scheduleCommit, RETRY_AFTER_MS);
+  }
+}
 
 // ===== v13-4: スナップショット自動保存（サブスクライブ） =====
 let _snapTimer: number | null = null;

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -389,6 +389,16 @@ export interface EditorState {
     filter?: { status?: ThreadStatus[]; onlySelection?: boolean };
   };
   variantSets: Record<string, VariantSet>;
+  /** v12-4: 差分エクスポート用 */
+  dirtyNodes: Record<string, number>;
+  lastExportAt: number | null;
+  lastSnapshotAt: number | null;
+  /** v13-5: 二段階コミット保存 */
+  pendingVersion: number;
+  committedVersion: number;
+  commitState: 'idle' | 'committing' | 'error';
+  lastCommittedAt: number | null;
+  lastCommitError: string | null;
 }
 
 // Component Props (ユーザー定義プロパティ)


### PR DESCRIPTION
## Summary
- store pending/committed versions and queue commits with exponential backoff using IndexedDB
- show SaveIndicator HUD for pending/committing/error states

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf90c2110832c9056a083f556eca4