### PR TITLE
feat(journal): add JournalForm with typed validation and API

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,17 @@
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@hookform/resolvers": "^5.2.1",
     "immer": "10.0.0",
     "prettier": "^3.6.2",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-docgen-typescript": "^2.2.2",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.62.0",
     "react-window": "^1.8.9",
     "ts-morph": "^22.0.0",
+    "zod": "^3.23.8",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/packages/data/src/registry.ts
+++ b/packages/data/src/registry.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { JournalInput } from "@schemas";
 import type { ApiEndpoint } from "./types";
 
 export const endpoints: Record<string, ApiEndpoint<any, any, any>> = {
@@ -25,5 +26,19 @@ export const endpoints: Record<string, ApiEndpoint<any, any, any>> = {
     paramsSchema: z.object({ key: z.string() }),
     bodySchema: z.record(z.any()),
     respSchema: z.object({ result: z.any(), trace: z.array(z.any()).optional() }),
+  },
+  "journal.validate": {
+    id: "journal.validate",
+    method: "POST",
+    path: "/api/journal/validate",
+    bodySchema: JournalInput,
+    respSchema: z.object({ ok: z.boolean(), issues: z.array(z.string()).default([]) }),
+  },
+  "journal.save": {
+    id: "journal.save",
+    method: "POST",
+    path: "/api/journal",
+    bodySchema: JournalInput,
+    respSchema: z.object({ ok: z.boolean(), id: z.string().optional(), message: z.string().optional() }),
   },
 };

--- a/packages/domain-components/package.json
+++ b/packages/domain-components/package.json
@@ -7,6 +7,9 @@
   "dependencies": {
     "zod": "^3.23.8",
     "@core": "workspace:*",
-    "@data": "workspace:*"
+    "@data": "workspace:*",
+    "@schemas": "workspace:*",
+    "react-hook-form": "^7.62.0",
+    "@hookform/resolvers": "^5.2.1"
   }
 }

--- a/packages/domain-components/src/components/JournalForm.tsx
+++ b/packages/domain-components/src/components/JournalForm.tsx
@@ -1,0 +1,135 @@
+import type { FC } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { JournalInput, TaxClass } from "@schemas";
+import type { z } from "zod";
+import { ActionBus } from "@core/action-bus";
+import { callEndpoint } from "@data";
+type JI = z.infer<typeof JournalInput>;
+
+type Props = {
+  initial?: Partial<JI>;
+  suggestTax?: boolean;
+  className?: string;
+  nodeId?: string;
+};
+
+export const JournalForm: FC<Props> = ({ initial, suggestTax = false, className, nodeId }) => {
+  const { register, handleSubmit, formState, setError, setValue, watch } = useForm<JI>({
+    resolver: zodResolver(JournalInput),
+    defaultValues: {
+      date: new Date().toISOString().slice(0, 10),
+      debitAccount: "",
+      creditAccount: "",
+      amount: 0,
+      taxClass: "課税",
+      note: "",
+      evidenceId: "",
+      ...(initial as any),
+    },
+    mode: "onChange",
+  });
+
+  // 任意：金額や勘定が変わったらDMNで税区分提案
+  const amount = watch("amount");
+  const debit = watch("debitAccount");
+  const credit = watch("creditAccount");
+
+  async function maybeSuggest() {
+    if (!suggestTax) return;
+    try {
+      const input = { amount, debit, credit };
+      const res = await callEndpoint("dmn.run", { params: { key: "consumption-tax" }, body: input });
+      const t = (res.result?.taxClass ?? "") as string;
+      if (TaxClass.options.includes(t as any)) {
+        // 軽いUI：採用ボタン／破棄ボタンをトースト代わりにconsoleで
+        console.log("[suggestion] taxClass:", t);
+        setValue("taxClass", t as any, { shouldValidate: true });
+      }
+    } catch {
+      /* noop */
+    }
+  }
+
+  const onSubmit = async (data: JI) => {
+    // 事前検証（冪等だがユーザ体験向上）
+    const v = await callEndpoint("journal.validate", { body: data }).catch(async (e) => {
+      setError("root.server", { message: "Validation failed" });
+      throw e;
+    });
+    if (!v.ok) {
+      setError("root.server", { message: v.issues.join("; ") });
+      return;
+    }
+    // 保存
+    try {
+      const res = await callEndpoint("journal.save", { body: data });
+      if (res.ok && res.id) {
+        ActionBus.emit({ type: "COMPONENT_EVENT", nodeId, event: "onSaved", payload: { journalId: res.id } });
+        console.log("[toast:success] 保存しました");
+      } else {
+        setError("root.server", { message: res.message ?? "保存に失敗しました" });
+      }
+    } catch (err: any) {
+      setError("root.server", { message: String(err?.message ?? "保存に失敗") });
+    }
+  };
+
+  return (
+    <form className={`p-4 space-y-3 ${className ?? ""}`} onSubmit={handleSubmit(onSubmit)}>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="space-y-1">
+          <span className="text-xs text-gray-500">日付</span>
+          <input type="date" className="w-full border rounded px-2 py-1" {...register("date")} />
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs text-gray-500">金額</span>
+          <input type="number" className="w-full border rounded px-2 py-1" {...register("amount", { valueAsNumber: true })} onBlur={maybeSuggest} />
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs text-gray-500">借方勘定</span>
+          <input className="w-full border rounded px-2 py-1" {...register("debitAccount")} onBlur={maybeSuggest} />
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs text-gray-500">貸方勘定</span>
+          <input className="w-full border rounded px-2 py-1" {...register("creditAccount")} onBlur={maybeSuggest} />
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs text-gray-500">税区分</span>
+          <select className="w-full border rounded px-2 py-1" {...register("taxClass")}>
+            {TaxClass.options.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs text-gray-500">証憑ID</span>
+          <input className="w-full border rounded px-2 py-1" {...register("evidenceId")} />
+        </label>
+        <label className="col-span-2 space-y-1">
+          <span className="text-xs text-gray-500">摘要</span>
+          <input className="w-full border rounded px-2 py-1" {...register("note")} />
+        </label>
+      </div>
+
+      {formState.errors.root?.server && (
+        <div className="text-red-600 text-sm">{formState.errors.root.server.message}</div>
+      )}
+
+      <div className="flex gap-2 pt-2">
+        <button type="submit" className="px-3 py-2 rounded bg-black text-white disabled:opacity-50" disabled={!formState.isValid}>
+          保存
+        </button>
+        <button
+          type="button"
+          className="px-3 py-2 rounded border"
+          onClick={() => ActionBus.emit({ type: "COMPONENT_EVENT", nodeId, event: "onCancel", payload: {} })}
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/packages/domain-components/src/registry.ts
+++ b/packages/domain-components/src/registry.ts
@@ -51,4 +51,20 @@ export const Registry: RegistryType = {
     events: { onClick: z.object({}).optional() },
     load: () => import("./components/Button").then((m) => m.Button),
   },
+  JournalForm: {
+    id: "JournalForm",
+    displayName: "仕訳フォーム",
+    tags: ["domain", "form"],
+    propsSchema: z.object({
+      initial: z.any().optional(),
+      suggestTax: z.boolean().default(false),
+      className: z.string().optional(),
+    }),
+    defaultProps: { suggestTax: false },
+    events: {
+      onSaved: z.object({ journalId: z.string() }),
+      onCancel: z.object({}).optional(),
+    },
+    load: () => import("./components/JournalForm").then((m) => m.JournalForm),
+  },
 };

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "@data",
+  "name": "@schemas",
   "version": "0.0.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
-    "@schemas": "workspace:*",
     "zod": "^3.23.8"
   }
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./journal";

--- a/packages/schemas/src/journal.ts
+++ b/packages/schemas/src/journal.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const TaxClass = z.enum(["課税", "非課税", "不課税", "免税", "対象外"]);
+export const JournalInput = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD"),
+  debitAccount: z.string().min(1),
+  creditAccount: z.string().min(1),
+  subAccount: z.string().optional(),
+  amount: z.number().int().positive(),
+  taxClass: TaxClass,
+  note: z.string().max(200).optional(),
+  evidenceId: z.string().optional(),
+});
+export type JournalInput = z.infer<typeof JournalInput>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@18.3.1))
       immer:
         specifier: 10.0.0
         version: 10.0.0
