### PR TITLE
chore: add immer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,18 @@
   "dependencies": {
     "@babel/generator": "^7.28.3",
     "@babel/types": "^7.28.2",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "immer": "10.0.0",
     "prettier": "^3.6.2",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-docgen-typescript": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-window": "^1.8.9",
-    "zustand": "^4.5.2",
-    "@dnd-kit/core": "^6.0.8",
-    "@dnd-kit/sortable": "^8.0.0",
-    "ts-morph": "^22.0.0"
+    "ts-morph": "^22.0.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.47",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      immer:
+        specifier: 10.0.0
+        version: 10.0.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -46,7 +49,7 @@ importers:
         version: 22.0.0
       zustand:
         specifier: ^4.5.2
-        version: 4.5.7(@types/react@18.3.24)(react@18.3.1)
+        version: 4.5.7(@types/react@18.3.24)(immer@10.0.0)(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.2.47
@@ -464,6 +467,9 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  immer@10.0.0:
+    resolution: {integrity: sha512-U5wLsGKDt7+XnufwMYH7+RWcy4JTITNkWsV/H4sNhfIxcXvypDTzn9Cj0Y9Fjj0h1a/Gaba9oZYK0a+kO13uJQ==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1272,6 +1278,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  immer@10.0.0: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -1691,9 +1699,10 @@ snapshots:
 
   yn@3.1.1: {}
 
-  zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
+  zustand@4.5.7(@types/react@18.3.24)(immer@10.0.0)(react@18.3.1):
     dependencies:
       use-sync-external-store: 1.5.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.24
+      immer: 10.0.0
       react: 18.3.1


### PR DESCRIPTION
## Summary
- install immer to resolve missing module errors in editor store

## Testing
- `pnpm -C web dev`
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68abfc3f5924832c92f1abdcf63c2758