### PR TITLE
feat: add builder HUD overlays

### DIFF
--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -9,6 +9,9 @@ import { useState, useEffect } from 'react';
 import { getCommand } from '@/lib/keymap';
 import { COMMANDS, runCommand } from '@/lib/commands';
 import { useEditorStore } from '@/store/editorStore';
+import { DeviceFrame } from '@/components/hud/DeviceFrame';
+import { GridOverlay } from '@/components/hud/GridOverlay';
+import { BuilderHUD } from '@/components/hud/BuilderHUD';
 
 export default function EditorShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -60,15 +63,23 @@ export default function EditorShell() {
   }, []);
 
   return (
-    <div className="grid grid-cols-[280px_1fr_320px] h-screen text-white">
-      <LeftPanel />
-      <div className="relative">
-        <div className="absolute top-2 right-2 z-10"><ShareButton /></div>
-        <CanvasStage />
+    <>
+      <div className="grid grid-cols-[280px_1fr_320px] h-screen text-white">
+        <LeftPanel />
+        <div className="relative h-full bg-[#0b1220]">
+          <div className="absolute top-2 right-2 z-10"><ShareButton /></div>
+          <DeviceFrame>
+            <div className="relative w-full h-full">
+              <CanvasStage />
+              <GridOverlay />
+            </div>
+          </DeviceFrame>
+        </div>
+        <RightPane />
       </div>
-      <RightPane />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <ContextMenu />
-    </div>
+      <BuilderHUD />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- inject global HUD controls into editor shell
- wrap canvas with device frame and grid overlay for preview

## Testing
- `pnpm test` *(fails: Jest worker encountered 4 child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68ad840994f0832cbed5d928cd6b76f6