### PR TITLE
feat(code): add support for user-code slots in JSX export/import

### DIFF
--- a/packages/domain-components/src/types.ts
+++ b/packages/domain-components/src/types.ts
@@ -22,6 +22,8 @@ export type ComponentNode = {
   componentId: string;
   props: Record<string, any>;
   children?: ComponentNode[];
+  /** user-defined expression props retained separately from serializable props */
+  userCode?: Record<string, string>;
   locked?: boolean;
   dataBindings?: DataBindings;
 };

--- a/scripts/generateCodeFromTree.ts
+++ b/scripts/generateCodeFromTree.ts
@@ -11,11 +11,15 @@ function jsxPropValue(val: any): string {
 
 function renderNode(node: ComponentNode): string {
   const tag = node.componentId;
-  const props = Object.entries(node.props || {})
-    .map(([k, v]) => `${k}=${jsxPropValue(v)}`)
-    .join(" ");
+  const propEntries = Object.entries(node.props || {}).map(
+    ([k, v]) => `${k}=${jsxPropValue(v)}`
+  );
+  const userCodeEntries = Object.entries(node.userCode ?? {}).map(
+    ([k, code]) => `${k}={${code}} // @user-code:${node.id}:${k}`
+  );
+  const allProps = [...propEntries, ...userCodeEntries].join(" ");
+  const propsStr = allProps ? ` ${allProps}` : "";
   const children = (node.children ?? []).map(renderNode).join("\n");
-  const propsStr = props ? ` ${props}` : "";
   if (!children) {
     return `<${tag}${propsStr} />`;
   } else {

--- a/scripts/parseComponentTree.ts
+++ b/scripts/parseComponentTree.ts
@@ -7,6 +7,7 @@ export type ComponentNode = {
   componentId: string;
   props: Record<string, any>;
   children?: ComponentNode[];
+  userCode?: Record<string, string>;
 };
 
 function parseJsxElement(el: any): ComponentNode | null {
@@ -19,6 +20,7 @@ function parseJsxElement(el: any): ComponentNode | null {
   const componentId = tagNode.getText();
   const attrs = isSelf ? el.getAttributes() : el.getOpeningElement().getAttributes();
   const props: Record<string, any> = {};
+  const userCode: Record<string, string> = {};
   attrs.forEach((attr: any) => {
     if (attr.getKind() === SyntaxKind.JsxAttribute) {
       const name = attr.getNameNode().getText();
@@ -28,7 +30,13 @@ function parseJsxElement(el: any): ComponentNode | null {
           props[name] = initializer.getLiteralText();
         } else if (initializer.getKind() === SyntaxKind.JsxExpression) {
           const expr = initializer.getExpression();
-          if (expr) props[name] = expr.getText();
+          const comment = attr.getTrailingCommentRanges?.()[0];
+          const commentText = comment?.getText?.() ?? "";
+          if (commentText.includes("@user-code:")) {
+            userCode[name] = expr?.getText() || "";
+          } else if (expr) {
+            props[name] = expr.getText();
+          }
         }
       }
     }
@@ -50,6 +58,7 @@ function parseJsxElement(el: any): ComponentNode | null {
     componentId,
     props,
     children: children.length ? children : undefined,
+    userCode: Object.keys(userCode).length ? userCode : undefined,
   };
 }
 

--- a/src/Inspector.tsx
+++ b/src/Inspector.tsx
@@ -19,13 +19,25 @@ const Inspector: React.FC = () => {
   const node = findNode(tree, selectedComponentId)
   if (!node) return <div className="p-2 text-sm text-gray-500">No component selected</div>
   return (
-    <AutoPropsEditor
-      selectedComponentType={node.type}
-      selectedProps={node.props || {}}
-      onChange={(next) => {
-        for (const k of Object.keys(next)) setProp(node.id, k, next[k])
-      }}
-    />
+    <div className="space-y-2">
+      <AutoPropsEditor
+        selectedComponentType={node.type}
+        selectedProps={node.props || {}}
+        onChange={(next) => {
+          for (const k of Object.keys(next)) setProp(node.id, k, next[k])
+        }}
+      />
+      {node.userCode && (
+        <div className="space-y-1">
+          {Object.entries(node.userCode).map(([k, code]) => (
+            <div key={k}>
+              <div className="text-xs text-gray-500">{k}</div>
+              <pre className="text-xs bg-gray-100 rounded p-2 overflow-auto">{code}</pre>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -4,6 +4,7 @@ export interface ComponentNode {
   id: string;
   type: string;
   props?: Record<string, any>;
+  userCode?: Record<string, string>;
   bindings?: Record<string, PropBinding>;
   variants?: { hover?: { className?: string } };
   children?: ComponentNode[];

--- a/web/components/Inspector.tsx
+++ b/web/components/Inspector.tsx
@@ -65,6 +65,19 @@ export default function Inspector() {
           }}
         />
       </div>
+      {node.userCode && (
+        <div className="space-y-1">
+          <div className="text-xs font-semibold text-gray-500">User Code</div>
+          {Object.entries(node.userCode).map(([k, code]) => (
+            <div key={k}>
+              <div className="text-xs text-gray-500">{k}</div>
+              <pre className="text-xs bg-gray-100 dark:bg-zinc-900 border border-zinc-800 rounded px-2 py-1 overflow-auto">
+                {code}
+              </pre>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/components/store.tsx
+++ b/web/components/store.tsx
@@ -12,6 +12,7 @@ export interface ComponentNode {
   id: string
   type: string
   props?: Record<string, any>
+  userCode?: Record<string, string>
   bindings?: Record<string, PropBinding>
   variants?: { hover?: { className?: string } }
   children?: ComponentNode[]

--- a/web/types/editor.ts
+++ b/web/types/editor.ts
@@ -296,6 +296,7 @@ export interface ComponentNode {
     constraints?: Constraints;
     layoutGrids?: LayoutGrid[];
   };
+  userCode?: Record<string, string>;
   bindings?: Record<string, PropBinding>;
   prototypeLink?: PrototypeLink;
   variants?: {


### PR DESCRIPTION
## Summary
- preserve user-defined JSX snippets via `userCode` in `ComponentNode`
- annotate generated JSX with `// @user-code` markers and parse them back
- display recovered code snippets in Props inspector

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3af47cc8832cb87e0fb616391551