### PR TITLE
Refactor export features and canvas rendering

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "max-lines": ["warn", { "max": 400, "skipBlankLines": true, "skipComments": true }],
+    "max-lines-per-function": ["warn", { "max": 120, "skipBlankLines": true, "skipComments": true, "IIFEs": true }],
+    "complexity": ["warn", { "max": 12 }],
+    "max-depth": ["warn", 4],
+    "max-params": ["warn", 6]
+  }
+}

--- a/web/components/editor/CanvasStage.tsx
+++ b/web/components/editor/CanvasStage.tsx
@@ -1,229 +1,65 @@
 'use client'
-import React, { useEffect, useRef, useState } from 'react'
-import { CanvasTiler, type Camera, type WorldRect } from '@/lib/render/tiler'
+import React, { useMemo, useRef } from 'react'
 import { useEditorStore } from '@/store/editorStore'
 import RecoveryPrompt from '@/components/hud/RecoveryPrompt'
 import SaveIndicator from '@/components/hud/SaveIndicator'
 import { updateHitIndex, pickAt } from '@/lib/vector/hitTest'
+import { useFPS } from '@/hooks/editor/useFPS'
+import { useCanvasTiler } from '@/hooks/editor/useCanvasTiler'
+import { usePanZoomCamera } from '@/hooks/editor/usePanZoomCamera'
+import { drawScene } from '@/lib/render/drawScene'
 
-/**
- * v13-1: タイル描画ステージ実装（MVP）
- * - 右ドラッグ：パン、ホイール：ズーム（Ctrl+0 でリセット）
- * - タイル化 + OffscreenCanvas によるオーバードロー削減
- * - FPS 簡易表示
- */
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const tilerRef = useRef<CanvasTiler | null>(null)
-  const [fps, setFps] = useState(0)
-  const fpsRef = useRef({ last: performance.now(), frames: 0 })
-  const tree = useEditorStore((s) => s.tree) // 既存のシーン構造（revには未連動）
+  const fps = useFPS()
+  const tree = useEditorStore((s) => s.tree)
 
