### PR TITLE
Add drag-and-drop builder page

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,27 +1,63 @@
 'use client'
 import React from 'react'
-import Toolbar from '../../components/Toolbar'
-import VersionsPanel from '../../components/VersionsPanel'
-import Canvas from '../../components/Canvas'
-import Library from '../../components/Library'
-import Inspector from '../../components/Inspector'
-import LoadInitialTree from '../../components/LoadInitialTree'
-import { EditorProvider } from '../../components/store'
+import { DndContext, useSensor, useSensors, PointerSensor, DragEndEvent } from '@dnd-kit/core'
+import { Palette } from '@/components/builder/Palette'
+import { Canvas } from '@/components/builder/Canvas'
+import { Inspector } from '@/components/builder/Inspector'
+import { useBuilderStore } from '@/store/builderStore'
 
 export default function BuilderPage() {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
+  const canvasRef = React.useRef<HTMLDivElement>(null)
+  const addFromPalette = useBuilderStore((s) => s.addFromPalette)
+  const moveExisting = useBuilderStore((s) => s.move)
+
+  const onDragEnd = React.useCallback(
+    (e: DragEndEvent) => {
+      const data: any = e.active?.data?.current
+      if (!data) return
+      const overId = e.over?.id
+      if (overId !== 'CANVAS') return
+
+      const evt = (e.activatorEvent || e.activator || {}) as any
+      const clientX =
+        evt?.clientX ??
+        (evt?.touches && evt.touches[0]?.clientX) ??
+        (evt?.changedTouches && evt.changedTouches[0]?.clientX)
+      const clientY =
+        evt?.clientY ??
+        (evt?.touches && evt.touches[0]?.clientY) ??
+        (evt?.changedTouches && evt.changedTouches[0]?.clientY)
+      const rect = canvasRef.current?.getBoundingClientRect()
+      const x = rect ? clientX - rect.left : 40
+      const y = rect ? clientY - rect.top : 40
+
+      if (data.from === 'palette') {
+        addFromPalette(data.type as any, { x, y })
+      } else if (data.from === 'canvas' && typeof data.id === 'string') {
+        // existing element drag end (dnd-kit coordinates are delta-based, so Canvas handles move())
+        moveExisting(data.id, { x: x - (data.anchorX ?? 0), y: y - (data.anchorY ?? 0) })
+      }
+    },
+    [addFromPalette, moveExisting],
+  )
+
   return (
-    <EditorProvider initialTree={[]}>
-      <div className="h-screen flex flex-col">
-        <Toolbar />
-        <LoadInitialTree />
-        <div className="flex flex-1 min-h-0">
-          <div className="w-60 border-r overflow-y-auto"><Library/></div>
-          <div className="flex-1 overflow-auto"><Canvas/></div>
-          <div className="w-80 border-l overflow-y-auto"><Inspector/></div>
-          <VersionsPanel />
-        </div>
-      </div>
-    </EditorProvider>
+    <div className="flex h-[calc(100vh-40px)]">
+      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+        <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-3">
+          <h2 className="text-sm font-semibold mb-2">パレット</h2>
+          <Palette />
+        </aside>
+        <main className="flex-1 relative">
+          <Canvas canvasRef={canvasRef} />
+        </main>
+        <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3">
+          <h2 className="text-sm font-semibold mb-2">プロパティ</h2>
+          <Inspector />
+        </aside>
+      </DndContext>
+    </div>
   )
 }
 

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -1,0 +1,110 @@
+'use client'
+import React from 'react'
+import { useDroppable, useDraggable } from '@dnd-kit/core'
+import { useBuilderStore, type Elm } from '@/store/builderStore'
+
+const GRID = 8
+function bgGridStyle() {
+  const s = GRID
+  return {
+    backgroundImage:
+      'linear-gradient(to right, rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.05) 1px, transparent 1px)',
+    backgroundSize: `${s}px ${s}px, ${s}px ${s}px`,
+    backgroundPosition: '0 0, 0 0',
+  } as React.CSSProperties
+}
+
+function ElmView({ elm }: { elm: Elm }) {
+  const select = useBuilderStore((s) => s.select)
+  const selectedId = useBuilderStore((s) => s.selectedId)
+  const isSel = selectedId === elm.id
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `elm_${elm.id}`,
+    data: { from: 'canvas', id: elm.id, anchorX: elm.w / 2, anchorY: elm.h / 2 },
+  })
+
+  const common = 'absolute rounded border text-[12px] select-none'
+  const border = isSel ? 'border-amber-400' : 'border-zinc-700'
+  const shadow = isSel ? 'shadow-[0_0_0_1px_rgba(251,191,36,0.6)]' : ''
+
+  const baseStyle: React.CSSProperties = {
+    left: elm.x,
+    top: elm.y,
+    width: elm.w,
+    height: elm.h,
+    background: elm.props?.bg,
+    color: elm.props?.color ?? '#e5e7eb',
+    opacity: elm.visible === false ? 0.4 : 1,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      onMouseDown={() => select(elm.id)}
+      className={`${common} ${border} ${shadow} cursor-move ${isDragging ? 'opacity-60' : ''}`}
+      style={baseStyle}
+    >
+      {elm.type === 'header' && <div className="h-full flex items-center px-3">Header</div>}
+      {elm.type === 'footer' && <div className="h-full flex items-center justify-center px-3">Footer</div>}
+      {elm.type === 'sidebar' && <div className="h-full flex items-start px-3 py-2">Sidebar</div>}
+      {elm.type === 'hud' && <div className="h-full flex items-center justify-center px-3">HUD</div>}
+      {elm.type === 'container' && <div className="h-full px-3 py-2">Container</div>}
+      {elm.type === 'button' && (
+        <div className="h-full flex items-center justify-center font-medium">{elm.props?.text ?? 'Button'}</div>
+      )}
+      {elm.type === 'text' && <div className="h-full flex items-center px-2">{elm.props?.text ?? 'Text'}</div>}
+    </div>
+  )
+}
+
+export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElement> }) {
+  const els = useBuilderStore((s) => s.elements)
+  const select = useBuilderStore((s) => s.select)
+  const nudge = useBuilderStore((s) => s.nudge)
+  const { setNodeRef } = useDroppable({ id: 'CANVAS' })
+
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete', 'Backspace'].includes(e.key)) {
+        e.preventDefault()
+      }
+      if (e.key === 'ArrowUp') nudge(0, -GRID)
+      if (e.key === 'ArrowDown') nudge(0, GRID)
+      if (e.key === 'ArrowLeft') nudge(-GRID, 0)
+      if (e.key === 'ArrowRight') nudge(GRID, 0)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [nudge])
+
+  return (
+    <div className="h-full w-full flex items-center justify-center bg-black">
+      <div
+        ref={(n) => {
+          setNodeRef(n)
+          // allow external reference
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          canvasRef.current = n
+        }}
+        onMouseDown={(e) => {
+          if (e.target === e.currentTarget) select(null)
+        }}
+        className="relative w-[1200px] h-[720px] border border-zinc-800 rounded-lg overflow-hidden"
+        style={bgGridStyle()}
+      >
+        {/* page base pseudo preview */}
+        <div className="absolute inset-0 pointer-events-none" />
+        {els.map((e) => (
+          <ElmView key={e.id} elm={e} />
+        ))}
+        <div className="absolute left-2 bottom-2 text-[11px] text-zinc-400 bg-black/40 px-2 py-1 rounded border border-zinc-800">
+          drag to move • drop from Palette • arrows to nudge • click empty = unselect
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/web/components/builder/Inspector.tsx
+++ b/web/components/builder/Inspector.tsx
@@ -1,0 +1,117 @@
+'use client'
+import React from 'react'
+import { useBuilderStore } from '@/store/builderStore'
+
+export function Inspector() {
+  const selId = useBuilderStore((s) => s.selectedId)
+  const elm = useBuilderStore((s) => s.elements.find((e) => e.id === s.selectedId) ?? null)
+  const updateProps = useBuilderStore((s) => s.updateProps)
+  const deleteSelected = useBuilderStore((s) => s.deleteSelected)
+  const bringToFront = useBuilderStore((s) => s.bringToFront)
+  const sendToBack = useBuilderStore((s) => s.sendToBack)
+  const move = useBuilderStore((s) => s.move)
+  const resize = useBuilderStore((s) => s.resize)
+
+  if (!selId || !elm) {
+    return <div className="text-xs text-zinc-400">要素を選択すると編集できます。</div>
+  }
+  return (
+    <div className="space-y-3">
+      <div className="text-xs text-zinc-400">ID: {elm.id}</div>
+      <div className="text-sm font-medium">基本</div>
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <label className="flex flex-col gap-1">
+          x
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.x}
+            onChange={(e) => move(elm.id, { x: Number(e.target.value), y: elm.y })}
+            type="number"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          y
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.y}
+            onChange={(e) => move(elm.id, { x: elm.x, y: Number(e.target.value) })}
+            type="number"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          w
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.w}
+            onChange={(e) => resize(elm.id, { w: Number(e.target.value), h: elm.h })}
+            type="number"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          h
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.h}
+            onChange={(e) => resize(elm.id, { w: elm.w, h: Number(e.target.value) })}
+            type="number"
+          />
+        </label>
+      </div>
+
+      <div className="text-sm font-medium">見た目</div>
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <label className="flex flex-col gap-1 col-span-2">
+          text
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.props?.text ?? ''}
+            onChange={(e) => updateProps(elm.id, { text: e.target.value })}
+            type="text"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          bg
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.props?.bg ?? ''}
+            onChange={(e) => updateProps(elm.id, { bg: e.target.value })}
+            type="text"
+            placeholder="#0ea5e9"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          color
+          <input
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+            value={elm.props?.color ?? ''}
+            onChange={(e) => updateProps(elm.id, { color: e.target.value })}
+            type="text"
+            placeholder="#e5e7eb"
+          />
+        </label>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="px-2 py-1 text-xs rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+          onClick={() => bringToFront(elm.id)}
+        >
+          Front
+        </button>
+        <button
+          className="px-2 py-1 text-xs rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+          onClick={() => sendToBack(elm.id)}
+        >
+          Back
+        </button>
+        <button
+          className="ml-auto px-2 py-1 text-xs rounded bg-rose-900/60 border border-rose-700 hover:bg-rose-800/60"
+          onClick={() => deleteSelected()}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -1,0 +1,46 @@
+'use client'
+import React from 'react'
+import { useDraggable } from '@dnd-kit/core'
+import type { ElmType } from '@/store/builderStore'
+
+function DraggableItem({ type, label }: { type: ElmType; label: string }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `pal_${type}`,
+    data: { from: 'palette', type },
+  })
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className={`text-xs px-2 py-1 rounded border border-zinc-700 hover:bg-zinc-800 cursor-grab active:cursor-grabbing ${
+        isDragging ? 'opacity-60' : ''
+      }`}
+    >
+      {label}
+    </div>
+  )
+}
+
+export function Palette() {
+  const items: { type: ElmType; label: string }[] = [
+    { type: 'header', label: 'Header' },
+    { type: 'footer', label: 'Footer' },
+    { type: 'sidebar', label: 'Sidebar' },
+    { type: 'hud', label: 'HUD' },
+    { type: 'container', label: 'Container' },
+    { type: 'button', label: 'Button' },
+    { type: 'text', label: 'Text' },
+  ]
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {items.map((it) => (
+        <DraggableItem key={it.type} type={it.type} label={it.label} />
+      ))}
+      <p className="col-span-2 text-[11px] text-zinc-400 mt-2">
+        パレットからキャンバスへドラッグ＆ドロップで配置できます
+      </p>
+    </div>
+  )
+}
+

