### PR TITLE
Add builder HUD with zoom and device controls

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -16,6 +16,9 @@ import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
 import { PagesPanel } from '@/components/builder/PagesPanel'
 import { usePageStore } from '@/store/pageStore'
+import { DeviceFrame } from '@/components/hud/DeviceFrame'
+import { GridOverlay } from '@/components/hud/GridOverlay'
+import { BuilderHUD } from '@/components/hud/BuilderHUD'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -177,7 +180,13 @@ export default function BuilderPage() {
           <Palette />
         </aside>
         <main className="flex-1 relative">
-          <Canvas canvasRef={canvasRef} />
+          <DeviceFrame>
+            <div className="relative w-full h-full">
+              <Canvas canvasRef={canvasRef} />
+              <GridOverlay />
+            </div>
+          </DeviceFrame>
+          <BuilderHUD />
         </main>
         <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3 flex flex-col">
           <h2 className="text-sm font-semibold mb-2">プロパティ</h2>

--- a/web/components/hud/BuilderHUD.tsx
+++ b/web/components/hud/BuilderHUD.tsx
@@ -1,0 +1,89 @@
+'use client'
+import React from 'react'
+import { useHudStore, type DeviceKind } from '@/store/hudStore'
+
+function IconBtn(props: React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean }) {
+  const { active, className, ...rest } = props
+  return (
+    <button
+      {...rest}
+      className={[
+        'h-8 px-2 rounded-md border text-xs',
+        active ? 'border-zinc-300 bg-white/10' : 'border-zinc-800 bg-zinc-900 hover:bg-white/5',
+        'text-zinc-200',
+        className ?? '',
+      ].join(' ')}
+    />
+  )
+}
+
+export function BuilderHUD() {
+  const {
+    zoom,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    device,
+    setDevice,
+    showGrid,
+    toggleGrid,
+    showOutline,
+    toggleOutline,
+    showRulers,
+    toggleRulers,
+    snapToPixel,
+    toggleSnap,
+  } = useHudStore()
+
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const meta = e.ctrlKey || e.metaKey
+      if (meta && (e.key === '=' || e.key === '+')) {
+        e.preventDefault()
+        zoomIn()
+      } else if (meta && e.key === '-') {
+        e.preventDefault()
+        zoomOut()
+      } else if (meta && e.key === '0') {
+        e.preventDefault()
+        resetZoom()
+      } else if (!meta && (e.key === 'g' || e.key === 'G')) {
+        toggleGrid()
+      } else if (!meta && (e.key === 'r' || e.key === 'R')) {
+        toggleRulers()
+      } else if (!meta && (e.key === 'o' || e.key === 'O')) {
+        toggleOutline()
+      } else if (!meta && (e.key === 'p' || e.key === 'P')) {
+        toggleSnap()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [zoomIn, zoomOut, resetZoom, toggleGrid, toggleRulers, toggleOutline, toggleSnap])
+
+  const DeviceBtn = ({ d, label }: { d: DeviceKind; label: string }) => (
+    <IconBtn active={device === d} onClick={() => setDevice(d)}>{label}</IconBtn>
+  )
+
+  return (
+    <>
+      <div className="pointer-events-auto fixed left-1/2 top-2 -translate-x-1/2 z-50 flex items-center gap-1">
+        <IconBtn onClick={zoomOut}>−</IconBtn>
+        <span className="px-2 text-xs text-zinc-300 tabular-nums">{Math.round(zoom * 100)}%</span>
+        <IconBtn onClick={zoomIn}>＋</IconBtn>
+        <IconBtn onClick={resetZoom}>100%</IconBtn>
+      </div>
+      <div className="pointer-events-auto fixed right-2 top-2 z-50 flex items-center gap-1">
+        <IconBtn active={showGrid} onClick={toggleGrid} title="Grid (G)">Grid</IconBtn>
+        <IconBtn active={showRulers} onClick={toggleRulers} title="Rulers (R)">Rul</IconBtn>
+        <IconBtn active={showOutline} onClick={toggleOutline} title="Outline (O)">Out</IconBtn>
+        <IconBtn active={snapToPixel} onClick={toggleSnap} title="Snap (P)">Snap</IconBtn>
+        <div className="mx-1 w-px h-6 bg-zinc-800" />
+        <DeviceBtn d="free" label="Free" />
+        <DeviceBtn d="desktop" label="Desktop" />
+        <DeviceBtn d="tablet" label="Tablet" />
+        <DeviceBtn d="mobile" label="Mobile" />
+      </div>
+    </>
+  )
+}