-  // Tiler 初期化
-  useEffect(() => {
+  // tiler（描画）とヒットインデックス
+  const draw = useMemo(
+    () => (ctx: CanvasRenderingContext2D, r: any, cam: any, dpr: number) => drawScene(ctx, r, cam, dpr, tree),
+    [tree],
+  )
+  const tilerRef = useCanvasTiler(canvasRef, draw)
+  React.useEffect(() => updateHitIndex(tree), [tree])
+
+  // カメラ（パン / ズーム）
+  usePanZoomCamera(canvasRef, (cam) => tilerRef.current?.setCamera(cam))
+
+  // クリック選択（MVP）
+  React.useEffect(() => {
     const el = canvasRef.current
     if (!el) return
-    const tiler = new CanvasTiler(el, { tileSize: 768 })
-    tiler.setDraw((ctx, tileRect, cam, dpr) => {
-      drawScene(ctx, tileRect, cam, dpr, tree)
-    })
-    tilerRef.current = tiler
-    const onResizeDpr = () => tiler.setDpr(window.devicePixelRatio || 1)
-    onResizeDpr()
-    window.addEventListener('resize', onResizeDpr)
-    updateHitIndex(tree) // 初期構築
-    const raf = () => {
-      const f = fpsRef.current
-      f.frames++
-      const now = performance.now()
-      if (now - f.last >= 500) {
-        setFps(Math.round((f.frames * 1000) / (now - f.last)))
-        f.frames = 0
-        f.last = now
-      }
-      requestAnimationFrame(raf)
-    }
-    const id = requestAnimationFrame(raf)
-    return () => {
-      window.removeEventListener('resize', onResizeDpr)
-      cancelAnimationFrame(id)
-      tiler.destroy()
-      tilerRef.current = null
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // シーン更新のたびに全タイル無効化（MVP）
-  useEffect(() => {
-    tilerRef.current?.invalidateAll()
-    updateHitIndex(tree)
-  }, [tree])
-
-  // ====== 入力（パン/ズーム） ======
-  useEffect(() => {
-    const el = canvasRef.current
-    const tiler = tilerRef.current
-    if (!el || !tiler) return
-
-    const cam: Camera = { x: -512, y: -512, scale: 1 } // 初期位置（原点を中央寄せ）
-    tiler.setCamera(cam)
-
-    let dragging = false
-    let lastX = 0
-    let lastY = 0
-
-    const onPointerDown = (e: PointerEvent) => {
-      if (e.button !== 0 && e.button !== 1 && e.button !== 2) return
-      dragging = true
-      lastX = e.clientX
-      lastY = e.clientY
-      ;(e.target as Element).setPointerCapture?.(e.pointerId)
-    }
-    const onPointerMove = (e: PointerEvent) => {
-      if (!dragging) return
-      const dx = (e.clientX - lastX) / cam.scale
-      const dy = (e.clientY - lastY) / cam.scale
-      cam.x -= dx
-      cam.y -= dy
-      lastX = e.clientX
-      lastY = e.clientY
-      tiler.setCamera(cam)
-    }
     const onPointerUp = (e: PointerEvent) => {
-      dragging = false
-      // 左クリック・ドラッグ量が小さければヒットテスト例（MVP）
-      if (e.button === 0) {
-        const rect = el.getBoundingClientRect()
-        const dpr = window.devicePixelRatio || 1
-        // CSS px → ワールド座標（CanvasTiler の変換と一致させる）
-        const px = (e.clientX - rect.left) / dpr
-        const py = (e.clientY - rect.top) / dpr
-        const wx = cam.x + px / cam.scale
-        const wy = cam.y + py / cam.scale
-        const id = pickAt(wx, wy)
-        if (id) {
-          // 既存の選択APIがある前提（なければ no-op）
-          try { useEditorStore.getState().select([id]) } catch {}
-        }
-      }
-    }
-    const onWheel = (e: WheelEvent) => {
-      e.preventDefault()
+      if (e.button !== 0) return
       const rect = el.getBoundingClientRect()
-      const px = (e.clientX - rect.left) / (window.devicePixelRatio || 1)
-      const py = (e.clientY - rect.top) / (window.devicePixelRatio || 1)
+      const dpr = window.devicePixelRatio || 1
+      const px = (e.clientX - rect.left) / dpr
+      const py = (e.clientY - rect.top) / dpr
+      // 現在のカメラは tiler が保持しているので、暫定で store から選択のみ
+      const state: any = (tilerRef.current as any)
+      const cam = state?._cam || { x: -512, y: -512, scale: 1 }
       const wx = cam.x + px / cam.scale
       const wy = cam.y + py / cam.scale
-      const s = Math.exp(-e.deltaY * 0.001) // smooth zoom
-      const next = Math.min(8, Math.max(0.2, cam.scale * s))
-      cam.x = wx - (px / next)
-      cam.y = wy - (py / next)
-      cam.scale = next
-      tiler.setCamera(cam)
+      const id = pickAt(wx, wy)
+      if (id) { try { useEditorStore.getState().select([id]) } catch {} }
     }
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === '0') {
-        cam.x = -512; cam.y = -512; cam.scale = 1
-        tiler.setCamera(cam)
-      }
-    }
-    el.addEventListener('pointerdown', onPointerDown)
-    window.addEventListener('pointermove', onPointerMove)
-    window.addEventListener('pointerup', onPointerUp)
-    el.addEventListener('wheel', onWheel, { passive: false })
-    window.addEventListener('keydown', onKey)
-    return () => {
-      el.removeEventListener('pointerdown', onPointerDown)
-      window.removeEventListener('pointermove', onPointerMove)
-      window.removeEventListener('pointerup', onPointerUp)
-      el.removeEventListener('wheel', onWheel)
-      window.removeEventListener('keydown', onKey)
-    }
-  }, [])
+    el.addEventListener('pointerup', onPointerUp)
+    return () => el.removeEventListener('pointerup', onPointerUp)
+  }, [tilerRef])
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-zinc-950">
       <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
-      {/* HUD: FPS */}
       <div className="absolute top-2 right-2 z-10 text-xs px-2 py-1 rounded bg-zinc-900/80 border border-zinc-700 text-zinc-300">
         FPS: {fps}
       </div>
       <div className="absolute top-2 left-2 z-10">
-        {/* v13-5: 保存状態 */}
         <SaveIndicator />
       </div>
       <RecoveryPrompt />
-      {/* ヒント */}
       <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 text-[11px] px-2 py-1 rounded bg-zinc-900/60 border border-zinc-700 text-zinc-400">
         Drag to pan • Wheel to zoom • Ctrl+0 reset
       </div>
     </div>
   )