--- a/web/components/shell/TopBar.tsx
+++ b/web/components/shell/TopBar.tsx
@@ -177,6 +177,9 @@ export default function TopBar() {
         </div>
         <div className="flex items-center gap-2">
           <nav className="flex items-center gap-2">
+            <Link href="/builder" className="px-2 py-0.5 text-xs rounded border border-zinc-700 hover:bg-zinc-800">
+              Builder
+            </Link>
             <Link href="/dev/pages" className="px-2 py-0.5 text-xs rounded border border-zinc-700 hover:bg-zinc-800">
               Dev
             </Link>

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -1,0 +1,170 @@
+'use client'
+import { create } from 'zustand'
+import { produce } from 'immer'
+
+export type ElmType = 'header' | 'footer' | 'sidebar' | 'hud' | 'button' | 'text' | 'container'
+
+export type Elm = {
+  id: string
+  type: ElmType
+  x: number
+  y: number
+  w: number
+  h: number
+  visible?: boolean
+  props?: {
+    text?: string
+    color?: string
+    bg?: string
+    align?: 'left' | 'center' | 'right'
+  }
+}
+
+type BuilderState = {
+  elements: Elm[]
+  selectedId: string | null
+  snap: number
+}
+
+type BuilderActions = {
+  addFromPalette: (type: ElmType, at?: { x: number; y: number }) => void
+  move: (id: string, to: { x: number; y: number }) => void
+  resize: (id: string, to: { w: number; h: number }) => void
+  select: (id: string | null) => void
+  updateProps: (id: string, patch: Partial<Elm['props']>) => void
+  deleteSelected: () => void
+  bringToFront: (id: string) => void
+  sendToBack: (id: string) => void
+  nudge: (dx: number, dy: number) => void
+}
+
+const SNAP = 8
+function snap(n: number, step = SNAP) {
+  return Math.round(n / step) * step
+}
+
+function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
+  switch (type) {
+    case 'header':
+      return { w: 960, h: 64, text: 'Header' }
+    case 'footer':
+      return { w: 960, h: 56, text: 'Footer' }
+    case 'sidebar':
+      return { w: 240, h: 600, text: 'Sidebar' }
+    case 'hud':
+      return { w: 280, h: 44, text: 'HUD' }
+    case 'button':
+      return { w: 120, h: 36, text: 'Button' }
+    case 'text':
+      return { w: 200, h: 24, text: 'Text' }
+    case 'container':
+    default:
+      return { w: 320, h: 200, text: 'Container' }
+  }
+}
+
+export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => ({
+  elements: [],
+  selectedId: null,
+  snap: SNAP,
+
+  addFromPalette(type, at) {
+    const id = `elm_${Date.now().toString(36)}`
+    const { w, h, text } = defaultSize(type)
+    const x = snap(at?.x ?? 40)
+    const y = snap(at?.y ?? 40)
+    set(
+      produce((draft: BuilderState) => {
+        draft.elements.push({
+          id,
+          type,
+          x,
+          y,
+          w,
+          h,
+          visible: true,
+          props: { text, bg: type === 'button' ? '#0ea5e9' : '#111827', color: '#e5e7eb' },
+        })
+        draft.selectedId = id
+      }),
+    )
+  },
+
+  move(id, to) {
+    set(
+      produce((draft: BuilderState) => {
+        const e = draft.elements.find((x) => x.id === id)
+        if (!e) return
+        e.x = snap(to.x)
+        e.y = snap(to.y)
+      }),
+    )
+  },
+
+  resize(id, to) {
+    set(
+      produce((draft: BuilderState) => {
+        const e = draft.elements.find((x) => x.id === id)
+        if (!e) return
+        e.w = Math.max(16, snap(to.w))
+        e.h = Math.max(16, snap(to.h))
+      }),
+    )
+  },
+
+  select(id) {
+    set({ selectedId: id })
+  },
+
+  updateProps(id, patch) {
+    set(
+      produce((draft: BuilderState) => {
+        const e = draft.elements.find((x) => x.id === id)
+        if (!e) return
+        e.props = { ...(e.props ?? {}), ...patch }
+      }),
+    )
+  },
+
+  deleteSelected() {
+    const id = get().selectedId
+    if (!id) return
+    set(
+      produce((draft: BuilderState) => {
+        draft.elements = draft.elements.filter((x) => x.id !== id)
+        draft.selectedId = null
+      }),
+    )
+  },
+
+  bringToFront(id) {
+    set(
+      produce((draft: BuilderState) => {
+        const i = draft.elements.findIndex((x) => x.id === id)
+        if (i < 0) return
+        const [e] = draft.elements.splice(i, 1)
+        draft.elements.push(e)
+      }),
+    )
+  },
+
+  sendToBack(id) {
+    set(
+      produce((draft: BuilderState) => {
+        const i = draft.elements.findIndex((x) => x.id === id)
+        if (i < 0) return
+        const [e] = draft.elements.splice(i, 1)
+        draft.elements.unshift(e)
+      }),
+    )
+  },
+
+  nudge(dx, dy) {
+    const id = get().selectedId
+    if (!id) return
+    const el = get().elements.find((x) => x.id === id)
+    if (!el) return
+    get().move(id, { x: el.x + dx, y: el.y + dy })
+  },
+}))
+


### PR DESCRIPTION
## Summary
- introduce interactive builder page with palette, canvas, and inspector
- manage builder state via new store
- expose builder entry point in top navigation

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ac08a41158832cbefcfd299cfa5b19