### PR TITLE
feat(header): add configurable logo

### DIFF
--- a/web/components/builder/header/HeaderInspector.tsx
+++ b/web/components/builder/header/HeaderInspector.tsx
@@ -4,8 +4,117 @@ import { useBuilderStore, type Elm } from '@/store/builderStore'
 
 export function HeaderInspector({ elm }: { elm: Elm }) {
   const updateProps = useBuilderStore((s) => s.updateProps)
+  const logo = (elm.props as any)?.logo as
+    | {
+        kind: 'text' | 'image'
+        text?: string
+        src?: string
+        w?: number
+        h?: number
+      }
+    | undefined
   return (
     <>
+      <div className="text-sm font-medium">Logo</div>
+      <div className="space-y-2 text-xs mb-4">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={!!logo}
+            onChange={(e) => {
+              if (e.target.checked) {
+                updateProps(elm.id, {
+                  logo: { kind: 'text', text: 'Logo' },
+                } as any)
+              } else {
+                updateProps(elm.id, { logo: undefined } as any)
+              }
+            }}
+          />
+          Enable
+        </label>
+        {logo && (
+          <>
+            <label className="flex flex-col gap-1">
+              Kind
+              <select
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={logo.kind}
+                onChange={(e) =>
+                  updateProps(elm.id, {
+                    logo: { ...(logo ?? {}), kind: e.target.value as 'text' | 'image' },
+                  } as any)
+                }
+              >
+                <option value="text">text</option>
+                <option value="image">image</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              Text
+              <input
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={logo.text ?? ''}
+                onChange={(e) =>
+                  updateProps(elm.id, {
+                    logo: { ...(logo ?? {}), text: e.target.value },
+                  } as any)
+                }
+                type="text"
+              />
+            </label>
+            {logo.kind === 'image' && (
+              <>
+                <label className="flex flex-col gap-1">
+                  Src
+                  <input
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={logo.src ?? ''}
+                    onChange={(e) =>
+                      updateProps(elm.id, {
+                        logo: { ...(logo ?? {}), src: e.target.value },
+                      } as any)
+                    }
+                    type="text"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  Width
+                  <input
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={logo.w ?? ''}
+                    onChange={(e) =>
+                      updateProps(elm.id, {
+                        logo: {
+                          ...(logo ?? {}),
+                          w: e.target.value ? Number(e.target.value) : undefined,
+                        },
+                      } as any)
+                    }
+                    type="number"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  Height
+                  <input
+                    className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                    value={logo.h ?? ''}
+                    onChange={(e) =>
+                      updateProps(elm.id, {
+                        logo: {
+                          ...(logo ?? {}),
+                          h: e.target.value ? Number(e.target.value) : undefined,
+                        },
+                      } as any)
+                    }
+                    type="number"
+                  />
+                </label>
+              </>
+            )}
+          </>
+        )}
+      </div>
       <div className="text-sm font-medium">Login Button</div>
       <div className="space-y-2 text-xs">
         <label className="flex items-center gap-2">

--- a/web/components/builder/header/HeaderView.tsx
+++ b/web/components/builder/header/HeaderView.tsx
@@ -3,11 +3,17 @@ import React from 'react'
 import type { Elm } from '@/store/builderStore'
 
 type LoginButton = NonNullable<Elm['props']>['loginButton']
+type Logo = {
+  kind: 'text' | 'image'
+  text?: string
+  src?: string
+  w?: number
+  h?: number
+}
 
 function HeaderLoginButton({ data }: { data: LoginButton }) {
   const Tag: any = data.href ? 'a' : 'button'
   const base = [
-    'absolute right-3 top-1/2 -translate-y-1/2',
     'min-w-[88px] h-8 px-3 rounded-lg flex items-center justify-center',
     'text-[12px] z-10 cursor-pointer',
   ].join(' ')
@@ -28,13 +34,45 @@ function HeaderLoginButton({ data }: { data: LoginButton }) {
 }
 
 export function HeaderView({ elm }: { elm: Elm }) {
+  const logo = (elm.props as any)?.logo as Logo | undefined
+  const [imgErr, setImgErr] = React.useState(false)
+  React.useEffect(() => {
+    setImgErr(false)
+  }, [logo?.src])
+
+  let logoEl: React.ReactNode = null
+  if (logo) {
+    const size = { width: logo.w, height: logo.h }
+    if (logo.kind === 'image' && logo.src && !imgErr) {
+      const alt = logo.text || elm.code?.displayName || ''
+      logoEl = (
+        <img
+          src={logo.src}
+          alt={alt}
+          style={size}
+          onError={() => setImgErr(true)}
+          className="object-contain"
+        />
+      )
+    } else {
+      logoEl = (
+        <div style={size} className="flex items-center">
+          {logo.text ?? ''}
+        </div>
+      )
+    }
+  }
+
   return (
-    <>
-      <div className="h-full flex items-center px-3">Header</div>
+    <div className="h-full w-full flex items-center px-3">
+      {logoEl && <div className="mr-3 flex items-center">{logoEl}</div>}
+      <div className="flex-1 h-full flex items-center">
+        {elm.props?.text ?? 'Header'}
+      </div>
       {elm.props?.loginButton?.enabled && (
         <HeaderLoginButton data={elm.props.loginButton} />
       )}
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- allow headers to render optional text or image logo with fallback
- add inspector controls for logo type, text, src, and size

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4c611644832ca1154087543f1e5f