### PR TITLE
feat: add guide snapping to builder

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,10 +1,19 @@
 'use client'
 import React from 'react'
-import { DndContext, useSensor, useSensors, PointerSensor, DragEndEvent } from '@dnd-kit/core'
+import {
+  DndContext,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  DragEndEvent,
+  DragStartEvent,
+  DragMoveEvent,
+} from '@dnd-kit/core'
 import { Palette } from '@/components/builder/Palette'
 import { Canvas } from '@/components/builder/Canvas'
 import { Inspector } from '@/components/builder/Inspector'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
+import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -12,39 +21,86 @@ export default function BuilderPage() {
   const addFromPalette = useBuilderStore((s) => s.addFromPalette)
   const moveExisting = useBuilderStore((s) => s.move)
   const elements = useBuilderStore((s) => s.elements)
+  const setDragDraft = useBuilderStore((s) => s.setDragDraft)
+  const setGuides = useBuilderStore((s) => s.setGuides)
+  const clearGuides = useBuilderStore((s) => s.clearGuides)
+
+  const startRectRef = React.useRef<{ x: number; y: number; w: number; h: number } | null>(null)
+  const snapPointsRef = React.useRef<ReturnType<typeof collectSnapPoints> | null>(null)
+
+  const onDragStart = React.useCallback(
+    (e: DragStartEvent) => {
+      const data: any = e.active?.data?.current
+      if (data?.from === 'canvas' && typeof data.id === 'string') {
+        const elm = useBuilderStore.getState().elements.find((el) => el.id === data.id)
+        if (!elm) return
+        startRectRef.current = { x: elm.x, y: elm.y, w: elm.w, h: elm.h }
+        setDragDraft({ id: data.id, rect: { x: elm.x, y: elm.y, w: elm.w, h: elm.h } })
+        snapPointsRef.current = collectSnapPoints(
+          useBuilderStore.getState().elements,
+          data.id,
+        )
+      }
+    },
+    [setDragDraft],
+  )
+
+  const onDragMove = React.useCallback(
+    (e: DragMoveEvent) => {
+      const data: any = e.active?.data?.current
+      if (!data) return
+      if (data.from === 'canvas' && startRectRef.current && snapPointsRef.current) {
+        const s = startRectRef.current
+        const candidate = { x: s.x + e.delta.x, y: s.y + e.delta.y, w: s.w, h: s.h }
+        const { rect, guides } = snapRect(candidate, snapPointsRef.current, {
+          mode: 'move',
+        })
+        setDragDraft({ id: data.id, rect })
+        setGuides(guides)
+      }
+    },
+    [setDragDraft, setGuides],
+  )
 
   const onDragEnd = React.useCallback(
     (e: DragEndEvent) => {
       const data: any = e.active?.data?.current
       if (!data) return
       const overId = e.over?.id
-      if (overId !== 'CANVAS') return
-
-      const evt = (e.activatorEvent || e.activator || {}) as any
-      const clientX =
-        evt?.clientX ??
-        (evt?.touches && evt.touches[0]?.clientX) ??
-        (evt?.changedTouches && evt.changedTouches[0]?.clientX)
-      const clientY =
-        evt?.clientY ??
-        (evt?.touches && evt.touches[0]?.clientY) ??
-        (evt?.changedTouches && evt.changedTouches[0]?.clientY)
-      const rect = canvasRef.current?.getBoundingClientRect()
-      const x = rect ? clientX - rect.left : 40
-      const y = rect ? clientY - rect.top : 40
 
       if (data.from === 'palette') {
+        if (overId !== 'CANVAS') return
+        const evt = (e.activatorEvent || e.activator || {}) as any
+        const clientX =
+          evt?.clientX ??
+          (evt?.touches && evt.touches[0]?.clientX) ??
+          (evt?.changedTouches && evt.changedTouches[0]?.clientX)
+        const clientY =
+          evt?.clientY ??
+          (evt?.touches && evt.touches[0]?.clientY) ??
+          (evt?.changedTouches && evt.changedTouches[0]?.clientY)
+        const rect = canvasRef.current?.getBoundingClientRect()
+        const x = rect ? clientX - rect.left : 40
+        const y = rect ? clientY - rect.top : 40
         if (data.type === 'code') {
           addFromPalette('code', { x, y }, data.meta)
         } else {
           addFromPalette(data.type as any, { x, y })
         }
       } else if (data.from === 'canvas' && typeof data.id === 'string') {
-        // existing element drag end (dnd-kit coordinates are delta-based, so Canvas handles move())
-        moveExisting(data.id, { x: x - (data.anchorX ?? 0), y: y - (data.anchorY ?? 0) })
+        if (overId === 'CANVAS') {
+          const draft = useBuilderStore.getState().ui.dragDraft
+          if (draft && draft.id === data.id) {
+            moveExisting(data.id, { x: draft.rect.x, y: draft.rect.y }, false)
+          }
+        }
       }
+      setDragDraft(undefined)
+      clearGuides()
+      startRectRef.current = null
+      snapPointsRef.current = null
     },
-    [addFromPalette, moveExisting],
+    [addFromPalette, moveExisting, setDragDraft, clearGuides],
   )
 
   const onExport = React.useCallback(() => {
@@ -92,7 +148,12 @@ export default function BuilderPage() {
 
   return (
     <div className="flex h-[calc(100vh-40px)]">
-      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+      <DndContext
+        sensors={sensors}
+        onDragStart={onDragStart}
+        onDragMove={onDragMove}
+        onDragEnd={onDragEnd}
+      >
         <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-3">
           <h2 className="text-sm font-semibold mb-2">パレット</h2>
           <Palette />

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { useDroppable, useDraggable } from '@dnd-kit/core'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
+import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
 
 const GRID = 8
 function bgGridStyle() {
@@ -95,6 +96,9 @@ type HandleDir = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
 function ResizeHandles({ elm }: { elm: Elm }) {
   const move = useBuilderStore((s) => s.move)
   const resize = useBuilderStore((s) => s.resize)
+  const setDragDraft = useBuilderStore((s) => s.setDragDraft)
+  const setGuides = useBuilderStore((s) => s.setGuides)
+  const clearGuides = useBuilderStore((s) => s.clearGuides)
   const [resizing, setResizing] = React.useState(false)
   const startRef = React.useRef({
     x: 0,
@@ -106,11 +110,7 @@ function ResizeHandles({ elm }: { elm: Elm }) {
     aspect: 1,
     dir: 'e' as HandleDir,
   })
-
-  const snap = React.useCallback((n: number) => {
-    const step = useBuilderStore.getState().snap
-    return Math.round(n / step) * step
-  }, [])
+  const snapPointsRef = React.useRef<ReturnType<typeof collectSnapPoints> | null>(null)
 
   const cursors: Record<HandleDir, string> = {
     n: 'ns-resize',
@@ -138,6 +138,12 @@ function ResizeHandles({ elm }: { elm: Elm }) {
     }
     setResizing(true)
     document.body.style.cursor = cursors[dir]
+    setDragDraft({ id: elm.id, rect: { x: elm.x, y: elm.y, w: elm.w, h: elm.h } })
+    setGuides([])
+    snapPointsRef.current = collectSnapPoints(
+      useBuilderStore.getState().elements,
+      elm.id,
+    )
 
     const onMove = (ev: PointerEvent) => {
       const s = startRef.current
@@ -166,8 +172,8 @@ function ResizeHandles({ elm }: { elm: Elm }) {
         }
       }
 
-      w = Math.max(16, snap(w))
-      h = Math.max(16, snap(h))
+      w = Math.max(16, w)
+      h = Math.max(16, h)
 
       let x = s.x
       let y = s.y
@@ -182,14 +188,24 @@ function ResizeHandles({ elm }: { elm: Elm }) {
         }
       }
 
-      x = snap(x)
-      y = snap(y)
-
-      move(elm.id, { x, y })
-      resize(elm.id, { w, h })
+      const { rect, guides } = snapRect(
+        { x, y, w, h },
+        snapPointsRef.current!,
+        {
+        mode: 'resize',
+        },
+      )
+      setDragDraft({ id: elm.id, rect })
+      setGuides(guides)
     }
 
     const onUp = () => {
+      const draft = useBuilderStore.getState().ui.dragDraft
+      const r = draft?.rect || { x: elm.x, y: elm.y, w: elm.w, h: elm.h }
+      move(elm.id, { x: r.x, y: r.y }, false)
+      resize(elm.id, { w: r.w, h: r.h }, false)
+      setDragDraft(undefined)
+      clearGuides()
       setResizing(false)
       document.body.style.cursor = ''
       window.removeEventListener('pointermove', onMove)
@@ -233,6 +249,7 @@ function ElmView({ elm }: { elm: Elm }) {
   const select = useBuilderStore((s) => s.select)
   const selectedId = useBuilderStore((s) => s.selectedId)
   const isSel = selectedId === elm.id
+  const dragDraft = useBuilderStore((s) => s.ui.dragDraft)
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `elm_${elm.id}`,
     data: { from: 'canvas', id: elm.id, anchorX: elm.w / 2, anchorY: elm.h / 2 },
@@ -242,14 +259,18 @@ function ElmView({ elm }: { elm: Elm }) {
   const border = isSel ? 'border-amber-400' : 'border-zinc-700'
   const shadow = isSel ? 'shadow-[0_0_0_1px_rgba(251,191,36,0.6)]' : ''
 
+  const preview = dragDraft && dragDraft.id === elm.id ? dragDraft.rect : null
   const baseStyle: React.CSSProperties = {
     left: elm.x,
     top: elm.y,
-    width: elm.w,
-    height: elm.h,
+    width: preview ? preview.w : elm.w,
+    height: preview ? preview.h : elm.h,
     background: elm.props?.bg,
     color: elm.props?.color ?? '#e5e7eb',
     opacity: elm.visible === false ? 0.4 : 1,
+    transform: preview
+      ? `translate3d(${preview.x - elm.x}px, ${preview.y - elm.y}px, 0)`
+      : undefined,
   }
 
   return (
@@ -279,6 +300,30 @@ function ElmView({ elm }: { elm: Elm }) {
       {elm.type === 'text' && <div className="h-full flex items-center px-2">{elm.props?.text ?? 'Text'}</div>}
       {elm.type === 'code' && <CodePreview elm={elm} />}
       {isSel && <ResizeHandles elm={elm} />}
+    </div>
+  )
+}
+
+function GuideOverlay() {
+  const guides = useBuilderStore((s) => s.ui.guides)
+  if (!guides.length) return null
+  return (
+    <div className="absolute inset-0 pointer-events-none z-50">
+      {guides.map((g, i) =>
+        g.axis === 'x' ? (
+          <div
+            key={i}
+            className="absolute top-0 bottom-0 border-l border-amber-400/70"
+            style={{ left: g.pos }}
+          />
+        ) : (
+          <div
+            key={i}
+            className="absolute left-0 right-0 border-t border-amber-400/70"
+            style={{ top: g.pos }}
+          />
+        ),
+      )}
     </div>
   )
 }
@@ -324,6 +369,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         {els.map((e) => (
           <ElmView key={e.id} elm={e} />
         ))}
+        <GuideOverlay />
         <div className="absolute left-2 bottom-2 text-[11px] text-zinc-400 bg-black/40 px-2 py-1 rounded border border-zinc-800">
           drag to move • drop from Palette • arrows to nudge • click empty = unselect
         </div>

--- a/web/lib/builder/snap.ts
+++ b/web/lib/builder/snap.ts
@@ -1,0 +1,124 @@
+import type { Elm } from '@/store/builderStore'
+
+export type SnapPoints = {
+  x: { left: number[]; center: number[]; right: number[] }
+  y: { top: number[]; middle: number[]; bottom: number[] }
+}
+
+export function collectSnapPoints(elements: Elm[], exceptId?: string): SnapPoints {
+  const points: SnapPoints = {
+    x: { left: [], center: [600], right: [] },
+    y: { top: [], middle: [360], bottom: [] },
+  }
+  elements.forEach((el) => {
+    if (el.id === exceptId || el.visible === false) return
+    points.x.left.push(el.x)
+    points.x.center.push(el.x + el.w / 2)
+    points.x.right.push(el.x + el.w)
+    points.y.top.push(el.y)
+    points.y.middle.push(el.y + el.h / 2)
+    points.y.bottom.push(el.y + el.h)
+  })
+  return points
+}
+
+export type Rect = { x: number; y: number; w: number; h: number }
+export type GuideLine = { axis: 'x' | 'y'; pos: number }
+
+const GRID = 8
+const SNAP_THRESHOLD = 6
+
+export function snapRect(
+  rect: Rect,
+  points: SnapPoints,
+  opts: { threshold?: number; mode?: 'move' | 'resize' } = {},
+): { rect: Rect; guides: GuideLine[] } {
+  const threshold = opts.threshold ?? SNAP_THRESHOLD
+  const mode = opts.mode ?? 'move'
+  let { x, y, w, h } = rect
+  x = Math.round(x / GRID) * GRID
+  y = Math.round(y / GRID) * GRID
+  w = Math.round(w / GRID) * GRID
+  h = Math.round(h / GRID) * GRID
+
+  const left = x
+  const right = x + w
+  const cx = x + w / 2
+  const top = y
+  const bottom = y + h
+  const cy = y + h / 2
+
+  const nearest = (arr: number[], value: number) => {
+    let best: { diff: number; pos: number } | null = null
+    for (const p of arr) {
+      const diff = p - value
+      const d = Math.abs(diff)
+      if (d <= threshold && (!best || d < Math.abs(best.diff))) {
+        best = { diff, pos: p }
+      }
+    }
+    return best
+  }
+
+  const dxLeft = nearest(points.x.left, left)
+  const dxRight = nearest(points.x.right, right)
+  const dxCenter = nearest(points.x.center, cx)
+  const dyTop = nearest(points.y.top, top)
+  const dyBottom = nearest(points.y.bottom, bottom)
+  const dyCenter = nearest(points.y.middle, cy)
+
+  let guideX: number | null = null
+  let guideY: number | null = null
+
+  if (mode === 'move') {
+    const diffX = [dxLeft, dxRight, dxCenter].reduce<
+      { diff: number; pos: number } | null
+    >((best, cur) => (cur && (!best || Math.abs(cur.diff) < Math.abs(best.diff)) ? cur : best), null)
+    const diffY = [dyTop, dyBottom, dyCenter].reduce<
+      { diff: number; pos: number } | null
+    >((best, cur) => (cur && (!best || Math.abs(cur.diff) < Math.abs(best.diff)) ? cur : best), null)
+    if (diffX) {
+      x += diffX.diff
+      guideX = diffX.pos
+    }
+    if (diffY) {
+      y += diffY.diff
+      guideY = diffY.pos
+    }
+  } else {
+    if (
+      dxLeft && (!dxRight || Math.abs(dxLeft.diff) <= Math.abs(dxRight.diff)) &&
+      (!dxCenter || Math.abs(dxLeft.diff) <= Math.abs(dxCenter.diff))
+    ) {
+      x += dxLeft.diff
+      w = right - x
+      guideX = dxLeft.pos
+    } else if (dxRight && (!dxCenter || Math.abs(dxRight.diff) <= Math.abs(dxCenter.diff))) {
+      w += dxRight.diff
+      guideX = dxRight.pos
+    } else if (dxCenter) {
+      x += dxCenter.diff
+      guideX = dxCenter.pos
+    }
+    if (
+      dyTop && (!dyBottom || Math.abs(dyTop.diff) <= Math.abs(dyBottom.diff)) &&
+      (!dyCenter || Math.abs(dyTop.diff) <= Math.abs(dyCenter.diff))
+    ) {
+      y += dyTop.diff
+      h = bottom - y
+      guideY = dyTop.pos
+    } else if (dyBottom && (!dyCenter || Math.abs(dyBottom.diff) <= Math.abs(dyCenter.diff))) {
+      h += dyBottom.diff
+      guideY = dyBottom.pos
+    } else if (dyCenter) {
+      y += dyCenter.diff
+      guideY = dyCenter.pos
+    }
+  }
+
+  const guides: GuideLine[] = []
+  if (guideX !== null) guides.push({ axis: 'x', pos: guideX })
+  if (guideY !== null) guides.push({ axis: 'y', pos: guideY })
+  return { rect: { x, y, w, h }, guides }
+}
+

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -46,6 +46,10 @@ type BuilderState = {
   elements: Elm[]
   selectedId: string | null
   snap: number
+  ui: {
+    dragDraft?: { id: string; rect: { x: number; y: number; w: number; h: number } }
+    guides: Array<{ axis: 'x' | 'y'; pos: number }>
+  }
 }
 
 type BuilderActions = {
@@ -54,8 +58,13 @@ type BuilderActions = {
     at?: { x: number; y: number },
     meta?: DocgenMetaItem,
   ) => void
-  move: (id: string, to: { x: number; y: number }) => void
-  resize: (id: string, to: { w: number; h: number }) => void
+  move: (id: string, to: { x: number; y: number }, snapGrid?: boolean) => void
+  resize: (id: string, to: { w: number; h: number }, snapGrid?: boolean) => void
+  setDragDraft: (
+    d?: { id: string; rect: { x: number; y: number; w: number; h: number } },
+  ) => void
+  setGuides: (lines: Array<{ axis: 'x' | 'y'; pos: number }>) => void
+  clearGuides: () => void
   select: (id: string | null) => void
   updateProps: (
     id: string,
@@ -98,6 +107,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
   elements: [],
   selectedId: null,
   snap: SNAP,
+  ui: { guides: [] },
 
   addFromPalette(type, at, meta) {
     const id = `elm_${Date.now().toString(36)}`
@@ -148,24 +158,48 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     )
   },
 
-  move(id, to) {
+  move(id, to, snapGrid = true) {
     set(
       produce((draft: BuilderState) => {
         const e = draft.elements.find((x) => x.id === id)
         if (!e) return
-        e.x = snap(to.x)
-        e.y = snap(to.y)
+        e.x = snapGrid ? snap(to.x) : to.x
+        e.y = snapGrid ? snap(to.y) : to.y
       }),
     )
   },
 
-  resize(id, to) {
+  resize(id, to, snapGrid = true) {
     set(
       produce((draft: BuilderState) => {
         const e = draft.elements.find((x) => x.id === id)
         if (!e) return
-        e.w = Math.max(16, snap(to.w))
-        e.h = Math.max(16, snap(to.h))
+        e.w = Math.max(16, snapGrid ? snap(to.w) : to.w)
+        e.h = Math.max(16, snapGrid ? snap(to.h) : to.h)
+      }),
+    )
+  },
+
+  setDragDraft(d) {
+    set(
+      produce((draft: BuilderState) => {
+        draft.ui.dragDraft = d
+      }),
+    )
+  },
+
+  setGuides(lines) {
+    set(
+      produce((draft: BuilderState) => {
+        draft.ui.guides = lines
+      }),
+    )
+  },
+
+  clearGuides() {
+    set(
+      produce((draft: BuilderState) => {
+        draft.ui.guides = []
       }),
     )
   },


### PR DESCRIPTION
## Summary
- add snap utilities to collect element edges and apply guide snapping
- extend builder store with drag draft and guide lines
- show snapping guides and previews while dragging or resizing

## Testing
- `pnpm build` *(fails: Module not found: Can't resolve 'nanoid')*

------
https://chatgpt.com/codex/tasks/task_e_68ac1edbc204832c83b3659295663b38