### PR TITLE
refactor: extract header modules

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -4,6 +4,7 @@ import { useDroppable, useDraggable } from '@dnd-kit/core'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
 import { CanvasOverlay } from './CanvasOverlay'
+import { HeaderView } from './header/HeaderView'
 
 const GRID = 8
 function bgGridStyle() {
@@ -14,31 +15,6 @@ function bgGridStyle() {
     backgroundSize: `${s}px ${s}px, ${s}px ${s}px`,
     backgroundPosition: '0 0, 0 0',
   } as React.CSSProperties
-}
-
-type LoginButton = NonNullable<Elm['props']>['loginButton']
-
-function HeaderLoginButton({ data }: { data: LoginButton }) {
-  const Tag: any = data.href ? 'a' : 'button'
-  const base = [
-    'absolute right-3 top-1/2 -translate-y-1/2',
-    'min-w-[88px] h-8 px-3 rounded-lg flex items-center justify-center',
-    'text-[12px] z-10 cursor-pointer',
-  ].join(' ')
-  const variant =
-    data.variant === 'outline'
-      ? 'bg-transparent border border-[#94a3b8] text-[#e5e7eb] hover:bg-white/10'
-      : 'bg-[#0ea5e9] text-[#0b1220] hover:bg-[#0ea5e9]/90'
-  const tagProps = data.href ? { href: data.href } : {}
-  return (
-    <Tag
-      {...tagProps}
-      className={`${base} ${variant}`}
-      onPointerDown={(e) => e.stopPropagation()}
-    >
-      {data.label}
-    </Tag>
-  )
 }
 
 class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
@@ -283,14 +259,7 @@ function ElmView({ elm }: { elm: Elm }) {
       className={`${common} ${border} ${shadow} cursor-move ${isDragging ? 'opacity-60' : ''}`}
       style={baseStyle}
     >
-      {elm.type === 'header' && (
-        <>
-          <div className="h-full flex items-center px-3">Header</div>
-          {elm.props?.loginButton?.enabled && (
-            <HeaderLoginButton data={elm.props.loginButton} />
-          )}
-        </>
-      )}
+      {elm.type === 'header' && <HeaderView elm={elm} />}
       {elm.type === 'footer' && <div className="h-full flex items-center justify-center px-3">Footer</div>}
       {elm.type === 'sidebar' && <div className="h-full flex items-start px-3 py-2">Sidebar</div>}
       {elm.type === 'hud' && <div className="h-full flex items-center justify-center px-3">HUD</div>}

--- a/web/components/builder/Inspector.tsx
+++ b/web/components/builder/Inspector.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { useBuilderStore } from '@/store/builderStore'
 import { loadDocgenMeta, parseValue, type DocgenProp } from '@/lib/builder/docgen'
+import { HeaderInspector } from './header/HeaderInspector'
 
 export function Inspector() {
   const selId = useBuilderStore((s) => s.selectedId)
@@ -180,89 +181,7 @@ export function Inspector() {
         </>
       )}
 
-      {elm.type === 'header' && (
-        <>
-          <div className="text-sm font-medium">Login Button</div>
-          <div className="space-y-2 text-xs">
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={elm.props?.loginButton?.enabled ?? false}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    const cur = elm.props?.loginButton
-                    updateProps(elm.id, {
-                      loginButton: {
-                        enabled: true,
-                        label: cur?.label ?? 'Log in',
-                        variant: cur?.variant ?? 'solid',
-                        href: cur?.href,
-                      },
-                    })
-                  } else {
-                    updateProps(elm.id, {
-                      loginButton: { ...(elm.props?.loginButton ?? {}), enabled: false },
-                    })
-                  }
-                }}
-              />
-              Enable
-            </label>
-            {elm.props?.loginButton?.enabled && (
-              <>
-                <label className="flex flex-col gap-1">
-                  Label
-                  <input
-                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
-                    value={elm.props?.loginButton?.label ?? ''}
-                    onChange={(e) =>
-                      updateProps(elm.id, {
-                        loginButton: { ...(elm.props?.loginButton ?? {}), label: e.target.value },
-                      })
-                    }
-                    type="text"
-                  />
-                </label>
-                <label className="flex flex-col gap-1">
-                  Variant
-                  <select
-                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
-                    value={elm.props?.loginButton?.variant ?? 'solid'}
-                    onChange={(e) =>
-                      updateProps(elm.id, {
-                        loginButton: {
-                          ...(elm.props?.loginButton ?? {}),
-                          variant: e.target.value as 'solid' | 'outline',
-                        },
-                      })
-                    }
-                  >
-                    <option value="solid">solid</option>
-                    <option value="outline">outline</option>
-                  </select>
-                </label>
-                <label className="flex flex-col gap-1">
-                  Link
-                  <input
-                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
-                    value={elm.props?.loginButton?.href ?? ''}
-                    onChange={(e) =>
-                      updateProps(elm.id, {
-                        loginButton: {
-                          ...(elm.props?.loginButton ?? {}),
-                          href: e.target.value || undefined,
-                        },
-                      })
-                    }
-                    type="text"
-                    placeholder="/login"
-                  />
-                </label>
-              </>
-            )}
-          </div>
-        </>
-      )}
+      {elm.type === 'header' && <HeaderInspector elm={elm} />}
 
       <div className="flex gap-2">
         <button

