### PR TITLE
feat: support code components in builder

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -4,13 +4,14 @@ import { DndContext, useSensor, useSensors, PointerSensor, DragEndEvent } from '
 import { Palette } from '@/components/builder/Palette'
 import { Canvas } from '@/components/builder/Canvas'
 import { Inspector } from '@/components/builder/Inspector'
-import { useBuilderStore } from '@/store/builderStore'
+import { useBuilderStore, type Elm } from '@/store/builderStore'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
   const canvasRef = React.useRef<HTMLDivElement>(null)
   const addFromPalette = useBuilderStore((s) => s.addFromPalette)
   const moveExisting = useBuilderStore((s) => s.move)
+  const elements = useBuilderStore((s) => s.elements)
 
   const onDragEnd = React.useCallback(
     (e: DragEndEvent) => {
@@ -33,7 +34,11 @@ export default function BuilderPage() {
       const y = rect ? clientY - rect.top : 40
 
       if (data.from === 'palette') {
-        addFromPalette(data.type as any, { x, y })
+        if (data.type === 'code') {
+          addFromPalette('code', { x, y }, data.meta)
+        } else {
+          addFromPalette(data.type as any, { x, y })
+        }
       } else if (data.from === 'canvas' && typeof data.id === 'string') {
         // existing element drag end (dnd-kit coordinates are delta-based, so Canvas handles move())
         moveExisting(data.id, { x: x - (data.anchorX ?? 0), y: y - (data.anchorY ?? 0) })
@@ -41,6 +46,49 @@ export default function BuilderPage() {
     },
     [addFromPalette, moveExisting],
   )
+
+  const onExport = React.useCallback(() => {
+    const codeEls = elements.filter((e) => e.type === 'code' && e.code) as Elm[]
+    const imports = new Map<string, { name: string; path: string; exp?: string }>()
+    codeEls.forEach((e) => {
+      const key = `${e.code!.importPath}::${e.code!.exportName || 'default'}`
+      if (!imports.has(key)) {
+        imports.set(key, {
+          name: e.code!.displayName,
+          path: e.code!.importPath,
+          exp: e.code!.exportName,
+        })
+      }
+    })
+    const importLines = Array.from(imports.values()).map((m) =>
+      m.exp
+        ? `import { ${m.exp} as ${m.name} } from "${m.path}"`
+        : `import ${m.name} from "${m.path}"`,
+    )
+    const body = codeEls
+      .map((e) => {
+        const name = e.code!.displayName
+        const propsStr = Object.entries(e.code!.props || {})
+          .map(([k, v]) =>
+            typeof v === 'string'
+              ? `${k}=${JSON.stringify(v)}`
+              : `${k}={${JSON.stringify(v)}}`,
+          )
+          .join(' ')
+        return `      <div style={{ position: 'absolute', left: ${e.x}, top: ${e.y}, width: ${e.w}, height: ${e.h} }}>` +
+          `\n        <${name}${propsStr ? ' ' + propsStr : ''} />\n      </div>`
+      })
+      .join('\n')
+    const content =
+      `import React from 'react'\n${importLines.join('\n')}\n\nexport default function Composer() {\n` +
+      `  return (\n    <div style={{ position: 'relative', width: 1200, height: 720 }}>\n${body}\n    </div>\n  )\n}\n`
+    const blob = new Blob([content], { type: 'text/plain' })
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(blob)
+    a.download = 'Composer.tsx'
+    a.click()
+    URL.revokeObjectURL(a.href)
+  }, [elements])
 
   return (
     <div className="flex h-[calc(100vh-40px)]">
@@ -52,9 +100,15 @@ export default function BuilderPage() {
         <main className="flex-1 relative">
           <Canvas canvasRef={canvasRef} />
         </main>
-        <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3">
+        <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3 flex flex-col">
           <h2 className="text-sm font-semibold mb-2">プロパティ</h2>
           <Inspector />
+          <button
+            className="mt-auto px-2 py-1 text-xs rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+            onClick={onExport}
+          >
+            Export Composer
+          </button>
         </aside>
       </DndContext>
     </div>

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -39,6 +39,57 @@ function HeaderLoginButton({ data }: { data: LoginButton }) {
   )
 }
 
+class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props)
+    this.state = { hasError: false }
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+  componentDidCatch() {}
+  render() {
+    if (this.state.hasError) {
+      return <div className="text-[11px] text-red-400">failed to load</div>
+    }
+    return this.props.children
+  }
+}
+
+function CodePreview({ elm }: { elm: Elm }) {
+  const Comp = React.useMemo(() => {
+    if (!elm.code?.importPath) return null
+    return React.lazy(async () => {
+      try {
+        const mod: any = await import(/* @vite-ignore */ elm.code.importPath)
+        return {
+          default: elm.code.exportName ? mod[elm.code.exportName] : mod.default,
+        }
+      } catch {
+        return {
+          default: () => (
+            <div className="text-[11px] text-red-400">load error</div>
+          ),
+        }
+      }
+    })
+  }, [elm.code?.importPath, elm.code?.exportName])
+  if (!Comp) {
+    return <div className="text-[11px] text-zinc-400">no component</div>
+  }
+  return (
+    <ErrorBoundary>
+      <React.Suspense
+        fallback={<div className="text-[11px] text-zinc-400">loading...</div>}
+      >
+        <div className="w-full h-full pointer-events-none">
+          <Comp {...(elm.code?.props ?? {})} />
+        </div>
+      </React.Suspense>
+    </ErrorBoundary>
+  )
+}
+
 function ElmView({ elm }: { elm: Elm }) {
   const select = useBuilderStore((s) => s.select)
   const selectedId = useBuilderStore((s) => s.selectedId)
@@ -87,6 +138,7 @@ function ElmView({ elm }: { elm: Elm }) {
         <div className="h-full flex items-center justify-center font-medium">{elm.props?.text ?? 'Button'}</div>
       )}
       {elm.type === 'text' && <div className="h-full flex items-center px-2">{elm.props?.text ?? 'Text'}</div>}
+      {elm.type === 'code' && <CodePreview elm={elm} />}
     </div>
   )
 }