-}
-
-// ====== デモ描画 / 既存レンダラ差し替えポイント ======
-function drawScene(
-  ctx: CanvasRenderingContext2D,
-  tileRect: WorldRect,
-  cam: Camera,
-  dpr: number,
-  tree: any[],
-) {
-  // 1) 背景グリッド（タイルごと）
-  drawGrid(ctx, tileRect)
-
-  // 2) 既存のノードを簡易描画（MVP: frame/text/image の名前のみ）
-  try {
-    traverse(tree, (n: any) => {
-      const t = String(n?.type ?? '')
-      const id = n?.id
-      const x = Number(n?.style?.left ?? n?.props?.x ?? 0)
-      const y = Number(n?.style?.top ?? n?.props?.y ?? 0)
-      const w = Number(n?.style?.width ?? n?.props?.w ?? 120)
-      const h = Number(n?.style?.height ?? n?.props?.h ?? 60)
-      if (!aabbIntersect({ x, y, w, h }, tileRect)) return
-      ctx.save()
-      ctx.translate(x, y)
-      ctx.fillStyle = t === 'frame' ? '#1f2937' : t === 'text' ? '#0ea5e9' : '#334155'
-      ctx.strokeStyle = '#475569'
-      ctx.lineWidth = 1
-      ctx.fillRect(0, 0, w, h)
-      ctx.strokeRect(0, 0, w, h)
-      ctx.fillStyle = '#e2e8f0'
-      ctx.font = '12px ui-sans-serif, system-ui'
-      ctx.fillText(`${t}:${n?.name ?? id}`, 6, 16)
-      ctx.restore()
-    })
-  } catch {
-    // 失敗しても描画は継続
-  }
-}
-
-function drawGrid(ctx: CanvasRenderingContext2D, r: WorldRect) {
-  const step = 64
-  const x0 = Math.floor(r.x / step) * step
-  const y0 = Math.floor(r.y / step) * step
-  ctx.save()
-  ctx.strokeStyle = 'rgba(148,163,184,0.15)'
-  ctx.lineWidth = 1
-  for (let x = x0; x < r.x + r.w; x += step) {
-    ctx.beginPath(); ctx.moveTo(x, r.y); ctx.lineTo(x, r.y + r.h); ctx.stroke()
-  }
-  for (let y = y0; y < r.y + r.h; y += step) {
-    ctx.beginPath(); ctx.moveTo(r.x, y); ctx.lineTo(r.x + r.w, y); ctx.stroke()
-  }
-  // タイル境界の可視化
-  ctx.strokeStyle = 'rgba(14,165,233,0.4)'
-  ctx.strokeRect(r.x, r.y, r.w, r.h)
-  ctx.restore()
-}
-
-function traverse(nodes: any[], fn: (n: any) => void) {
-  for (const n of nodes ?? []) {
-    fn(n)
-    if (n?.children) traverse(n.children, fn)
-  }
-}
-function aabbIntersect(a: WorldRect, b: WorldRect) {
-  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
 }

--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -4,7 +4,6 @@ import CanvasStage from './CanvasStage';
 import RightPane from './RightPane';
 import CommandPalette from './CommandPalette';
 import ContextMenu from './ContextMenu';
-import ExportPanel from './ExportPanel';
 import ShareButton from './ShareButton';
 import { useState, useEffect } from 'react';
 import { getCommand } from '@/lib/keymap';
@@ -13,7 +12,6 @@ import { useEditorStore } from '@/store/editorStore';
 
 export default function EditorShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const [exportOpen, setExportOpen] = useState(false);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -56,11 +54,8 @@ export default function EditorShell() {
       }
     };
     window.addEventListener('keydown', handler);
-    const openListener = () => setExportOpen(true);
-    window.addEventListener('uibuilder:export', openListener as any);
     return () => {
       window.removeEventListener('keydown', handler);
-      window.removeEventListener('uibuilder:export', openListener as any);
     };
   }, []);
 
@@ -74,7 +69,6 @@ export default function EditorShell() {
       <RightPane />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <ContextMenu />
-      <ExportPanel open={exportOpen} onClose={() => setExportOpen(false)} />
     </div>
   );
 }

