### PR TITLE
refactor: handle SSR devicePixelRatio

### DIFF
--- a/web/lib/render/tiler.ts
+++ b/web/lib/render/tiler.ts
@@ -47,9 +47,16 @@ export class CanvasTiler {
     if (!ctx) throw new Error('2D context unavailable')
     this.canvas = canvas
     this.ctx = ctx
+    // SSRでも落ちないようにwindow存在チェックしつつ、
+    // ?? と || の混在を避けて括弧で明示。
+    const defaultDpr =
+      typeof window !== 'undefined'
+        ? (window.devicePixelRatio ?? 1)
+        : 1
+
     this.opts = {
       tileSize: opts?.tileSize ?? 768,
-      dpr: opts?.dpr ?? window.devicePixelRatio || 1,
+      dpr: opts?.dpr ?? defaultDpr,
       maxConcurrentRenders: opts?.maxConcurrentRenders ?? 2,
     }
     this.setupResize()


### PR DESCRIPTION
## Summary
- guard against missing `window` and clarify devicePixelRatio fallback

## Testing
- `pnpm test` *(fails: Jest worker encountered 4 child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac03378444832cabfebc2eb22fce6a