--- a/web/components/hud/DeviceFrame.tsx
+++ b/web/components/hud/DeviceFrame.tsx
@@ -1,0 +1,24 @@
+'use client'
+import React from 'react'
+import { useHudStore } from '@/store/hudStore'
+
+const widths: Record<string, number> = {
+  desktop: 1280,
+  tablet: 768,
+  mobile: 390,
+}
+
+export function DeviceFrame({ children }: { children: React.ReactNode }) {
+  const device = useHudStore((s) => s.device)
+
+  if (device === 'free') return <>{children}</>
+
+  const w = widths[device] ?? undefined
+  return (
+    <div className="w-full h-full flex justify-center">
+      <div className="relative h-full" style={{ width: w }}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/web/components/hud/GridOverlay.tsx
+++ b/web/components/hud/GridOverlay.tsx
@@ -1,0 +1,25 @@
+'use client'
+import React from 'react'
+import { useHudStore } from '@/store/hudStore'
+
+export function GridOverlay() {
+  const show = useHudStore((s) => s.showGrid)
+  const zoom = useHudStore((s) => s.zoom)
+  if (!show) return null
+
+  const base = 8 * zoom
+  const fine = Math.max(1, base)
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-40"
+      style={{
+        backgroundImage: `
+          linear-gradient(0deg, rgba(148,163,184,0.12) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(148,163,184,0.12) 1px, transparent 1px)
+        `,
+        backgroundSize: `${fine}px ${fine}px`,
+      }}
+    />
+  )
+}

--- a/web/store/hudStore.ts
+++ b/web/store/hudStore.ts
@@ -1,0 +1,71 @@
+'use client'
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+export type DeviceKind = 'free' | 'desktop' | 'tablet' | 'mobile'
+
+type HudState = {
+  zoom: number
+  minZoom: number
+  maxZoom: number
+  showGrid: boolean
+  showRulers: boolean
+  showOutline: boolean
+  snapToPixel: boolean
+  device: DeviceKind
+  setZoom: (z: number) => void
+  zoomIn: () => void
+  zoomOut: () => void
+  resetZoom: () => void
+  setDevice: (d: DeviceKind) => void
+  toggleGrid: () => void
+  toggleRulers: () => void
+  toggleOutline: () => void
+  toggleSnap: () => void
+}
+
+export const useHudStore = create<HudState>()(
+  persist(
+    (set, get) => ({
+      zoom: 1,
+      minZoom: 0.25,
+      maxZoom: 2,
+      showGrid: false,
+      showRulers: false,
+      showOutline: false,
+      snapToPixel: true,
+      device: 'free',
+      setZoom: (z) => {
+        const { minZoom, maxZoom } = get()
+        const clamped = Math.min(maxZoom, Math.max(minZoom, z))
+        set({ zoom: Number(clamped.toFixed(2)) })
+      },
+      zoomIn: () => {
+        const { zoom, setZoom } = get()
+        setZoom(zoom * 1.2)
+      },
+      zoomOut: () => {
+        const { zoom, setZoom } = get()
+        setZoom(zoom / 1.2)
+      },
+      resetZoom: () => set({ zoom: 1 }),
+      setDevice: (d) => set({ device: d }),
+      toggleGrid: () => set((s) => ({ showGrid: !s.showGrid })),
+      toggleRulers: () => set((s) => ({ showRulers: !s.showRulers })),
+      toggleOutline: () => set((s) => ({ showOutline: !s.showOutline })),
+      toggleSnap: () => set((s) => ({ snapToPixel: !s.snapToPixel })),
+    }),
+    {
+      name: 'ui-hud',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({
+        zoom: s.zoom,
+        showGrid: s.showGrid,
+        showRulers: s.showRulers,
+        showOutline: s.showOutline,
+        snapToPixel: s.snapToPixel,
+        device: s.device,
+      }),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- add global HUD store for zoom, layout toggles, and device preview
- overlay builder HUD with keyboard shortcuts and device buttons
- wrap builder canvas with device frame and optional grid overlay

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad823f67d8832ca9f917737e09f16f