--- a/web/components/editor/ExportPanel.tsx
+++ b/web/components/editor/ExportPanel.tsx
@@ -1,123 +1,18 @@
-'use client';
-import { useState } from 'react';
-import {
-  exportMany,
-  PRESETS,
-  ExportScope,
-  ExportOptions,
-  ExportPreset,
-} from '@/lib/export';
-import { useEditorStore } from '@/store/editorStore';
+'use client'
+import React from 'react'
+import DesignTokensCard from '@/components/editor/export/DesignTokensCard'
+import AssetMapCard from '@/components/editor/export/AssetMapCard'
+import DiffExportCard from '@/components/editor/export/DiffExportCard'
+import ReactCodeCard from '@/components/editor/export/ReactCodeCard'
 
-export default function ExportPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const [tab, setTab] = useState<'presets' | 'custom'>('presets');
-  const [format, setFormat] = useState<'png' | 'svg' | 'html' | 'react'>('png');
-  const [scale, setScale] = useState(1);
-  const [background, setBackground] = useState<'transparent' | 'white'>('transparent');
-  const selectedIds = useEditorStore((s) => s.selectedIds);
-  if (!open) return null;
-
-  const download = (blob: Blob, filename: string) => {
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const handleExport = async () => {
-    const scopes: ExportScope[] =
-      selectedIds.length > 1
-        ? selectedIds.map((id) => ({ mode: 'frame', id }))
-        : [{ mode: 'selection' }];
-    const opts: ExportOptions = {
-      scale,
-      background: background === 'transparent' ? 'transparent' : { color: background },
-    };
-    const results = await exportMany(scopes, { format, ...opts } as ExportPreset);
-    results.forEach((res, i) => {
-      let blob: Blob;
-      if (format === 'png') blob = res as Blob;
-      else if (format === 'svg')
-        blob = res instanceof Blob ? res : new Blob([res as any], { type: 'image/svg+xml' });
-      else if (format === 'html')
-        blob = new Blob([(res as any).html], { type: 'text/html' });
-      else blob = new Blob([(res as any).jsx], { type: 'text/plain' });
-      download(blob, `export-${i}.${format === 'react' ? 'tsx' : format}`);
-    });
-    onClose();
-  };
-
+export default function ExportPanel() {
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
-      <div className="bg-white text-black p-4 rounded" onClick={(e) => e.stopPropagation()}>
-        <h2 className="mb-2">Export</h2>
-        <div className="mb-2 border-b flex mb-4">
-          <button className={`px-2 py-1 ${tab === 'presets' ? 'border-b-2' : ''}`} onClick={() => setTab('presets')}>Presets</button>
-          <button className={`px-2 py-1 ${tab === 'custom' ? 'border-b-2' : ''}`} onClick={() => setTab('custom')}>Custom</button>
-        </div>
-        {tab === 'presets' ? (
-          <div className="space-y-2">
-            {Object.entries(PRESETS).map(([id, p]) => (
-              <button
-                key={id}
-                className="px-2 py-1 border block w-full text-left"
-                onClick={async () => {
-                  const scopes: ExportScope[] =
-                    selectedIds.length > 1
-                      ? selectedIds.map((sid) => ({ mode: 'frame', id: sid }))
-                      : [{ mode: 'selection' }];
-                  const results = await exportMany(scopes, p);
-                  results.forEach((res, i) => {
-                    let blob: Blob;
-                    if (p.format === 'png') blob = res as Blob;
-                    else if (p.format === 'svg')
-                      blob = res instanceof Blob ? res : new Blob([res as any], { type: 'image/svg+xml' });
-                    else if (p.format === 'html')
-                      blob = new Blob([(res as any).html], { type: 'text/html' });
-                    else blob = new Blob([(res as any).jsx], { type: 'text/plain' });
-                    download(blob, `export-${i}.${p.format === 'react' ? 'tsx' : p.format}`);
-                  });
-                  onClose();
-                }}
-              >
-                {id.toUpperCase()}
-              </button>
-            ))}
-          </div>
-        ) : (
-          <>
-            <div className="mb-2">
-              <label className="mr-2">Format</label>
-              <select value={format} onChange={(e) => setFormat(e.target.value as any)}>
-                <option value="png">PNG</option>
-                <option value="svg">SVG</option>
-                <option value="html">HTML</option>
-                <option value="react">React</option>
-              </select>
-            </div>
-            <div className="mb-2">
-              <label className="mr-2">Scale</label>
-              <select value={scale} onChange={(e) => setScale(Number(e.target.value))}>
-                {[1, 2, 3, 4].map((s) => (
-                  <option key={s} value={s}>{`${s}x`}</option>
-                ))}
-              </select>
-            </div>
-            <div className="mb-4">
-              <label className="mr-2">Background</label>
-              <select value={background} onChange={(e) => setBackground(e.target.value as any)}>
-                <option value="transparent">Transparent</option>
-                <option value="white">White</option>
-              </select>
-            </div>
-            <button className="px-2 py-1 border" onClick={handleExport}>
-              Export
-            </button>
-          </>
-        )}
-      </div>
+    <div className="space-y-3">
+      <div className="text-xs uppercase tracking-wider text-zinc-400">Export</div>
+      <DesignTokensCard />
+      <AssetMapCard />
+      <DiffExportCard />
+      <ReactCodeCard />
     </div>
-  );
+  )
 }

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -12,7 +12,7 @@ import type {
 import { mapNodesForSwap } from "@/lib/override/compat";
 import { listOverridable } from "@/lib/override/util";
 import { findNode } from "@/lib/tree";
-import TokensExportPanel from "@/components/editor/TokensExportPanel";
+import ExportPanel from "@/components/editor/ExportPanel";
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedIds[0]);
@@ -438,7 +438,7 @@ export default function RightPane() {
       </div>
       {/* v12-2: Export（Design Tokens） */}
       <div className="pt-2 border-t border-zinc-800">
-        <TokensExportPanel />
+        <ExportPanel />
       </div>
     </div>
   );

