### PR TITLE
feat(builder): add ComponentTree to JSX export

### DIFF
--- a/scripts/generateCodeFromTree.ts
+++ b/scripts/generateCodeFromTree.ts
@@ -1,0 +1,58 @@
+import type { ComponentNode } from "@domain-components";
+import fs from "fs";
+import path from "path";
+
+function jsxPropValue(val: any): string {
+  if (typeof val === "string") return `"${val}"`;
+  if (typeof val === "number" || typeof val === "boolean") return `{${val}}`;
+  if (typeof val === "object") return `{${JSON.stringify(val)}}`;
+  return `{${String(val)}}`;
+}
+
+function renderNode(node: ComponentNode): string {
+  const tag = node.componentId;
+  const props = Object.entries(node.props || {})
+    .map(([k, v]) => `${k}=${jsxPropValue(v)}`)
+    .join(" ");
+  const children = (node.children ?? []).map(renderNode).join("\n");
+  const propsStr = props ? ` ${props}` : "";
+  if (!children) {
+    return `<${tag}${propsStr} />`;
+  } else {
+    return `<${tag}${propsStr}>
+  ${children}
+</${tag}>`;
+  }
+}
+
+function collectUsed(nodes: ComponentNode[], used: Set<string>) {
+  for (const n of nodes) {
+    used.add(n.componentId);
+    if (n.children) collectUsed(n.children, used);
+  }
+}
+
+export function generateCodeFromTree(tree: ComponentNode[], outPath: string) {
+  const used = new Set<string>();
+  collectUsed(tree, used);
+  const imports = `import { ${Array.from(used).join(", ")} } from "@/components";`;
+  const body = tree.map(renderNode).join("\n");
+  const code = `${imports}\n\nexport default function Page() {\n  return (\n    <>\n${body
+    .split("\n")
+    .map((l) => "      " + l)
+    .join("\n")}\n    </>\n  );\n}\n`;
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, code, "utf-8");
+}
+
+if (require.main === module) {
+  const input = process.argv[2];
+  const out = process.argv[3];
+  if (!input || !out) {
+    console.error("Usage: ts-node generateCodeFromTree.ts <tree.json> <out.tsx>");
+    process.exit(1);
+  }
+  const tree = JSON.parse(fs.readFileSync(input, "utf-8"));
+  const outPath = path.resolve(process.cwd(), out);
+  generateCodeFromTree(tree, outPath);
+}

--- a/web/app/api/export-code/route.ts
+++ b/web/app/api/export-code/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generateCodeFromTree } from "../../../../scripts/generateCodeFromTree";
+import path from "path";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const tree = body.tree;
+  const outPath = path.resolve(process.cwd(), "../components/generated/page.tsx");
+  generateCodeFromTree(tree, outPath);
+  return NextResponse.json({ ok: true, path: outPath });
+}

--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -6,6 +6,7 @@ import ExportPanel from '@/components/editor/ExportPanel'
 import { seedToStore, markPreviousCrashedForTest } from '@/dev/seed'
 import { useEditorStore } from '@/store/editorStore'
 import { LoadFromCode } from '@/components/LoadFromCode'
+import { ExportCode } from '@/components/ExportCode'
 
 export default function DevPages() {
   const s = useEditorStore()
@@ -15,6 +16,7 @@ export default function DevPages() {
         <h1 className="text-lg font-semibold">Dev / Pages</h1>
         <div className="flex gap-2">
           <LoadFromCode />
+          <ExportCode />
           <button className="px-2 py-1 text-sm rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700" onClick={() => seedToStore(100)}>
             Seed 100
           </button>

--- a/web/components/ExportCode.tsx
+++ b/web/components/ExportCode.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEditorStore } from "@/store/editorStore";
+
+export function ExportCode() {
+  const tree = useEditorStore((s) => s.tree);
+
+  async function exportCode() {
+    const res = await fetch("/api/export-code", {
+      method: "POST",
+      body: JSON.stringify({ tree }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const data = await res.json();
+    alert(`コードを書き出しました！\n${data.path}`);
+  }
+
+  return (
+    <button onClick={exportCode} className="px-2 py-1 border rounded">
+      コードとして保存
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- generate React JSX from ComponentTree nodes
- add API route to export code to components/generated/page.tsx
- expose ExportCode button in UI alongside LoadFromCode

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ac389abeec832c97823aeb021efb7d