### PR TITLE
feat(code): support expression props in ComponentTree and JSX output

### DIFF
--- a/packages/domain-components/src/types.ts
+++ b/packages/domain-components/src/types.ts
@@ -17,10 +17,17 @@ export interface RegisteredComp<TProps = any> {
 
 export type Registry = Record<string, RegisteredComp<any>>;
 
+export type PropValue =
+  | string
+  | number
+  | boolean
+  | { __expr: string };
+
 export type ComponentNode = {
   id: string;
   componentId: string;
-  props: Record<string, any>;
+  props: Record<string, PropValue>;
+  userCode?: Record<string, string>;
   children?: ComponentNode[];
   locked?: boolean;
   dataBindings?: DataBindings;

--- a/scripts/generateCodeFromTree.ts
+++ b/scripts/generateCodeFromTree.ts
@@ -5,7 +5,12 @@ import path from "path";
 function jsxPropValue(val: any): string {
   if (typeof val === "string") return `"${val}"`;
   if (typeof val === "number" || typeof val === "boolean") return `{${val}}`;
-  if (typeof val === "object") return `{${JSON.stringify(val)}}`;
+  if (typeof val === "object") {
+    if (val && typeof val === "object" && "__expr" in val) {
+      return `{${(val as any).__expr}}`;
+    }
+    return `{${JSON.stringify(val)}}`;
+  }
   return `{${String(val)}}`;
 }
 

--- a/scripts/parseComponentTree.ts
+++ b/scripts/parseComponentTree.ts
@@ -2,10 +2,17 @@ import { Project, SyntaxKind } from "ts-morph";
 import path from "path";
 import fs from "fs";
 
+export type PropValue =
+  | string
+  | number
+  | boolean
+  | { __expr: string };
+
 export type ComponentNode = {
   id: string;
   componentId: string;
-  props: Record<string, any>;
+  props: Record<string, PropValue>;
+  userCode?: Record<string, string>;
   children?: ComponentNode[];
 };
 
@@ -18,7 +25,8 @@ function parseJsxElement(el: any): ComponentNode | null {
     : el.getOpeningElement().getTagNameNode();
   const componentId = tagNode.getText();
   const attrs = isSelf ? el.getAttributes() : el.getOpeningElement().getAttributes();
-  const props: Record<string, any> = {};
+  const props: Record<string, PropValue> = {};
+  const userCode: Record<string, string> = {};
   attrs.forEach((attr: any) => {
     if (attr.getKind() === SyntaxKind.JsxAttribute) {
       const name = attr.getNameNode().getText();
@@ -28,7 +36,17 @@ function parseJsxElement(el: any): ComponentNode | null {
           props[name] = initializer.getLiteralText();
         } else if (initializer.getKind() === SyntaxKind.JsxExpression) {
           const expr = initializer.getExpression();
-          if (expr) props[name] = expr.getText();
+          const exprText = expr?.getText();
+          if (exprText) {
+            const comment =
+              attr.getTrailingCommentRanges()?.[0]?.getText?.() ?? "";
+            const matched = comment.match(/@user-code:(.+?):(.+)/);
+            if (matched) {
+              userCode[name] = exprText;
+            } else {
+              props[name] = { __expr: exprText };
+            }
+          }
         }
       }
     }
@@ -49,6 +67,7 @@ function parseJsxElement(el: any): ComponentNode | null {
     id: "id_" + Math.random().toString(36).slice(2, 8),
     componentId,
     props,
+    userCode: Object.keys(userCode).length ? userCode : undefined,
     children: children.length ? children : undefined,
   };
 }


### PR DESCRIPTION
## Summary
- preserve JSX expressions in ComponentNode props via `__expr`
- parse JSX attributes into `__expr` or `userCode` slots
- render expression props back to JSX when generating code

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b018280832cb4e80204c3342bcc