--- a/web/components/builder/header/HeaderInspector.tsx
+++ b/web/components/builder/header/HeaderInspector.tsx
@@ -1,0 +1,94 @@
+'use client'
+import React from 'react'
+import { useBuilderStore, type Elm } from '@/store/builderStore'
+
+export function HeaderInspector({ elm }: { elm: Elm }) {
+  const updateProps = useBuilderStore((s) => s.updateProps)
+  return (
+    <>
+      <div className="text-sm font-medium">Login Button</div>
+      <div className="space-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={elm.props?.loginButton?.enabled ?? false}
+            onChange={(e) => {
+              if (e.target.checked) {
+                const cur = elm.props?.loginButton
+                updateProps(elm.id, {
+                  loginButton: {
+                    enabled: true,
+                    label: cur?.label ?? 'Log in',
+                    variant: cur?.variant ?? 'solid',
+                    href: cur?.href,
+                  },
+                })
+              } else {
+                updateProps(elm.id, {
+                  loginButton: { ...(elm.props?.loginButton ?? {}), enabled: false },
+                })
+              }
+            }}
+          />
+          Enable
+        </label>
+        {elm.props?.loginButton?.enabled && (
+          <>
+            <label className="flex flex-col gap-1">
+              Label
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.loginButton?.label ?? ''}
+                onChange={(e) =>
+                  updateProps(elm.id, {
+                    loginButton: {
+                      ...(elm.props?.loginButton ?? {}),
+                      label: e.target.value,
+                    },
+                  })
+                }
+                type="text"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              Variant
+              <select
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.loginButton?.variant ?? 'solid'}
+                onChange={(e) =>
+                  updateProps(elm.id, {
+                    loginButton: {
+                      ...(elm.props?.loginButton ?? {}),
+                      variant: e.target.value as 'solid' | 'outline',
+                    },
+                  })
+                }
+              >
+                <option value="solid">solid</option>
+                <option value="outline">outline</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              Link
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.loginButton?.href ?? ''}
+                onChange={(e) =>
+                  updateProps(elm.id, {
+                    loginButton: {
+                      ...(elm.props?.loginButton ?? {}),
+                      href: e.target.value || undefined,
+                    },
+                  })
+                }
+                type="text"
+                placeholder="/login"
+              />
+            </label>
+          </>
+        )}
+      </div>
+    </>
+  )
+}
+

--- a/web/components/builder/header/HeaderView.tsx
+++ b/web/components/builder/header/HeaderView.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React from 'react'
+import type { Elm } from '@/store/builderStore'
+
+type LoginButton = NonNullable<Elm['props']>['loginButton']
+
+function HeaderLoginButton({ data }: { data: LoginButton }) {
+  const Tag: any = data.href ? 'a' : 'button'
+  const base = [
+    'absolute right-3 top-1/2 -translate-y-1/2',
+    'min-w-[88px] h-8 px-3 rounded-lg flex items-center justify-center',
+    'text-[12px] z-10 cursor-pointer',
+  ].join(' ')
+  const variant =
+    data.variant === 'outline'
+      ? 'bg-transparent border border-[#94a3b8] text-[#e5e7eb] hover:bg-white/10'
+      : 'bg-[#0ea5e9] text-[#0b1220] hover:bg-[#0ea5e9]/90'
+  const tagProps = data.href ? { href: data.href } : {}
+  return (
+    <Tag
+      {...tagProps}
+      className={`${base} ${variant}`}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {data.label}
+    </Tag>
+  )
+}
+
+export function HeaderView({ elm }: { elm: Elm }) {
+  return (
+    <>
+      <div className="h-full flex items-center px-3">Header</div>
+      {elm.props?.loginButton?.enabled && (
+        <HeaderLoginButton data={elm.props.loginButton} />
+      )}
+    </>
+  )
+}
+


### PR DESCRIPTION
## Summary
- extract header rendering into `HeaderView`
- move header inspector controls into `HeaderInspector`
- delegate header branches in canvas and inspector to the new modules

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*
- `pnpm -C web build` *(fails: Cannot find module '@domain-components')*


------
https://chatgpt.com/codex/tasks/task_e_68ad4963e3d8832cbc8d1552591c1b01