### PR TITLE
feat(builder): load existing JSX into builder via component tree parsing

### DIFF
--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,0 +1,10 @@
+import { TextBlock, Button } from "@/components";
+
+export default function Page() {
+  return (
+    <div>
+      <TextBlock text="ようこそ！" align="center" />
+      <Button label="次へ" variant="solid" />
+    </div>
+  );
+}

--- a/scripts/parseComponentTree.ts
+++ b/scripts/parseComponentTree.ts
@@ -1,0 +1,74 @@
+import { Project, SyntaxKind } from "ts-morph";
+import path from "path";
+import fs from "fs";
+
+export type ComponentNode = {
+  id: string;
+  componentId: string;
+  props: Record<string, any>;
+  children?: ComponentNode[];
+};
+
+function parseJsxElement(el: any): ComponentNode | null {
+  if (!el) return null;
+
+  const isSelf = el.getKind() === SyntaxKind.JsxSelfClosingElement;
+  const tagNode = isSelf
+    ? el.getTagNameNode()
+    : el.getOpeningElement().getTagNameNode();
+  const componentId = tagNode.getText();
+  const attrs = isSelf ? el.getAttributes() : el.getOpeningElement().getAttributes();
+  const props: Record<string, any> = {};
+  attrs.forEach((attr: any) => {
+    if (attr.getKind() === SyntaxKind.JsxAttribute) {
+      const name = attr.getNameNode().getText();
+      const initializer = attr.getInitializer();
+      if (initializer) {
+        if (initializer.getKind() === SyntaxKind.StringLiteral) {
+          props[name] = initializer.getLiteralText();
+        } else if (initializer.getKind() === SyntaxKind.JsxExpression) {
+          const expr = initializer.getExpression();
+          if (expr) props[name] = expr.getText();
+        }
+      }
+    }
+  });
+
+  const children: ComponentNode[] = [];
+  const childEls = isSelf
+    ? []
+    : el.getChildrenOfKind(SyntaxKind.JsxElement).concat(
+        el.getChildrenOfKind(SyntaxKind.JsxSelfClosingElement)
+      );
+  childEls.forEach((childEl: any) => {
+    const c = parseJsxElement(childEl);
+    if (c) children.push(c);
+  });
+
+  return {
+    id: "id_" + Math.random().toString(36).slice(2, 8),
+    componentId,
+    props,
+    children: children.length ? children : undefined,
+  };
+}
+
+export function parseComponentTreeFromFile(filePath: string): ComponentNode[] {
+  const project = new Project({ tsConfigFilePath: "tsconfig.json" });
+  const source = project.addSourceFileAtPath(filePath);
+  const rootJsx = source.getDescendantsOfKind(SyntaxKind.JsxElement)[0];
+
+  const root = parseJsxElement(rootJsx);
+  return root ? [root] : [];
+}
+
+if (require.main === module) {
+  const target = process.argv[2];
+  if (!target) {
+    console.error("Usage: ts-node parseComponentTree.ts <file>");
+    process.exit(1);
+  }
+  const fp = path.resolve(process.cwd(), target);
+  const tree = parseComponentTreeFromFile(fp);
+  fs.writeFileSync("componentTree.json", JSON.stringify(tree, null, 2));
+}

--- a/web/app/api/load-component-tree/route.ts
+++ b/web/app/api/load-component-tree/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import path from "path";
+import { parseComponentTreeFromFile } from "../../../../scripts/parseComponentTree";
+
+export async function GET() {
+  const filePath = path.resolve(process.cwd(), "../components/page.tsx");
+  const tree = parseComponentTreeFromFile(filePath);
+  return NextResponse.json({ tree });
+}

--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -5,6 +5,7 @@ import LayersPanel from '@/components/sidebar/LayersPanel'
 import ExportPanel from '@/components/editor/ExportPanel'
 import { seedToStore, markPreviousCrashedForTest } from '@/dev/seed'
 import { useEditorStore } from '@/store/editorStore'
+import { LoadFromCode } from '@/components/LoadFromCode'
 
 export default function DevPages() {
   const s = useEditorStore()
@@ -13,6 +14,7 @@ export default function DevPages() {
       <header className="flex items-center justify-between">
         <h1 className="text-lg font-semibold">Dev / Pages</h1>
         <div className="flex gap-2">
+          <LoadFromCode />
           <button className="px-2 py-1 text-sm rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700" onClick={() => seedToStore(100)}>
             Seed 100
           </button>

--- a/web/components/LoadFromCode.tsx
+++ b/web/components/LoadFromCode.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useEditorStore } from "@/store/editorStore";
+
+export function LoadFromCode() {
+  const load = async () => {
+    const res = await fetch("/api/load-component-tree");
+    const data = await res.json();
+    useEditorStore.setState((s) => ({ ...s, tree: data.tree }));
+  };
+
+  return (
+    <button onClick={load} className="px-2 py-1 border rounded">
+      既存コードを読み込む
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add ts-morph script to parse React JSX into ComponentNode tree
- expose `/api/load-component-tree` API to fetch parsed tree
- load parsed tree into editor via new `LoadFromCode` button

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ac367155ac832c917ed9848f5e5c32