### PR TITLE
feat: add header login button

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -14,6 +14,31 @@ function bgGridStyle() {
   } as React.CSSProperties
 }
 
+type LoginButton = NonNullable<Elm['props']>['loginButton']
+
+function HeaderLoginButton({ data }: { data: LoginButton }) {
+  const Tag: any = data.href ? 'a' : 'button'
+  const base = [
+    'absolute right-3 top-1/2 -translate-y-1/2',
+    'min-w-[88px] h-8 px-3 rounded-lg flex items-center justify-center',
+    'text-[12px] z-10 cursor-pointer',
+  ].join(' ')
+  const variant =
+    data.variant === 'outline'
+      ? 'bg-transparent border border-[#94a3b8] text-[#e5e7eb] hover:bg-white/10'
+      : 'bg-[#0ea5e9] text-[#0b1220] hover:bg-[#0ea5e9]/90'
+  const tagProps = data.href ? { href: data.href } : {}
+  return (
+    <Tag
+      {...tagProps}
+      className={`${base} ${variant}`}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {data.label}
+    </Tag>
+  )
+}
+
 function ElmView({ elm }: { elm: Elm }) {
   const select = useBuilderStore((s) => s.select)
   const selectedId = useBuilderStore((s) => s.selectedId)
@@ -46,7 +71,14 @@ function ElmView({ elm }: { elm: Elm }) {
       className={`${common} ${border} ${shadow} cursor-move ${isDragging ? 'opacity-60' : ''}`}
       style={baseStyle}
     >
-      {elm.type === 'header' && <div className="h-full flex items-center px-3">Header</div>}
+      {elm.type === 'header' && (
+        <>
+          <div className="h-full flex items-center px-3">Header</div>
+          {elm.props?.loginButton?.enabled && (
+            <HeaderLoginButton data={elm.props.loginButton} />
+          )}
+        </>
+      )}
       {elm.type === 'footer' && <div className="h-full flex items-center justify-center px-3">Footer</div>}
       {elm.type === 'sidebar' && <div className="h-full flex items-start px-3 py-2">Sidebar</div>}
       {elm.type === 'hud' && <div className="h-full flex items-center justify-center px-3">HUD</div>}

--- a/web/components/builder/Inspector.tsx
+++ b/web/components/builder/Inspector.tsx
@@ -91,6 +91,90 @@ export function Inspector() {
         </label>
       </div>
 
+      {elm.type === 'header' && (
+        <>
+          <div className="text-sm font-medium">Login Button</div>
+          <div className="space-y-2 text-xs">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={elm.props?.loginButton?.enabled ?? false}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    const cur = elm.props?.loginButton
+                    updateProps(elm.id, {
+                      loginButton: {
+                        enabled: true,
+                        label: cur?.label ?? 'Log in',
+                        variant: cur?.variant ?? 'solid',
+                        href: cur?.href,
+                      },
+                    })
+                  } else {
+                    updateProps(elm.id, {
+                      loginButton: { ...(elm.props?.loginButton ?? {}), enabled: false },
+                    })
+                  }
+                }}
+              />
+              Enable
+            </label>
+            {elm.props?.loginButton?.enabled && (
+              <>
+                <label className="flex flex-col gap-1">
+                  Label
+                  <input
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={elm.props?.loginButton?.label ?? ''}
+                    onChange={(e) =>
+                      updateProps(elm.id, {
+                        loginButton: { ...(elm.props?.loginButton ?? {}), label: e.target.value },
+                      })
+                    }
+                    type="text"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  Variant
+                  <select
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={elm.props?.loginButton?.variant ?? 'solid'}
+                    onChange={(e) =>
+                      updateProps(elm.id, {
+                        loginButton: {
+                          ...(elm.props?.loginButton ?? {}),
+                          variant: e.target.value as 'solid' | 'outline',
+                        },
+                      })
+                    }
+                  >
+                    <option value="solid">solid</option>
+                    <option value="outline">outline</option>
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1">
+                  Link
+                  <input
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={elm.props?.loginButton?.href ?? ''}
+                    onChange={(e) =>
+                      updateProps(elm.id, {
+                        loginButton: {
+                          ...(elm.props?.loginButton ?? {}),
+                          href: e.target.value || undefined,
+                        },
+                      })
+                    }
+                    type="text"
+                    placeholder="/login"
+                  />
+                </label>
+              </>
+            )}
+          </div>
+        </>
+      )}
+
       <div className="flex gap-2">
         <button
           className="px-2 py-1 text-xs rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -17,6 +17,12 @@ export type Elm = {
     color?: string
     bg?: string
     align?: 'left' | 'center' | 'right'
+    loginButton?: {
+      enabled: boolean
+      label: string
+      variant: 'solid' | 'outline'
+      href?: string
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- support optional login button props on header elements
- render login button on canvas when enabled
- add inspector controls to toggle and configure login button

## Testing
- `pnpm install`
- `pnpm build --no-lint` *(fails: Property 'activator' does not exist on type 'DragEndEvent')*


------
https://chatgpt.com/codex/tasks/task_e_68ac0bb553e8832c8346cbed3b3b170d