### PR TITLE
feat: add BVH hit testing for canvas stage

### DIFF
--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -4,6 +4,7 @@ import { CanvasTiler, type Camera, type WorldRect } from '@/lib/render/tiler'
 import { useEditorStore } from '@/store/editorStore'
 import RecoveryPrompt from '@/components/hud/RecoveryPrompt'
 import SaveIndicator from '@/components/hud/SaveIndicator'
+import { updateHitIndex, pickAt } from '@/lib/vector/hitTest'
 
 /**
  * v13-1: タイル描画ステージ実装（MVP）
@@ -30,6 +31,7 @@ export default function CanvasStage() {
     const onResizeDpr = () => tiler.setDpr(window.devicePixelRatio || 1)
     onResizeDpr()
     window.addEventListener('resize', onResizeDpr)
+    updateHitIndex(tree) // 初期構築
     const raf = () => {
       const f = fpsRef.current
       f.frames++
@@ -54,6 +56,7 @@ export default function CanvasStage() {
   // シーン更新のたびに全タイル無効化（MVP）
   useEffect(() => {
     tilerRef.current?.invalidateAll()
+    updateHitIndex(tree)
   }, [tree])
 
   // ====== 入力（パン/ズーム） ======
@@ -88,6 +91,21 @@ export default function CanvasStage() {
     }
     const onPointerUp = (e: PointerEvent) => {
       dragging = false
+      // 左クリック・ドラッグ量が小さければヒットテスト例（MVP）
+      if (e.button === 0) {
+        const rect = el.getBoundingClientRect()
+        const dpr = window.devicePixelRatio || 1
+        // CSS px → ワールド座標（CanvasTiler の変換と一致させる）
+        const px = (e.clientX - rect.left) / dpr
+        const py = (e.clientY - rect.top) / dpr
+        const wx = cam.x + px / cam.scale
+        const wy = cam.y + py / cam.scale
+        const id = pickAt(wx, wy)
+        if (id) {
+          // 既存の選択APIがある前提（なければ no-op）
+          try { useEditorStore.getState().select([id]) } catch {}
+        }
+      }
     }
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()

--- a/web/lib/hittest/bvh.ts
+++ b/web/lib/hittest/bvh.ts
@@ -1,0 +1,125 @@
+/**
+ * v13-2: BVH ヒットテスト（AABBツリー）
+ *
+ * - 軸に沿った中央値分割の AABB ツリー（再帰・葉は最大8件）
+ * - 点ヒット / 矩形クエリ（重なり）をサポート
+ * - zOrder（描画順）で降順ソートして最前面を返却
+ * - 依存なし。1kノードで>3×、5kで>5×の高速化を狙う（目安）
+ */
+
+export type AABB = { minX: number; minY: number; maxX: number; maxY: number }
+export type Item = { id: string; box: AABB; zOrder: number; visible?: boolean }
+
+export type BVHNode =
+  | { type: 'leaf'; box: AABB; items: Item[] }
+  | { type: 'branch'; box: AABB; left: BVHNode; right: BVHNode }
+
+const LEAF_CAPACITY = 8
+
+export function buildBVH(items: Item[]): BVHNode | null {
+  const src = items.filter((i) => i.visible !== false && valid(i.box))
+  if (src.length === 0) return null
+  return build(src)
+}
+
+export function hitTestPoint(root: BVHNode | null, x: number, y: number): Item | null {
+  if (!root) return null
+  // 走査しつつ zOrder 降順で最初に当たったものを返す
+  let best: Item | null = null
+  const stack: BVHNode[] = [root]
+  while (stack.length) {
+    const n = stack.pop()!
+    if (!containsPoint(n.box, x, y)) continue
+    if (n.type === 'leaf') {
+      for (let i = 0; i < n.items.length; i++) {
+        const it = n.items[i]
+        if (containsPoint(it.box, x, y)) {
+          if (!best || it.zOrder > best.zOrder) best = it
+        }
+      }
+    } else {
+      // 描画順とは無関係だが、探索を先に進めてもよい
+      stack.push(n.left, n.right)
+    }
+  }
+  return best
+}
+
+export function queryOverlap(root: BVHNode | null, r: AABB): Item[] {
+  if (!root) return []
+  const out: Item[] = []
+  const stack: BVHNode[] = [root]
+  while (stack.length) {
+    const n = stack.pop()!
+    if (!intersects(n.box, r)) continue
+    if (n.type === 'leaf') {
+      for (let i = 0; i < n.items.length; i++) {
+        const it = n.items[i]
+        if (intersects(it.box, r)) out.push(it)
+      }
+    } else {
+      stack.push(n.left, n.right)
+    }
+  }
+  // 表示順でソート（前面が先頭）
+  out.sort((a, b) => b.zOrder - a.zOrder)
+  return out
+}
+
+// ===== internal =====
+function build(list: Item[]): BVHNode {
+  const nodeBox = list.reduce(expandToFit, makeEmptyAABB())
+  if (list.length <= LEAF_CAPACITY) {
+    // 葉。描画順（zOrder降順）に詰めておく
+    const items = list.slice().sort((a, b) => b.zOrder - a.zOrder)
+    return { type: 'leaf', box: nodeBox, items }
+  }
+  const extX = nodeBox.maxX - nodeBox.minX
+  const extY = nodeBox.maxY - nodeBox.minY
+  const axis: 'x' | 'y' = extX >= extY ? 'x' : 'y'
+  const centers = list.map((it) => ({
+    c: axis === 'x' ? (it.box.minX + it.box.maxX) / 2 : (it.box.minY + it.box.maxY) / 2,
+    it,
+  }))
+  centers.sort((a, b) => a.c - b.c)
+  const mid = centers.length >> 1
+  const left = centers.slice(0, mid).map((c) => c.it)
+  const right = centers.slice(mid).map((c) => c.it)
+  // 片寄り防止（極端な場合は分割しないで葉に）
+  if (left.length === 0 || right.length === 0) {
+    const items = list.slice().sort((a, b) => b.zOrder - a.zOrder)
+    return { type: 'leaf', box: nodeBox, items }
+  }
+  const L = build(left)
+  const R = build(right)
+  const box = mergeAABB(L.box, R.box)
+  return { type: 'branch', box, left: L, right: R }
+}
+
+function containsPoint(b: AABB, x: number, y: number) {
+  return x >= b.minX && x <= b.maxX && y >= b.minY && y <= b.maxY
+}
+function intersects(a: AABB, b: AABB) {
+  return a.minX <= b.maxX && a.maxX >= b.minX && a.minY <= b.maxY && a.maxY >= b.minY
+}
+function valid(b: AABB) {
+  return Number.isFinite(b.minX) && Number.isFinite(b.minY) && Number.isFinite(b.maxX) && Number.isFinite(b.maxY)
+}
+function makeEmptyAABB(): AABB {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+}
+function expandToFit(box: AABB, it: Item) {
+  box.minX = Math.min(box.minX, it.box.minX)
+  box.minY = Math.min(box.minY, it.box.minY)
+  box.maxX = Math.max(box.maxX, it.box.maxX)
+  box.maxY = Math.max(box.maxY, it.box.maxY)
+  return box
+}
+function mergeAABB(a: AABB, b: AABB): AABB {
+  return {
+    minX: Math.min(a.minX, b.minX),
+    minY: Math.min(a.minY, b.minY),
+    maxX: Math.max(a.maxX, b.maxX),
+    maxY: Math.max(a.maxY, b.maxY),
+  }
+}

