### PR TITLE
feat(builder): add basic page management and overlay

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -14,6 +14,8 @@ import { Canvas } from '@/components/builder/Canvas'
 import { Inspector } from '@/components/builder/Inspector'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
+import { PagesPanel } from '@/components/builder/PagesPanel'
+import { usePageStore } from '@/store/pageStore'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -24,6 +26,11 @@ export default function BuilderPage() {
   const setDragDraft = useBuilderStore((s) => s.setDragDraft)
   const setGuides = useBuilderStore((s) => s.setGuides)
   const clearGuides = useBuilderStore((s) => s.clearGuides)
+  const setElements = useBuilderStore((s) => s.setElements)
+
+  const currentPageId = usePageStore((s) => s.currentPageId)
+  const getTree = usePageStore((s) => s.getTree)
+  const setTree = usePageStore((s) => s.setTree)
 
   const startRectRef = React.useRef<{ x: number; y: number; w: number; h: number } | null>(null)
   const snapPointsRef = React.useRef<ReturnType<typeof collectSnapPoints> | null>(null)
@@ -146,6 +153,14 @@ export default function BuilderPage() {
     URL.revokeObjectURL(a.href)
   }, [elements])
 
+  React.useEffect(() => {
+    setElements(getTree())
+  }, [currentPageId, getTree, setElements])
+
+  React.useEffect(() => {
+    setTree(elements)
+  }, [elements, setTree])
+
   return (
     <div className="flex h-[calc(100vh-40px)]">
       <DndContext
@@ -154,6 +169,9 @@ export default function BuilderPage() {
         onDragMove={onDragMove}
         onDragEnd={onDragEnd}
       >
+        <aside className="w-48 border-r border-zinc-800 bg-zinc-950/40 p-3">
+          <PagesPanel />
+        </aside>
         <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-3">
           <h2 className="text-sm font-semibold mb-2">パレット</h2>
           <Palette />

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useDroppable, useDraggable } from '@dnd-kit/core'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
+import { CanvasOverlay } from './CanvasOverlay'
 
 const GRID = 8
 function bgGridStyle() {
@@ -304,29 +305,6 @@ function ElmView({ elm }: { elm: Elm }) {
   )
 }
 
-function GuideOverlay() {
-  const guides = useBuilderStore((s) => s.ui.guides)
-  if (!guides.length) return null
-  return (
-    <div className="absolute inset-0 pointer-events-none z-50">
-      {guides.map((g, i) =>
-        g.axis === 'x' ? (
-          <div
-            key={i}
-            className="absolute top-0 bottom-0 border-l border-amber-400/70"
-            style={{ left: g.pos }}
-          />
-        ) : (
-          <div
-            key={i}
-            className="absolute left-0 right-0 border-t border-amber-400/70"
-            style={{ top: g.pos }}
-          />
-        ),
-      )}
-    </div>
-  )
-}
 
 export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElement> }) {
   const els = useBuilderStore((s) => s.elements)
@@ -369,7 +347,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         {els.map((e) => (
           <ElmView key={e.id} elm={e} />
         ))}
-        <GuideOverlay />
+        <CanvasOverlay />
         <div className="absolute left-2 bottom-2 text-[11px] text-zinc-400 bg-black/40 px-2 py-1 rounded border border-zinc-800">
           drag to move • drop from Palette • arrows to nudge • click empty = unselect
         </div>

--- a/web/components/builder/CanvasOverlay.tsx
+++ b/web/components/builder/CanvasOverlay.tsx
@@ -1,0 +1,28 @@
+'use client'
+import React from 'react'
+import { useBuilderStore } from '@/store/builderStore'
+
+export function CanvasOverlay() {
+  const guides = useBuilderStore((s) => s.ui.guides)
+  if (!guides.length) return null
+  return (
+    <div className="absolute inset-0 pointer-events-none z-50">
+      {guides.map((g, i) =>
+        g.axis === 'x' ? (
+          <div
+            key={i}
+            className="absolute top-0 bottom-0 border-l border-amber-400/70"
+            style={{ left: g.pos }}
+          />
+        ) : (
+          <div
+            key={i}
+            className="absolute left-0 right-0 border-t border-amber-400/70"
+            style={{ top: g.pos }}
+          />
+        ),
+      )}
+    </div>
+  )
+}
+

--- a/web/components/builder/PagesPanel.tsx
+++ b/web/components/builder/PagesPanel.tsx
@@ -1,0 +1,41 @@
+'use client'
+import React from 'react'
+import { usePageStore } from '@/store/pageStore'
+
+export function PagesPanel() {
+  const pages = usePageStore((s) => s.pages)
+  const current = usePageStore((s) => s.currentPageId)
+  const selectPage = usePageStore((s) => s.selectPage)
+  const addPage = usePageStore((s) => s.addPage)
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-semibold">Pages</h2>
+        <button
+          className="px-1 text-xs border border-zinc-700 rounded"
+          onClick={() => addPage()}
+        >
+          +
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {pages.map((p) => (
+          <li key={p.id}>
+            <button
+              className={`w-full text-left px-2 py-1 rounded text-xs ${
+                p.id === current
+                  ? 'bg-zinc-700 text-white'
+                  : 'bg-transparent text-zinc-300 hover:bg-zinc-800'
+              }`}
+              onClick={() => selectPage(p.id)}
+            >
+              {p.title} <span className="text-[10px] text-zinc-400">{p.path}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/web/lib/builder/treeOps.ts
+++ b/web/lib/builder/treeOps.ts
@@ -1,0 +1,84 @@
+export type ComponentNode = {
+  id: string
+  children?: ComponentNode[]
+  [key: string]: any
+}
+
+export function findNode(
+  tree: ComponentNode[],
+  id: string,
+  parent: ComponentNode | null = null,
+): { node: ComponentNode; parent: ComponentNode | null; index: number } | null {
+  for (let i = 0; i < tree.length; i++) {
+    const n = tree[i]
+    if (n.id === id) return { node: n, parent, index: i }
+    if (n.children) {
+      const found = findNode(n.children, id, n)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+export function insertNode(
+  tree: ComponentNode[],
+  parentId: string | null,
+  node: ComponentNode,
+  index?: number,
+): ComponentNode[] {
+  if (parentId === null) {
+    const t = tree.slice()
+    if (index === undefined || index < 0 || index > t.length) t.push(node)
+    else t.splice(index, 0, node)
+    return t
+  }
+  return tree.map((n) => {
+    if (n.id === parentId) {
+      const children = n.children ? n.children.slice() : []
+      if (index === undefined || index < 0 || index > children.length)
+        children.push(node)
+      else children.splice(index, 0, node)
+      return { ...n, children }
+    }
+    if (n.children) {
+      return { ...n, children: insertNode(n.children, parentId, node, index) }
+    }
+    return n
+  })
+}
+
+export function removeNode(
+  tree: ComponentNode[],
+  nodeId: string,
+): { newTree: ComponentNode[]; removed?: ComponentNode } {
+  let removed: ComponentNode | undefined
+  function helper(nodes: ComponentNode[]): ComponentNode[] {
+    return nodes
+      .map((n) => {
+        if (n.id === nodeId) {
+          removed = n
+          return null
+        }
+        if (n.children) {
+          const childRes = helper(n.children)
+          if (childRes !== n.children) return { ...n, children: childRes }
+        }
+        return n
+      })
+      .filter(Boolean) as ComponentNode[]
+  }
+  const newTree = helper(tree)
+  return { newTree, removed }
+}
+
+export function moveNode(
+  tree: ComponentNode[],
+  nodeId: string,
+  targetParentId: string | null,
+  targetIndex: number,
+): ComponentNode[] {
+  const { newTree, removed } = removeNode(tree, nodeId)
+  if (!removed) return tree
+  return insertNode(newTree, targetParentId, removed, targetIndex)
+}
+

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -74,6 +74,7 @@ type BuilderActions = {
   bringToFront: (id: string) => void
   sendToBack: (id: string) => void
   nudge: (dx: number, dy: number) => void
+  setElements: (els: Elm[]) => void
 }
 
 const SNAP = 8
@@ -270,6 +271,14 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     const el = get().elements.find((x) => x.id === id)
     if (!el) return
     get().move(id, { x: el.x + dx, y: el.y + dy })
+  },
+
+  setElements(els) {
+    set(
+      produce((draft: BuilderState) => {
+        draft.elements = els
+      }),
+    )
   },
 }))
 

--- a/web/store/pageStore.ts
+++ b/web/store/pageStore.ts
@@ -1,0 +1,149 @@
+import { create } from 'zustand'
+import { nanoid } from 'nanoid'
+import { type Elm } from '@/store/builderStore'
+
+export type PageId = string
+export type RoutePath = `/${string}`
+
+export type Page = {
+  id: PageId
+  title: string
+  path: RoutePath
+  tree: Elm[]
+  bindings: Record<`${string}:${string}`, unknown>
+}
+
+interface PageState {
+  pages: Page[]
+  currentPageId: PageId
+}
+
+interface PageActions {
+  selectPage: (id: PageId) => void
+  addPage: (init?: Partial<Page>) => PageId
+  removePage: (id: PageId) => void
+  duplicatePage: (id: PageId) => PageId
+  updatePageMeta: (
+    id: PageId,
+    patch: Partial<Pick<Page, 'title' | 'path'>>,
+  ) => void
+  getTree: () => Elm[]
+  setTree: (tree: Elm[]) => void
+  getBindings: () => Page['bindings']
+  setBindings: (b: Page['bindings']) => void
+  exportJSON: () => string
+  importJSON: (json: string) => void
+}
+
+function defaultPage(idx: number): Page {
+  return {
+    id: `page_${nanoid(6)}`,
+    title: idx === 0 ? 'Home' : `Page ${idx + 1}`,
+    path: idx === 0 ? '/' : (`/page-${idx + 1}` as RoutePath),
+    tree: [],
+    bindings: {},
+  }
+}
+
+const initial = defaultPage(0)
+
+export const usePageStore = create<PageState & PageActions>((set, get) => ({
+  pages: [initial],
+  currentPageId: initial.id,
+
+  selectPage(id) {
+    const exists = get().pages.some((p) => p.id === id)
+    if (exists) set({ currentPageId: id })
+  },
+
+  addPage(init) {
+    const pages = get().pages
+    const idx = pages.length
+    const page: Page = {
+      ...defaultPage(idx),
+      ...init,
+      id: `page_${nanoid(6)}`,
+      path: init?.path ?? (`/page-${idx + 1}` as RoutePath),
+      title: init?.title ?? `Page ${idx + 1}`,
+      tree: init?.tree ?? [],
+      bindings: init?.bindings ?? {},
+    }
+    set({ pages: [...pages, page], currentPageId: page.id })
+    return page.id
+  },
+
+  removePage(id) {
+    set((s) => {
+      const pages = s.pages.filter((p) => p.id !== id)
+      let currentPageId = s.currentPageId
+      if (s.currentPageId === id && pages.length) {
+        currentPageId = pages[0].id
+      }
+      return { pages, currentPageId }
+    })
+  },
+
+  duplicatePage(id) {
+    const src = get().pages.find((p) => p.id === id)
+    if (!src) return get().currentPageId
+    const idx = get().pages.length
+    const newPage: Page = {
+      ...src,
+      id: `page_${nanoid(6)}`,
+      title: `${src.title} Copy`,
+      path: (`/page-${idx + 1}` as RoutePath),
+      tree: JSON.parse(JSON.stringify(src.tree)),
+      bindings: JSON.parse(JSON.stringify(src.bindings)),
+    }
+    set((s) => ({ pages: [...s.pages, newPage], currentPageId: newPage.id }))
+    return newPage.id
+  },
+
+  updatePageMeta(id, patch) {
+    set((s) => ({
+      pages: s.pages.map((p) => (p.id === id ? { ...p, ...patch } : p)),
+    }))
+  },
+
+  getTree() {
+    const p = get().pages.find((p) => p.id === get().currentPageId)
+    return p ? p.tree : []
+  },
+
+  setTree(tree) {
+    set((s) => ({
+      pages: s.pages.map((p) =>
+        p.id === s.currentPageId ? { ...p, tree } : p,
+      ),
+    }))
+  },
+
+  getBindings() {
+    const p = get().pages.find((p) => p.id === get().currentPageId)
+    return p ? p.bindings : {}
+  },
+
+  setBindings(b) {
+    set((s) => ({
+      pages: s.pages.map((p) =>
+        p.id === s.currentPageId ? { ...p, bindings: b } : p,
+      ),
+    }))
+  },
+
+  exportJSON() {
+    return JSON.stringify(get().pages)
+  },
+
+  importJSON(json) {
+    try {
+      const pages = JSON.parse(json) as Page[]
+      if (Array.isArray(pages) && pages.length) {
+        set({ pages, currentPageId: pages[0].id })
+      }
+    } catch {
+      // ignore
+    }
+  },
+}))
+


### PR DESCRIPTION
## Summary
- add `pageStore` for per-page trees and bindings
- introduce simple `PagesPanel` UI and sync builder elements to pages
- extract `CanvasOverlay` and add pure tree utilities

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*
- `pnpm -C web build` *(fails: module not found for '@core/action-bus')*

------
https://chatgpt.com/codex/tasks/task_e_68ac2c0f2d20832cae1ffbd6d20f1c66