### PR TITLE
feat: add sticky header options

### DIFF
--- a/web/components/builder/header/HeaderInspector.tsx
+++ b/web/components/builder/header/HeaderInspector.tsx
@@ -6,9 +6,13 @@ type NavItem = { id: string; label: string; href?: string; active?: boolean }
 
 export function HeaderInspector({ elm }: { elm: Elm }) {
   const updateProps = useBuilderStore((s) => s.updateProps)
+  const props = elm.props as any
+  const sticky: boolean = props?.sticky ?? false
+  const shadowOnScroll: boolean = props?.shadowOnScroll ?? false
+  const shadowPreview: boolean = props?.shadowPreview ?? false
 
   // ---- Logo ----
-  const logo = (elm.props as any)?.logo as
+  const logo = props?.logo as
     | {
         kind: 'text' | 'image'
         text?: string
@@ -19,7 +23,7 @@ export function HeaderInspector({ elm }: { elm: Elm }) {
     | undefined
 
   // ---- Navigation ----
-  const navItems: NavItem[] | undefined = (elm.props as any)?.navItems
+  const navItems: NavItem[] | undefined = props?.navItems
   const setNavItems = (items: NavItem[]) =>
     updateProps(elm.id, { navItems: items } as any)
 
@@ -49,13 +53,48 @@ export function HeaderInspector({ elm }: { elm: Elm }) {
   }
 
   // ---- CTA / Login / Search ----
-  const props = elm.props as any
   const search = props?.search as
     | { enabled: boolean; placeholder?: string; width?: number }
     | undefined
 
   return (
     <>
+      {/* Behavior */}
+      <div className="text-sm font-medium">Behavior</div>
+      <div className="space-y-2 text-xs mb-4">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={sticky}
+            onChange={(e) =>
+              updateProps(elm.id, { sticky: e.target.checked } as any)
+            }
+          />
+          Sticky
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={shadowOnScroll}
+            onChange={(e) =>
+              updateProps(elm.id, { shadowOnScroll: e.target.checked } as any)
+            }
+          />
+          Shadow on scroll
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={shadowPreview}
+            disabled={!shadowOnScroll}
+            onChange={(e) =>
+              updateProps(elm.id, { shadowPreview: e.target.checked } as any)
+            }
+          />
+          Preview shadow
+        </label>
+      </div>
+
       {/* Logo */}
       <div className="text-sm font-medium">Logo</div>
       <div className="space-y-2 text-xs mb-4">

--- a/web/components/builder/header/HeaderView.tsx
+++ b/web/components/builder/header/HeaderView.tsx
@@ -56,6 +56,12 @@ export function HeaderView({ elm }: { elm: Elm }) {
   const navItems: NavItem[] | undefined = props?.navItems
   const logo = props?.logo as Logo | undefined
   const search = props?.search as SearchProps | undefined
+  const sticky: boolean | undefined = props?.sticky
+  const shadowOnScroll: boolean | undefined = props?.shadowOnScroll
+  const shadowPreview: boolean | undefined = props?.shadowPreview
+
+  const shadowCls = shadowOnScroll && shadowPreview ? 'shadow-md' : 'shadow-none'
+  const stickyCls = sticky ? 'sticky top-0 z-10' : ''
 
   // --- Logo handling ---
   const [imgErr, setImgErr] = React.useState(false)
@@ -87,7 +93,10 @@ export function HeaderView({ elm }: { elm: Elm }) {
   }
 
   return (
-    <div className="h-full w-full flex items-center px-3 relative">
+    <div
+      className={`h-full w-full flex items-center px-3 relative ${shadowCls} ${stickyCls}`}
+      style={sticky ? { position: 'sticky', top: 0, zIndex: 10 } : undefined}
+    >
       {/* 左: Logo */}
       {logoEl && <div className="mr-3 flex items-center">{logoEl}</div>}
 


### PR DESCRIPTION
## Summary
- support sticky positioning for headers
- add shadow-on-scroll with preview toggle

## Testing
- `pnpm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a0c6c8c832c93322182adfcb4dc