--- a/web/lib/vector/hitTest.ts
+++ b/web/lib/vector/hitTest.ts
@@ -1,0 +1,93 @@
+/**
+ * v13-2: ヒットテスト（BVH 経由）
+ *
+ * - エディタツリーから AABB と zOrder を抽出して BVH を構築
+ * - ポイントヒット / 矩形選択（重なり）API を提供
+ * - 既存の呼び出し側からは updateHitIndex(tree), pickAt, queryRect を使用
+ *
+ * ※ 変形（回転/スケール）は MVP では未対応。AABB は left/top/width/height を基準に算出。
+ */
+import { buildBVH, hitTestPoint, queryOverlap, type AABB, type BVHNode, type Item } from '@/lib/hittest/bvh'
+
+let _root: BVHNode | null = null
+let _idToItem = new Map<string, Item>()
+let _version = 0
+
+export function updateHitIndex(tree: any[]) {
+  _idToItem.clear()
+  const items: Item[] = []
+  let z = 0
+  traverse(tree, (n: any) => {
+    const id = String(n?.id ?? '')
+    if (!id) return
+    const vis = isVisible(n)
+    const box = aabbOf(n)
+    if (!box) return
+    // z は描画順（後に来る = 前面）
+    items.push({ id, box, zOrder: z++, visible: vis })
+  })
+  _root = buildBVH(items)
+  for (const it of items) _idToItem.set(it.id, it)
+  _version++
+}
+
+/** クリック等のヒットテスト（前面の1件の id を返す） */
+export function pickAt(x: number, y: number): string | null {
+  if (!_root) return null
+  const it = hitTestPoint(_root, x, y)
+  return it?.id ?? null
+}
+
+/** 矩形選択（重なった id を zOrder 降順で返す） */
+export function queryRect(x: number, y: number, w: number, h: number): string[] {
+  if (!_root) return []
+  const r: AABB = {
+    minX: Math.min(x, x + w),
+    minY: Math.min(y, y + h),
+    maxX: Math.max(x, x + w),
+    maxY: Math.max(y, y + h),
+  }
+  const items = queryOverlap(_root, r)
+  return items.map((it) => it.id)
+}
+
+export function currentHitIndexVersion() {
+  return _version
+}
+
+// ===== Helpers =====
+function aabbOf(n: any): AABB | null {
+  const s = n?.style ?? {}
+  const p = n?.props ?? {}
+  const x = pickNum(s.left, p.x, 0)
+  const y = pickNum(s.top, p.y, 0)
+  const w = pickNum(s.width, p.w, 0)
+  const h = pickNum(s.height, p.h, 0)
+  if (!(isFiniteNum(x) && isFiniteNum(y) && isFiniteNum(w) && isFiniteNum(h))) return null
+  return { minX: x, minY: y, maxX: x + w, maxY: y + h }
+}
+function isVisible(n: any): boolean {
+  const s = n?.style ?? {}
+  const p = n?.props ?? {}
+  if (p.visible === false) return false
+  if (s.display === 'none') return false
+  if (Number(s.opacity) === 0 || Number(p.opacity) === 0) return false
+  return true
+}
+function traverse(nodes: any[], fn: (n: any) => void) {
+  for (const n of nodes ?? []) {
+    fn(n)
+    const ch = n?.children
+    if (ch && Array.isArray(ch)) traverse(ch, fn)
+  }
+}
+function pickNum(...vals: any[]): number {
+  for (const v of vals) {
+    const n = Number(v)
+    if (!Number.isNaN(n)) return n
+  }
+  return 0
+}
+function isFiniteNum(v: any): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -555,3 +555,9 @@ export interface EditorState {
   data?: DataState;
   vars?: VariablesState;
 }
+
+// ヒットテスト関連の（既存 or 参照用）型補助（必要なら拡張）
+export type HitTestAPI = {
+  updateHitIndex(tree: any[]): void
+  pickAt(x: number, y: number): string | null
+}


### PR DESCRIPTION
## Summary
- add AABB BVH utilities for point and overlap hit tests
- build BVH from editor tree and expose pickAt/queryRect helpers
- integrate BVH hit testing into CanvasStage and expose type helper

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68aafa9512d8832ca9dbfa098b605749