### PR TITLE
feat: add sign up cta

### DIFF
--- a/web/components/builder/header/HeaderInspector.tsx
+++ b/web/components/builder/header/HeaderInspector.tsx
@@ -4,9 +4,103 @@ import { useBuilderStore, type Elm } from '@/store/builderStore'
 
 export function HeaderInspector({ elm }: { elm: Elm }) {
   const updateProps = useBuilderStore((s) => s.updateProps)
+  const props = elm.props as any
   return (
     <>
-      <div className="text-sm font-medium">Login Button</div>
+      <div className="text-sm font-medium">Sign Up Button</div>
+      <div className="space-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={props?.cta?.enabled ?? false}
+            onChange={(e) => {
+              if (e.target.checked) {
+                const cur = props?.cta
+                updateProps(
+                  elm.id,
+                  {
+                    cta: {
+                      enabled: true,
+                      label: cur?.label ?? 'Sign up',
+                      variant: cur?.variant ?? 'solid',
+                      href: cur?.href,
+                    },
+                  } as any,
+                )
+              } else {
+                updateProps(
+                  elm.id,
+                  { cta: { ...(props?.cta ?? {}), enabled: false } } as any,
+                )
+              }
+            }}
+          />
+          Enable
+        </label>
+        {props?.cta?.enabled && (
+          <>
+            <label className="flex flex-col gap-1">
+              Label
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={props?.cta?.label ?? ''}
+                onChange={(e) =>
+                  updateProps(
+                    elm.id,
+                    {
+                      cta: { ...(props?.cta ?? {}), label: e.target.value },
+                    } as any,
+                  )
+                }
+                type="text"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              Variant
+              <select
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={props?.cta?.variant ?? 'solid'}
+                onChange={(e) =>
+                  updateProps(
+                    elm.id,
+                    {
+                      cta: {
+                        ...(props?.cta ?? {}),
+                        variant: e.target.value as 'solid' | 'outline',
+                      },
+                    } as any,
+                  )
+                }
+              >
+                <option value="solid">solid</option>
+                <option value="outline">outline</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              Link
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={props?.cta?.href ?? ''}
+                onChange={(e) =>
+                  updateProps(
+                    elm.id,
+                    {
+                      cta: {
+                        ...(props?.cta ?? {}),
+                        href: e.target.value || undefined,
+                      },
+                    } as any,
+                  )
+                }
+                type="text"
+                placeholder="/signup"
+              />
+            </label>
+          </>
+        )}
+      </div>
+
+      <div className="text-sm font-medium mt-4">Login Button</div>
       <div className="space-y-2 text-xs">
         <label className="flex items-center gap-2">
           <input

--- a/web/components/builder/header/HeaderView.tsx
+++ b/web/components/builder/header/HeaderView.tsx
@@ -2,12 +2,11 @@
 import React from 'react'
 import type { Elm } from '@/store/builderStore'
 
-type LoginButton = NonNullable<Elm['props']>['loginButton']
+type ButtonProps = NonNullable<Elm['props']>['loginButton']
 
-function HeaderLoginButton({ data }: { data: LoginButton }) {
+function HeaderButton({ data }: { data: ButtonProps }) {
   const Tag: any = data.href ? 'a' : 'button'
   const base = [
-    'absolute right-3 top-1/2 -translate-y-1/2',
     'min-w-[88px] h-8 px-3 rounded-lg flex items-center justify-center',
     'text-[12px] z-10 cursor-pointer',
   ].join(' ')
@@ -28,12 +27,16 @@ function HeaderLoginButton({ data }: { data: LoginButton }) {
 }
 
 export function HeaderView({ elm }: { elm: Elm }) {
+  const props = elm.props as any
   return (
     <>
       <div className="h-full flex items-center px-3">Header</div>
-      {elm.props?.loginButton?.enabled && (
-        <HeaderLoginButton data={elm.props.loginButton} />
-      )}
+      <div className="absolute right-3 top-1/2 -translate-y-1/2 flex gap-2">
+        {props?.cta?.enabled && <HeaderButton data={props.cta} />}
+        {elm.props?.loginButton?.enabled && (
+          <HeaderButton data={elm.props.loginButton} />
+        )}
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add configurable sign up CTA next to login button
- expose inspector controls for sign up button settings

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4c822cd0832cb9a67d908688a3d1