### PR TITLE
feat(dev): add seeding utilities and dev page

### DIFF
--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -1,0 +1,68 @@
+'use client'
+import React from 'react'
+import { CanvasStage } from '@/components/editor'
+import LayersPanel from '@/components/sidebar/LayersPanel'
+import ExportPanel from '@/components/editor/ExportPanel'
+import { seedToStore, markPreviousCrashedForTest } from '@/dev/seed'
+import { useEditorStore } from '@/store/editorStore'
+
+export default function DevPages() {
+  const s = useEditorStore()
+  return (
+    <div className="p-4 space-y-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Dev / Pages</h1>
+        <div className="flex gap-2">
+          <button className="px-2 py-1 text-sm rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700" onClick={() => seedToStore(100)}>
+            Seed 100
+          </button>
+          <button className="px-2 py-1 text-sm rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700" onClick={() => seedToStore(1000)}>
+            Seed 1k
+          </button>
+          <button className="px-2 py-1 text-sm rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700" onClick={() => seedToStore(5000)}>
+            Seed 5k
+          </button>
+          <button
+            className="px-2 py-1 text-sm rounded bg-amber-800/60 border border-amber-600 hover:bg-amber-700/60"
+            title="次回リロードで復旧ダイアログが出ます"
+            onClick={() => {
+              markPreviousCrashedForTest()
+              location.reload()
+            }}
+          >
+            Simulate Crash → Reload
+          </button>
+          <button
+            className="px-2 py-1 text-sm rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+            onClick={() => s.select([])}
+          >
+            Unselect
+          </button>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-12 gap-4">
+        <section className="col-span-7 rounded-lg overflow-hidden border border-zinc-800">
+          <div className="px-3 py-2 text-sm border-b border-zinc-800 bg-zinc-900/50">CanvasStage</div>
+          <div className="h-[70vh] bg-black">
+            <CanvasStage />
+          </div>
+        </section>
+        <aside className="col-span-5 space-y-4">
+          <div className="rounded-lg overflow-hidden border border-zinc-800">
+            <div className="px-3 py-2 text-sm border-b border-zinc-800 bg-zinc-900/50">Layers</div>
+            <div className="h-[30vh] overflow-auto">
+              <LayersPanel />
+            </div>
+          </div>
+          <div className="rounded-lg overflow-hidden border border-zinc-800">
+            <div className="px-3 py-2 text-sm border-b border-zinc-800 bg-zinc-900/50">Export</div>
+            <div className="max-h-[40vh] overflow-auto p-3">
+              <ExportPanel />
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Link from 'next/link';
 import { TOP_BAR_HEIGHT } from '@/lib/layout/constants';
 import { useEditorStore } from '@/store/editorStore';
 import { useState, useRef, useEffect } from 'react';
@@ -175,6 +176,11 @@ export default function TopBar() {
           </label>
         </div>
         <div className="flex items-center gap-2">
+          <nav className="flex items-center gap-2">
+            <Link href="/dev/pages" className="px-2 py-0.5 text-xs rounded border border-zinc-700 hover:bg-zinc-800">
+              Dev
+            </Link>
+          </nav>
           <button>Share</button>
           <button>Present</button>
           <button onClick={togglePreferences}>Preferences</button>

--- a/web/dev/seed.ts
+++ b/web/dev/seed.ts
@@ -1,0 +1,95 @@
+'use client'
+import { useEditorStore } from '@/store/editorStore'
+
+type Node = {
+  id: string
+  name?: string
+  type: 'frame' | 'text' | 'image'
+  style?: Partial<Record<'left'|'top'|'width'|'height'|'backgroundColor'|'color'|'borderColor'|'borderRadius'|'opacity'|'position', any>>
+  props?: any
+  children?: Node[]
+}
+
+/** n個の矩形フレームをグリッド状にばらまく（描画/ヒットテスト用のダミー） */
+export function makeGridDoc(n = 100, cell = 160): Node[] {
+  const cols = Math.max(1, Math.floor(Math.sqrt(n)))
+  const rows = Math.ceil(n / cols)
+  const nodes: Node[] = []
+  let i = 0
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      if (i >= n) break
+      const left = x * cell
+      const top = y * cell
+      nodes.push({
+        id: `node_${i}`,
+        name: `Rect ${i}`,
+        type: 'frame',
+        style: {
+          left,
+          top,
+          width: 120 + ((i * 7) % 16),
+          height: 72 + ((i * 11) % 18),
+          backgroundColor: i % 5 === 0 ? '#0ea5e9' : '#1f2937',
+          borderColor: '#475569',
+          borderRadius: (i * 3) % 12,
+          opacity: 1,
+          position: 'absolute',
+        },
+        children: [
+          {
+            id: `label_${i}`,
+            type: 'text',
+            name: `Label ${i}`,
+            style: { left: 8, top: 8, width: 100, height: 16, color: '#e2e8f0', position: 'absolute' },
+            props: { text: `#${i}` },
+          },
+        ],
+      })
+      i++
+    }
+  }
+  return nodes
+}
+
+/** 少量のコンポーネント定義をダミー生成（React Codegen 等の試験用） */
+export function makeDummyComponents() {
+  return {
+    btn: {
+      id: 'comp_btn',
+      name: 'Button',
+      props: [
+        { id: 'label', name: 'label', type: 'text', defaultValue: 'Click me', targetPath: 'root.children[0].props.text' },
+        { id: 'primary', name: 'isPrimary', type: 'boolean', defaultValue: true, targetPath: 'root.style.backgroundColor' },
+      ],
+      root: {
+        id: 'root',
+        type: 'frame',
+        style: { width: 120, height: 36, backgroundColor: '#0ea5e9', borderRadius: 8, position: 'relative' },
+        children: [
+          { id: 'l', type: 'text', style: { left: 12, top: 9, width: 96, height: 18 }, props: { text: 'Click me' } },
+        ],
+      },
+    },
+  } as any
+}
+
+/** ストアへシード投入（tree/selected を上書きし、dirty/pending を進める） */
+export function seedToStore(count: number) {
+  const tree = makeGridDoc(count)
+  useEditorStore.setState((prev: any) => ({
+    ...prev,
+    tree,
+    selectedIds: [],
+    dirtyNodes: {},
+    pendingVersion: (prev?.pendingVersion ?? 0) + 1,
+    components: { ...(prev?.components ?? {}), ...makeDummyComponents() },
+  }))
+}
+
+/** 復旧ダイアログを強制的に出したいときの“クラッシュ演出”（テスト用） */
+export function markPreviousCrashedForTest() {
+  try {
+    localStorage.setItem('ui.session.alive', '1') // 前回終了時に落ちた扱い
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add seed utilities for generating mock nodes and components
- add /dev/pages route for experimenting with CanvasStage and panels
- link to dev tools from TopBar

## Testing
- `npm test` (fails: TypeError: reject is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68abe196ba34832cbacab2c430021485