--- a/web/components/editor/export/AssetMapCard.tsx
+++ b/web/components/editor/export/AssetMapCard.tsx
@@ -1,0 +1,61 @@
+'use client'
+import React, { useState } from 'react'
+import { useEditorStore } from '@/store/editorStore'
+import { buildAssetMapJSON } from '@/lib/export'
+
+export default function AssetMapCard() {
+  const tree = useEditorStore((s) => s.tree)
+  const [busy, setBusy] = useState(false)
+  const [stats, setStats] = useState<{ total: number; unique: number; duplicates: number } | null>(null)
+
+  const download = (filename: string, content: string, type = 'application/json') => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    URL.revokeObjectURL(url)
+    a.remove()
+  }
+
+  const handle = async () => {
+    try {
+      setBusy(true)
+      const { json, map } = await buildAssetMapJSON(tree)
+      download('asset-map.json', json)
+      setStats(map.stats)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-zinc-700 p-3 bg-zinc-900/50">
+      <div className="text-sm font-medium mb-2">Asset Map</div>
+      <p className="text-xs text-zinc-400 mb-3">
+        画像アセットをハッシュで重複判定し、参照先一覧とともに <code>asset-map.json</code> を出力します。
+        <br />
+        <span className="text-[11px]">
+          data:URL は <b>SHA-256</b>、その他URLは <b>FNV-1a</b>（文字列）でハッシュ（MVP）。
+        </span>
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm disabled:opacity-60"
+          onClick={handle}
+          disabled={busy}
+        >
+          {busy ? 'Building…' : 'Build & Download Map'}
+        </button>
+        {stats && (
+          <span className="text-xs text-zinc-400">
+            total: {stats.total} / unique: {stats.unique}{' '}
+            {stats.duplicates > 0 && <>(dup: {stats.duplicates})</>}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/editor/export/DesignTokensCard.tsx
+++ b/web/components/editor/export/DesignTokensCard.tsx
@@ -1,0 +1,77 @@
+'use client'
+import React, { useMemo } from 'react'
+import { useEditorStore } from '@/store/editorStore'
+import { extractTokensFromTree, tokensToJSON, tokensToTS } from '@/lib/export/tokens'
+
+export default function DesignTokensCard() {
+  const tree = useEditorStore((s) => s.tree)
+  const tokens = useMemo(() => extractTokensFromTree(tree), [tree])
+
+  const download = (filename: string, content: string, type = 'application/json') => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    URL.revokeObjectURL(url)
+    a.remove()
+  }
+
+  return (
+    <div className="rounded-lg border border-zinc-700 p-3 bg-zinc-900/50">
+      <div className="text-sm font-medium mb-2">Design Tokens</div>
+      <p className="text-xs text-zinc-400 mb-3">
+        現在のドキュメントから <code>colors / typography / spacing</code> を抽出します。
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <button
+          className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+          onClick={() => download('tokens.json', tokensToJSON(tokens))}
+        >
+          Download JSON
+        </button>
+        <button
+          className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+          onClick={() => download('tokens.ts', tokensToTS(tokens))}
+        >
+          Download TS
+        </button>
+      </div>
+      {/* preview (抜粋) */}
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        <div>
+          <div className="text-xs mb-1 text-zinc-400">Colors</div>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(tokens.colors).slice(0, 8).map(([k, v]) => (
+              <div key={k} className="flex items-center gap-2">
+                <span className="inline-block w-4 h-4 rounded-sm" style={{ background: v }} />
+                <span className="text-xs">{k}</span>
+              </div>
+            ))}
+            {Object.keys(tokens.colors).length === 0 && (
+              <div className="text-xs text-zinc-500">—</div>
+            )}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs mb-1 text-zinc-400">Typography</div>
+          <div className="text-xs text-zinc-300 space-y-1">
+            <div>fonts: {tokens.typography.fonts.join(', ') || '—'}</div>
+            <div>fontSizes(px): {tokens.typography.fontSizes.join(', ') || '—'}</div>
+            <div>lineHeights(px): {tokens.typography.lineHeights.join(', ') || '—'}</div>
+            <div>letterSpacing(px): {tokens.typography.letterSpacing.join(', ') || '—'}</div>
+            <div>fontWeights: {tokens.typography.fontWeights.join(', ') || '—'}</div>
+          </div>
+        </div>
+        <div className="col-span-2">
+          <div className="text-xs mb-1 text-zinc-400">Spacing(px)</div>
+          <div className="text-xs text-zinc-300">
+            {tokens.spacing.space.join(', ') || '—'}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/editor/export/DiffExportCard.tsx
+++ b/web/components/editor/export/DiffExportCard.tsx
@@ -1,0 +1,53 @@
+'use client'
+import React from 'react'
+import { useEditorStore } from '@/store/editorStore'
+import { exportChanged } from '@/lib/export'
+
+export default function DiffExportCard() {
+  const tree = useEditorStore((s) => s.tree)
+  const dirtyIds = useEditorStore((s) => Object.keys(s.dirtyNodes))
+  const lastExportAt = useEditorStore((s) => s.lastExportAt)
+  const clearDirty = useEditorStore((s) => s.clearDirtyAfterExport)
+
+  const download = (filename: string, content: string, type = 'application/json') => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    URL.revokeObjectURL(url)
+    a.remove()
+  }
+
+  const handle = () => {
+    if (!dirtyIds.length) return
+    const { json, meta } = exportChanged(tree, dirtyIds)
+    const stamp = new Date(meta.exportedAt).toISOString().replace(/[:.]/g, '-')
+    download(`diff-${stamp}.json`, json)
+    clearDirty()
+  }
+
+  return (
+    <div className="rounded-lg border border-zinc-700 p-3 bg-zinc-900/50">
+      <div className="text-sm font-medium mb-2">Diff Export</div>
+      <p className="text-xs text-zinc-400 mb-3">
+        変更されたノードのみを書き出します（ストアの <code>dirtyNodes</code> を参照）。
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm disabled:opacity-60"
+          onClick={handle}
+          disabled={!dirtyIds.length}
+          title={dirtyIds.length ? '' : '変更がありません'}
+        >
+          Export Changed ({dirtyIds.length})
+        </button>
+        <span className="text-xs text-zinc-500">
+          last: {lastExportAt ? new Date(lastExportAt).toLocaleString() : '—'}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/components/editor/export/ReactCodeCard.tsx
+++ b/web/components/editor/export/ReactCodeCard.tsx
@@ -1,0 +1,51 @@
+'use client'
+import React from 'react'
+import { useEditorStore } from '@/store/editorStore'
+import { generateReactTSX } from '@/lib/export/react-codegen'
+
+export default function ReactCodeCard() {
+  const components = useEditorStore((s) => s.components)
+
+  const download = (filename: string, content: string, type = 'text/tsx') => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    URL.revokeObjectURL(url)
+    a.remove()
+  }
+
+  return (
+    <div className="rounded-lg border border-zinc-700 p-3 bg-zinc-900/50">
+      <div className="text-sm font-medium mb-2">React Code</div>
+      <p className="text-xs text-zinc-400 mb-3">
+        Component を <code>.tsx</code> 出力します（Props/Variants/最小Overrides対応）。
+      </p>
+      <ul className="space-y-1">
+        {Object.values(components).length === 0 && (
+          <li className="text-xs text-zinc-500">Components がありません。</li>
+        )}
+        {Object.values(components).map((def) => (
+          <li key={def.id} className="flex items-center justify-between gap-3">
+            <div className="text-xs truncate">{def.name}</div>
+            <button
+              className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-sm"
+              onClick={() => {
+                const { filename, code } = generateReactTSX(def)
+                download(filename, code)
+              }}
+            >
+              Download TSX
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 text-[11px] text-zinc-500">
+        注: レイアウト/スタイルは inline style で最小限を出力。±1px差異は手調整の前提です。
+      </div>
+    </div>
+  )
+}

--- a/web/hooks/editor/useCanvasTiler.ts
+++ b/web/hooks/editor/useCanvasTiler.ts
@@ -1,0 +1,26 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import { CanvasTiler, type Camera, type WorldRect } from '@/lib/render/tiler'
+
+export function useCanvasTiler(
+  canvasRef: React.RefObject<HTMLCanvasElement>,
+  draw: (ctx: CanvasRenderingContext2D, r: WorldRect, cam: Camera, dpr: number) => void,
+) {
+  const tilerRef = useRef<CanvasTiler | null>(null)
+  useEffect(() => {
+    const el = canvasRef.current
+    if (!el) return
+    const tiler = new CanvasTiler(el, { tileSize: 768 })
+    tiler.setDraw((ctx, r, cam, dpr) => draw(ctx, r, cam, dpr))
+    tilerRef.current = tiler
+    const onResizeDpr = () => tiler.setDpr(window.devicePixelRatio || 1)
+    onResizeDpr()
+    window.addEventListener('resize', onResizeDpr)
+    return () => {
+      window.removeEventListener('resize', onResizeDpr)
+      tiler.destroy()
+      tilerRef.current = null
+    }
+  }, [canvasRef, draw])
+  return tilerRef
+}

--- a/web/hooks/editor/useFPS.ts
+++ b/web/hooks/editor/useFPS.ts
@@ -1,0 +1,24 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+
+export function useFPS() {
+  const [fps, setFps] = useState(0)
+  const ref = useRef({ last: performance.now(), frames: 0 })
+  useEffect(() => {
+    let alive = true
+    const loop = () => {
+      if (!alive) return
+      const f = ref.current
+      f.frames++
+      const now = performance.now()
+      if (now - f.last >= 500) {
+        setFps(Math.round((f.frames * 1000) / (now - f.last)))
+        f.frames = 0; f.last = now
+      }
+      requestAnimationFrame(loop)
+    }
+    const id = requestAnimationFrame(loop)
+    return () => { alive = false; cancelAnimationFrame(id) }
+  }, [])
+  return fps
+}

--- a/web/hooks/editor/usePanZoomCamera.ts
+++ b/web/hooks/editor/usePanZoomCamera.ts
@@ -1,0 +1,58 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import type { Camera } from '@/lib/render/tiler'
+
+export function usePanZoomCamera(canvasRef: React.RefObject<HTMLCanvasElement>, onChange: (cam: Camera) => void) {
+  const camRef = useRef<Camera>({ x: -512, y: -512, scale: 1 })
+
+  useEffect(() => {
+    const el = canvasRef.current
+    if (!el) return
+    const cam = camRef.current
+    onChange(cam)
+    let dragging = false, lastX = 0, lastY = 0
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0 && e.button !== 1 && e.button !== 2) return
+      dragging = true; lastX = e.clientX; lastY = e.clientY
+      ;(e.target as Element).setPointerCapture?.(e.pointerId)
+    }
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return
+      const dx = (e.clientX - lastX) / cam.scale
+      const dy = (e.clientY - lastY) / cam.scale
+      cam.x -= dx; cam.y -= dy; lastX = e.clientX; lastY = e.clientY
+      onChange(cam)
+    }
+    const onPointerUp = () => { dragging = false }
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      const rect = el.getBoundingClientRect()
+      const dpr = window.devicePixelRatio || 1
+      const px = (e.clientX - rect.left) / dpr
+      const py = (e.clientY - rect.top) / dpr
+      const wx = cam.x + px / cam.scale
+      const wy = cam.y + py / cam.scale
+      const s = Math.exp(-e.deltaY * 0.001)
+      const next = Math.min(8, Math.max(0.2, cam.scale * s))
+      cam.x = wx - (px / next); cam.y = wy - (py / next); cam.scale = next
+      onChange(cam)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === '0') { cam.x = -512; cam.y = -512; cam.scale = 1; onChange(cam) }
+    }
+    el.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    el.addEventListener('wheel', onWheel, { passive: false })
+    window.addEventListener('keydown', onKey)
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+      el.removeEventListener('wheel', onWheel)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [canvasRef, onChange])
+
+  return camRef
+}

--- a/web/lib/export/index.ts
+++ b/web/lib/export/index.ts
@@ -71,3 +71,20 @@ export const PRESETS: Record<string, ExportPreset> = {
   html: { format: 'html' },
   react: { format: 'react' },
 };
+
+// ===== Diff Export (MVP) =====
+export function exportChanged(tree: any[], ids: string[]) {
+  const idSet = new Set(ids)
+  const nodes: any[] = []
+  traverse(tree, (n: any) => { if (idSet.has(n?.id)) nodes.push(n) })
+  const meta = { exportedAt: Date.now(), ids: Array.from(idSet) }
+  const json = JSON.stringify({ meta, nodes }, null, 2)
+  return { json, meta }
+}
+
+function traverse(nodes: any[], fn: (n: any) => void) {
+  for (const n of nodes || []) {
+    fn(n)
+    if (n?.children) traverse(n.children, fn)
+  }
+}

--- a/web/lib/render/drawScene.ts
+++ b/web/lib/render/drawScene.ts
@@ -1,0 +1,60 @@
+import type { WorldRect, Camera } from '@/lib/render/tiler'
+
+export function drawScene(
+  ctx: CanvasRenderingContext2D,
+  tileRect: WorldRect,
+  cam: Camera,
+  dpr: number,
+  tree: any[],
+) {
+  drawGrid(ctx, tileRect)
+  try {
+    traverse(tree, (n: any) => {
+      const t = String(n?.type ?? '')
+      const id = n?.id
+      const x = Number(n?.style?.left ?? n?.props?.x ?? 0)
+      const y = Number(n?.style?.top ?? n?.props?.y ?? 0)
+      const w = Number(n?.style?.width ?? n?.props?.w ?? 120)
+      const h = Number(n?.style?.height ?? n?.props?.h ?? 60)
+      if (!aabbIntersect({ x, y, w, h }, tileRect)) return
+      ctx.save()
+      ctx.translate(x, y)
+      ctx.fillStyle = t === 'frame' ? '#1f2937' : t === 'text' ? '#0ea5e9' : '#334155'
+      ctx.strokeStyle = '#475569'
+      ctx.lineWidth = 1
+      ctx.fillRect(0, 0, w, h)
+      ctx.strokeRect(0, 0, w, h)
+      ctx.fillStyle = '#e2e8f0'
+      ctx.font = '12px ui-sans-serif, system-ui'
+      ctx.fillText(`${t}:${n?.name ?? id}`, 6, 16)
+      ctx.restore()
+    })
+  } catch {}
+}
+
+function drawGrid(ctx: CanvasRenderingContext2D, r: WorldRect) {
+  const step = 64
+  const x0 = Math.floor(r.x / step) * step
+  const y0 = Math.floor(r.y / step) * step
+  ctx.save()
+  ctx.strokeStyle = 'rgba(148,163,184,0.15)'
+  ctx.lineWidth = 1
+  for (let x = x0; x < r.x + r.w; x += step) {
+    ctx.beginPath(); ctx.moveTo(x, r.y); ctx.lineTo(x, r.y + r.h); ctx.stroke()
+  }
+  for (let y = y0; y < r.y + r.h; y += step) {
+    ctx.beginPath(); ctx.moveTo(r.x, y); ctx.lineTo(r.x + r.w, y); ctx.stroke()
+  }
+  ctx.strokeStyle = 'rgba(14,165,233,0.4)'
+  ctx.strokeRect(r.x, r.y, r.w, r.h)
+  ctx.restore()
+}
+function traverse(nodes: any[], fn: (n: any) => void) {
+  for (const n of nodes ?? []) {
+    fn(n)
+    if (n?.children) traverse(n.children, fn)
+  }
+}
+function aabbIntersect(a: {x:number;y:number;w:number;h:number}, b: {x:number;y:number;w:number;h:number}) {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
+}


### PR DESCRIPTION
## Summary
- add ESLint config for Next.js with limits on line count and complexity
- modularize export panel with cards for tokens, asset map, diff export, and React code generation
- introduce canvas hooks and scene renderer, simplifying CanvasStage and removing export modal

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aafc66f980832c99689b8ea2365071