@@ -41,12 +44,18 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@18.3.1)
       react-window:
         specifier: ^1.8.9
         version: 1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-morph:
         specifier: ^22.0.0
         version: 22.0.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
       zustand:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@18.3.24)(immer@10.0.0)(react@18.3.1)
@@ -69,6 +78,9 @@ importers:
 
   packages/data:
     dependencies:
+      '@schemas':
+        specifier: workspace:*
+        version: link:../schemas
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -81,6 +93,21 @@ importers:
       '@data':
         specifier: workspace:*
         version: link:../data
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@18.3.1))
+      '@schemas':
+        specifier: workspace:*
+        version: link:../schemas
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+
+  packages/schemas:
+    dependencies:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -96,6 +123,9 @@ importers:
       '@domain-components':
         specifier: workspace:*
         version: link:../packages/domain-components
+      '@schemas':
+        specifier: workspace:*
+        version: link:../packages/schemas
       '@tanstack/react-query':
         specifier: ^5.59.7
         version: 5.85.5(react@18.3.1)
@@ -232,6 +262,11 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -344,6 +379,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -1032,6 +1070,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1383,6 +1427,11 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.62.0(react@18.3.1)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -1467,6 +1516,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -2116,6 +2167,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.62.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 

--- a/web/app/api/journal/route.ts
+++ b/web/app/api/journal/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { JournalInput } from "@schemas";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const parsed = JournalInput.safeParse(body);
+  if (!parsed.success) {
+    const msgs = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`);
+    return NextResponse.json({ ok: false, message: msgs.join("; ") }, { status: 400 });
+  }
+  const id = "j-" + Math.random().toString(36).slice(2, 8);
+  return NextResponse.json({ ok: true, id, message: "保存しました" });
+}

--- a/web/app/api/journal/validate/route.ts
+++ b/web/app/api/journal/validate/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { JournalInput } from "@schemas";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const parsed = JournalInput.safeParse(body);
+  if (!parsed.success) {
+    const msgs = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`);
+    return NextResponse.json({ ok: false, issues: msgs }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true, issues: [] });
+}

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "@core": "workspace:*",
     "@domain-components": "workspace:*",
     "@data": "workspace:*",
+    "@schemas": "workspace:*",
     "dexie": "^4.2.0",
     "immer": "^10.0.0",
     "nanoid": "^5.0.2",


### PR DESCRIPTION
## Summary
- add shared journal schemas (TaxClass & JournalInput)
- extend data layer and API routes for journal validation and save
- implement JournalForm component with DMN tax suggestion and events

## Testing
- `pnpm install`
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ac33d24d20832ca16cb778dfa7dbb6