--- a/web/components/builder/Inspector.tsx
+++ b/web/components/builder/Inspector.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 import { useBuilderStore } from '@/store/builderStore'
+import { loadDocgenMeta, parseValue, type DocgenProp } from '@/lib/builder/docgen'
 
 export function Inspector() {
   const selId = useBuilderStore((s) => s.selectedId)
@@ -11,6 +12,16 @@ export function Inspector() {
   const sendToBack = useBuilderStore((s) => s.sendToBack)
   const move = useBuilderStore((s) => s.move)
   const resize = useBuilderStore((s) => s.resize)
+  const [docgen, setDocgen] = React.useState<any[]>([])
+  React.useEffect(() => {
+    loadDocgenMeta().then(setDocgen)
+  }, [])
+  const codeMeta = React.useMemo(() => {
+    if (!elm || elm.type !== 'code' || !elm.code) return null
+    return docgen.find(
+      (m) => m.displayName === elm.code?.displayName && m.importPath === elm.code?.importPath,
+    )
+  }, [docgen, elm])
 
   if (!selId || !elm) {
     return <div className="text-xs text-zinc-400">要素を選択すると編集できます。</div>
@@ -58,38 +69,116 @@ export function Inspector() {
         </label>
       </div>
 
-      <div className="text-sm font-medium">見た目</div>
-      <div className="grid grid-cols-2 gap-2 text-xs">
-        <label className="flex flex-col gap-1 col-span-2">
-          text
-          <input
-            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
-            value={elm.props?.text ?? ''}
-            onChange={(e) => updateProps(elm.id, { text: e.target.value })}
-            type="text"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          bg
-          <input
-            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
-            value={elm.props?.bg ?? ''}
-            onChange={(e) => updateProps(elm.id, { bg: e.target.value })}
-            type="text"
-            placeholder="#0ea5e9"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          color
-          <input
-            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
-            value={elm.props?.color ?? ''}
-            onChange={(e) => updateProps(elm.id, { color: e.target.value })}
-            type="text"
-            placeholder="#e5e7eb"
-          />
-        </label>
-      </div>
+      {elm.type !== 'code' && (
+        <>
+          <div className="text-sm font-medium">見た目</div>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <label className="flex flex-col gap-1 col-span-2">
+              text
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.text ?? ''}
+                onChange={(e) => updateProps(elm.id, { text: e.target.value })}
+                type="text"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              bg
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.bg ?? ''}
+                onChange={(e) => updateProps(elm.id, { bg: e.target.value })}
+                type="text"
+                placeholder="#0ea5e9"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              color
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.color ?? ''}
+                onChange={(e) => updateProps(elm.id, { color: e.target.value })}
+                type="text"
+                placeholder="#e5e7eb"
+              />
+            </label>
+          </div>
+        </>
+      )}
+      {elm.type === 'code' && codeMeta && (
+        <>
+          <div className="text-sm font-medium">Code</div>
+          <div className="text-xs text-zinc-400">
+            {elm.code?.displayName} ({elm.code?.importPath})
+          </div>
+          <div className="space-y-2 text-xs mt-2">
+            {codeMeta.props?.map((p: DocgenProp) => {
+              const val = (elm.code?.props ?? {})[p.name]
+              const onChange = (v: unknown) =>
+                updateProps(elm.id, { code: { props: { [p.name]: v } } })
+              if (p.type.name === 'boolean') {
+                return (
+                  <label key={p.name} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(val)}
+                      onChange={(e) => onChange(e.target.checked)}
+                    />
+                    {p.name}
+                  </label>
+                )
+              }
+              if (p.type.name === 'number') {
+                return (
+                  <label key={p.name} className="flex flex-col gap-1">
+                    {p.name}
+                    <input
+                      className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                      value={val ?? ''}
+                      onChange={(e) => onChange(Number(e.target.value))}
+                      type="number"
+                    />
+                  </label>
+                )
+              }
+              if (p.type.name === 'enum' || p.type.name === 'union') {
+                const opts = (p.type.value || []).map((v) => parseValue(v.value))
+                if (opts.every((o) => ['string', 'number', 'boolean'].includes(typeof o))) {
+                  return (
+                    <label key={p.name} className="flex flex-col gap-1">
+                      {p.name}
+                      <select
+                        className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                        value={val === undefined ? '' : String(val)}
+                        onChange={(e) => onChange(parseValue(e.target.value))}
+                      >
+                        <option value="" />
+                        {opts.map((o) => (
+                          <option key={String(o)} value={String(o)}>
+                            {String(o)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )
+                }
+              }
+              // string or fallback
+              return (
+                <label key={p.name} className="flex flex-col gap-1">
+                  {p.name}
+                  <input
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={val ?? ''}
+                    onChange={(e) => onChange(e.target.value)}
+                    type="text"
+                  />
+                </label>
+              )
+            })}
+          </div>
+        </>
+      )}
 
       {elm.type === 'header' && (
         <>

--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -2,12 +2,33 @@
 import React from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import type { ElmType } from '@/store/builderStore'
+import { loadDocgenMeta, type DocgenMetaItem } from '@/lib/builder/docgen'
 
 function DraggableItem({ type, label }: { type: ElmType; label: string }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `pal_${type}`,
     data: { from: 'palette', type },
   })
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className={`text-xs px-2 py-1 rounded border border-zinc-700 hover:bg-zinc-800 cursor-grab active:cursor-grabbing ${
+        isDragging ? 'opacity-60' : ''
+      }`}
+    >
+      {label}
+    </div>
+  )
+}
+
+function CodeItem({ meta }: { meta: DocgenMetaItem }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `code_${meta.displayName}_${meta.importPath}`,
+    data: { from: 'palette', type: 'code', meta },
+  })
+  const label = meta.displayName || meta.importPath
   return (
     <div
       ref={setNodeRef}
@@ -32,14 +53,53 @@ export function Palette() {
     { type: 'button', label: 'Button' },
     { type: 'text', label: 'Text' },
   ]
+  const [tab, setTab] = React.useState<'basic' | 'code'>('basic')
+  const [codes, setCodes] = React.useState<DocgenMetaItem[]>([])
+  React.useEffect(() => {
+    loadDocgenMeta().then(setCodes)
+  }, [])
   return (
-    <div className="grid grid-cols-2 gap-2">
-      {items.map((it) => (
-        <DraggableItem key={it.type} type={it.type} label={it.label} />
-      ))}
-      <p className="col-span-2 text-[11px] text-zinc-400 mt-2">
-        パレットからキャンバスへドラッグ＆ドロップで配置できます
-      </p>
+    <div className="text-xs">
+      <div className="flex gap-2 mb-2">
+        <button
+          className={`px-2 py-1 rounded border border-zinc-700 ${
+            tab === 'basic' ? 'bg-zinc-800' : 'bg-zinc-900'
+          }`}
+          onClick={() => setTab('basic')}
+        >
+          Elements
+        </button>
+        <button
+          className={`px-2 py-1 rounded border border-zinc-700 ${
+            tab === 'code' ? 'bg-zinc-800' : 'bg-zinc-900'
+          }`}
+          onClick={() => setTab('code')}
+        >
+          Code Components
+        </button>
+      </div>
+      {tab === 'basic' && (
+        <div className="grid grid-cols-2 gap-2">
+          {items.map((it) => (
+            <DraggableItem key={it.type} type={it.type} label={it.label} />
+          ))}
+          <p className="col-span-2 text-[11px] text-zinc-400 mt-2">
+            パレットからキャンバスへドラッグ＆ドロップで配置できます
+          </p>
+        </div>
+      )}
+      {tab === 'code' && (
+        <div className="grid grid-cols-2 gap-2">
+          {codes.map((m) => (
+            <CodeItem key={`${m.importPath}-${m.displayName}`} meta={m} />
+          ))}
+          {codes.length === 0 && (
+            <p className="col-span-2 text-[11px] text-zinc-400 mt-2">
+              component-meta.json がありません
+            </p>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/lib/builder/docgen.ts
+++ b/web/lib/builder/docgen.ts
@@ -1,0 +1,46 @@
+export type DocgenProp = {
+  name: string
+  type: {
+    name: 'string' | 'number' | 'boolean' | 'enum' | 'union' | 'any'
+    raw?: string
+    value?: Array<{ value: string }>
+  }
+  required?: boolean
+  defaultValue?: { value: string }
+}
+
+export type DocgenMetaItem = {
+  displayName: string
+  importPath: string
+  exportName?: string
+  props?: DocgenProp[]
+}
+
+export type DocgenMeta = DocgenMetaItem[]
+
+let cache: DocgenMeta | null = null
+
+export async function loadDocgenMeta(): Promise<DocgenMeta> {
+  if (cache) return cache
+  try {
+    const res = await fetch('/component-meta.json')
+    const json = (await res.json()) as DocgenMeta
+    cache = json
+    return json
+  } catch {
+    cache = []
+    return []
+  }
+}
+
+export function parseValue(raw?: string): unknown {
+  if (raw == null) return undefined
+  const v = raw.trim()
+  if (v === 'true') return true
+  if (v === 'false') return false
+  if (/^-?\d+(\.\d+)?$/.test(v)) return Number(v)
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+    return v.slice(1, -1)
+  }
+  return v
+}

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -1,8 +1,18 @@
 'use client'
 import { create } from 'zustand'
 import { produce } from 'immer'
+import type { DocgenMetaItem } from '@/lib/builder/docgen'
+import { parseValue } from '@/lib/builder/docgen'
 
-export type ElmType = 'header' | 'footer' | 'sidebar' | 'hud' | 'button' | 'text' | 'container'
+export type ElmType =
+  | 'header'
+  | 'footer'
+  | 'sidebar'
+  | 'hud'
+  | 'button'
+  | 'text'
+  | 'container'
+  | 'code'
 
 export type Elm = {
   id: string
@@ -24,6 +34,12 @@ export type Elm = {
       href?: string
     }
   }
+  code?: {
+    displayName: string
+    importPath: string
+    exportName?: string
+    props: Record<string, unknown>
+  }
 }
 
 type BuilderState = {
@@ -33,11 +49,18 @@ type BuilderState = {
 }
 
 type BuilderActions = {
-  addFromPalette: (type: ElmType, at?: { x: number; y: number }) => void
+  addFromPalette: (
+    type: ElmType,
+    at?: { x: number; y: number },
+    meta?: DocgenMetaItem,
+  ) => void
   move: (id: string, to: { x: number; y: number }) => void
   resize: (id: string, to: { w: number; h: number }) => void
   select: (id: string | null) => void
-  updateProps: (id: string, patch: Partial<Elm['props']>) => void
+  updateProps: (
+    id: string,
+    patch: Partial<Elm['props']> & { code?: Partial<Elm['code']> },
+  ) => void
   deleteSelected: () => void
   bringToFront: (id: string) => void
   sendToBack: (id: string) => void
@@ -63,6 +86,8 @@ function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
       return { w: 120, h: 36, text: 'Button' }
     case 'text':
       return { w: 200, h: 24, text: 'Text' }
+    case 'code':
+      return { w: 160, h: 40 }
     case 'container':
     default:
       return { w: 320, h: 200, text: 'Container' }
@@ -74,23 +99,50 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
   selectedId: null,
   snap: SNAP,
 
-  addFromPalette(type, at) {
+  addFromPalette(type, at, meta) {
     const id = `elm_${Date.now().toString(36)}`
     const { w, h, text } = defaultSize(type)
     const x = snap(at?.x ?? 40)
     const y = snap(at?.y ?? 40)
     set(
       produce((draft: BuilderState) => {
-        draft.elements.push({
-          id,
-          type,
-          x,
-          y,
-          w,
-          h,
-          visible: true,
-          props: { text, bg: type === 'button' ? '#0ea5e9' : '#111827', color: '#e5e7eb' },
-        })
+        if (type === 'code') {
+          const initProps: Record<string, unknown> = {}
+          meta?.props?.forEach((p) => {
+            const v = parseValue(p.defaultValue?.value)
+            if (v !== undefined) initProps[p.name] = v
+          })
+          draft.elements.push({
+            id,
+            type,
+            x,
+            y,
+            w,
+            h,
+            visible: true,
+            code: {
+              displayName: meta?.displayName ?? 'Component',
+              importPath: meta?.importPath ?? '',
+              exportName: meta?.exportName,
+              props: initProps,
+            },
+          })
+        } else {
+          draft.elements.push({
+            id,
+            type,
+            x,
+            y,
+            w,
+            h,
+            visible: true,
+            props: {
+              text,
+              bg: type === 'button' ? '#0ea5e9' : '#111827',
+              color: '#e5e7eb',
+            },
+          })
+        }
         draft.selectedId = id
       }),
     )
@@ -127,7 +179,20 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
       produce((draft: BuilderState) => {
         const e = draft.elements.find((x) => x.id === id)
         if (!e) return
-        e.props = { ...(e.props ?? {}), ...patch }
+        const { code, ...rest } = patch as any
+        if (Object.keys(rest).length) {
+          e.props = { ...(e.props ?? {}), ...rest }
+        }
+        if (code) {
+          e.code = {
+            ...(e.code ?? { displayName: '', importPath: '', props: {} }),
+            ...code,
+            props: {
+              ...(e.code?.props ?? {}),
+              ...(code.props ?? {}),
+            },
+          }
+        }
       }),
     )
   },


### PR DESCRIPTION
## Summary
- allow builder elements of type `code` with metadata-driven props
- load docgen metadata into Palette and render imported components on Canvas
- generate prop editors, exports and Composer.tsx from code elements

## Testing
- `pnpm run gen:component-meta`
- `pnpm -C web build` *(fails: Module not found: Can't resolve 'nanoid', 'immer')*

------
https://chatgpt.com/codex/tasks/task_e_68ac15e8a36c832c967a27c7b32941b3