### PR TITLE
chore: use pnpm -C for web scripts and disable v3 additions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "type": "commonjs",
   "scripts": {
-    "dev": "pnpm --filter web dev",
-    "build": "pnpm --filter web build",
-    "start": "pnpm --filter web start",
+    "dev": "pnpm -C web dev",
+    "build": "pnpm -C web build",
+    "start": "pnpm -C web start",
     "gen:component-meta": "ts-node scripts/gen-component-meta.ts --root ./src/components --out ./public/component-meta.json",
     "test": "npm install --no-save --prefix .tmp jest ts-jest @testing-library/react @testing-library/jest-dom react-test-renderer @types/jest jest-environment-jsdom > /dev/null && NODE_PATH=\"$(pwd)/.tmp/node_modules\" node .tmp/node_modules/jest/bin/jest.js --config jest.config.cjs --coverage",
     "run:prompts": "node scripts/run-prompts.mjs",

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -139,7 +139,9 @@ interface EditorActions {
   ) => void;
 }
 
-  // v3 additions
+/* v3 additions (TEMP DISABLE)
+ * 型シグネチャの羅列が値コンテキストに混入してビルドが落ちていたため、一旦コメントアウト。
+ * TODO: types/editor.ts の interface へ移設してから再配線する。
   align: (
     kind: "left" | "right" | "top" | "bottom" | "centerH" | "centerV",
   ) => void;
@@ -285,6 +287,7 @@ interface EditorActions {
     style: Partial<TextStyle> & { link?: string },
   ) => void;
 }
+*/
 
 interface EditorPersistState {
   saveQueue: number[];


### PR DESCRIPTION
## Summary
- run web scripts with `pnpm -C web`
- temporarily disable v3 additions in `editorStore` until interfaces are relocated

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68abec3d6d50832cb264c12fc7b4141f