### PR TITLE
Fix syntax error in editor store

### DIFF
--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -891,7 +891,6 @@ swapInstanceDef(nodeId, newDefId, opts) {
   });
 },
 
-        },
         align(kind) {
           // TODO: implement alignment logic
         },


### PR DESCRIPTION
## Summary
- remove stray bracket causing compilation error in editor store

## Testing
- `pnpm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68abf8de4c9c832cbdcbf2a91d1ab5f4