### PR TITLE
fix: add react-query dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "react-hook-form": "^7.62.0",
     "react-window": "^1.8.9",
     "ts-morph": "^22.0.0",
+    "@tanstack/react-query": "^5.85.5",
+    "@tanstack/react-query-devtools": "^5.85.5",
     "zod": "^3.23.8",
     "zustand": "^4.5.2"
   },

--- a/packages/domain-components/src/types.ts
+++ b/packages/domain-components/src/types.ts
@@ -27,10 +27,9 @@ export type ComponentNode = {
   id: string;
   componentId: string;
   props: Record<string, PropValue>;
-  userCode?: Record<string, string>;
-  children?: ComponentNode[];
   /** user-defined expression props retained separately from serializable props */
   userCode?: Record<string, string>;
+  children?: ComponentNode[];
   locked?: boolean;
   dataBindings?: DataBindings;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@18.3.1))
+      '@tanstack/react-query':
+        specifier: ^5.85.5
+        version: 5.85.5(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.85.5
+        version: 5.85.5(@tanstack/react-query@5.85.5(react@18.3.1))(react@18.3.1)
       immer:
         specifier: 10.0.0
         version: 10.0.0


### PR DESCRIPTION
## Summary
- add TanStack React Query packages to root workspace
- remove duplicate field from ComponentNode type

## Testing
- `pnpm -C web build` (fails: Cannot find module '@domain-components')
- `pnpm test` (fails: Test suite failed to run)


------
https://chatgpt.com/codex/tasks/task_e_68ac670ee5d8832cb7f4e692ae3f5e7d