### PR TITLE
feat: add guides store and ruler components

### DIFF
--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -7,9 +7,10 @@ import Viewport from './canvas/Viewport'
 import HUDContainer from './hud/HUDContainer'
 import { ViewportProvider } from './canvas/ViewportStore'
 import GridOverlay from './canvas/GridOverlay'
-import Rulers from './canvas/Rulers'
+import { Rulers } from './Rulers'
 import { RectsProvider, useRects } from './canvas/RectsStore'
 import SmartGuidesOverlay from './canvas/SmartGuidesOverlay'
+import { GuidesOverlay } from './overlays/GuidesOverlay'
 import type { Guide } from './canvas/snap'
 
 function NodeRenderer({ node }: { node: ComponentNode }) {
@@ -62,9 +63,10 @@ export default function Canvas() {
             </div>
           </Viewport>
           <GridOverlay />
-          <Rulers />
+          <Rulers width={2000} height={2000} />
           <HUDContainer />
           <SmartGuidesOverlay guides={guides} />
+          <GuidesOverlay width={2000} height={2000} />
         </div>
       </RectsProvider>
     </ViewportProvider>

--- a/web/components/Rulers.tsx
+++ b/web/components/Rulers.tsx
@@ -1,0 +1,92 @@
+'use client'
+import React from 'react'
+import { useGuidesStore } from '@/store/guidesStore'
+
+export function Rulers({ width, height }: { width: number; height: number }) {
+  const { unit, setUnit, baseRemPx } = useGuidesStore((s) => ({
+    unit: s.unit,
+    setUnit: s.setUnit,
+    baseRemPx: s.baseRemPx,
+  }))
+
+  const ticksX = getTicks(width, unit, baseRemPx)
+  const ticksY = getTicks(height, unit, baseRemPx)
+
+  return (
+    <div className="absolute top-0 left-0 select-none">
+      {/* 水平ルーラー */}
+      <div className="relative h-6 w-full bg-neutral-900/70 text-neutral-200">
+        <select
+          className="absolute left-1 top-1 h-4 text-[10px] bg-neutral-800 rounded px-1"
+          value={unit}
+          onChange={(e) => setUnit(e.target.value as any)}
+          title="unit"
+        >
+          <option value="px">px</option>
+          <option value="%">%</option>
+          <option value="rem">rem</option>
+        </select>
+        <svg className="absolute left-0 top-0" width={width} height={24}>
+          {ticksX.map((t) => (
+            <g key={t.px}>
+              <line x1={t.px} y1={0} x2={t.px} y2={t.long ? 16 : 10} stroke="rgba(255,255,255,.5)" />
+              {t.label != null && (
+                <text x={t.px + 2} y={20} fontSize={10} fill="white">{t.label}</text>
+              )}
+            </g>
+          ))}
+        </svg>
+      </div>
+
+      {/* 垂直ルーラー */}
+      <div className="absolute top-0 left-0 w-6 h-full bg-neutral-900/70 text-neutral-200">
+        <svg className="absolute left-0 top-0" width={24} height={height}>
+          {ticksY.map((t) => (
+            <g key={t.px}>
+              <line x1={0} y1={t.px} x2={t.long ? 16 : 10} y2={t.px} stroke="rgba(255,255,255,.5)" />
+              {t.label != null && (
+                <text x={2} y={t.px - 2} fontSize={10} fill="white" transform={`rotate(-90, 8, ${t.px - 2})`}>
+                  {t.label}
+                </text>
+              )}
+            </g>
+          ))}
+        </svg>
+      </div>
+    </div>
+  )
+}
+
+function getTicks(lenPx: number, unit: 'px'|'%'|'rem', baseRemPx: number) {
+  const ticks: { px: number; long: boolean; label?: string|number }[] = []
+
+  if (unit === 'px') {
+    // ズームに合わせた刻み幅にしたければ外から渡して調整
+    const step = pickStepPx(lenPx)
+    for (let x = 0; x <= lenPx; x += step/5) {
+      const isLong = Math.round(x * 5) % step === 0
+      ticks.push({ px: x, long: isLong, label: isLong ? Math.round(x) : undefined })
+    }
+  } else if (unit === '%') {
+    for (let p = 0; p <= 100; p += 1) {
+      const x = (p / 100) * lenPx
+      const isLong = p % 10 === 0
+      ticks.push({ px: x, long: isLong, label: isLong ? p : undefined })
+    }
+  } else { // rem
+    const stepRem = 1
+    const stepPx = baseRemPx * stepRem
+    for (let r = 0, x = 0; x <= lenPx; r += stepRem, x += stepPx) {
+      const isLong = r % 5 === 0
+      ticks.push({ px: x, long: isLong, label: isLong ? r : undefined })
+    }
+  }
+
+  return ticks
+}
+
+function pickStepPx(lenPx: number) {
+  if (lenPx <= 800) return 100
+  if (lenPx <= 1600) return 200
+  return 400
+}

--- a/web/components/overlays/GuidesOverlay.tsx
+++ b/web/components/overlays/GuidesOverlay.tsx
@@ -1,0 +1,38 @@
+'use client'
+import React, { memo } from 'react'
+import { useGuidesStore } from '@/store/guidesStore'
+
+/** 画面→SVG変換など既存の座標系があればそれを使用。
+ * ここではシンプルにワールド(px)＝SVG座標として描く例。
+ */
+export const GuidesOverlay = memo(function GuidesOverlay({
+  width,
+  height,
+  active = [],
+}: {
+  width: number
+  height: number
+  active?: { axis: 'x'|'y'; at: number }[]
+}) {
+  const { guides, visible } = useGuidesStore((s) => ({ guides: s.guides, visible: s.visible }))
+  if (!visible) return null
+
+  const activeKey = (g: {axis:'x'|'y'; at:number}) => `${g.axis}:${Math.round(g.at)}`
+
+  const activeMap = new Set(active.map(activeKey))
+  return (
+    <svg className="pointer-events-none absolute inset-0" width={width} height={height}>
+      {guides.map((g) => {
+        const key = `${g.axis}:${Math.round(g.pos)}`
+        const isActive = activeMap.has(key)
+        const stroke = isActive ? 'rgba(32,148,243,1)' : 'rgba(32,148,243,.5)'
+        const dash = isActive ? '0' : '6,6'
+        return g.axis === 'x' ? (
+          <line key={key} x1={g.pos} y1={0} x2={g.pos} y2={height} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+        ) : (
+          <line key={key} x1={0} y1={g.pos} x2={width} y2={g.pos} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+        )
+      })}
+    </svg>
+  )
+})

--- a/web/hooks/useSnapToGuides.ts
+++ b/web/hooks/useSnapToGuides.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+import { useGuidesStore } from '@/store/guidesStore'
+
+export type Rect = { x: number; y: number; w: number; h: number }
+export type SnapResult = {
+  rect: Rect
+  snapped: boolean
+  active: { axis: 'x'|'y'; at: number }[]
+}
+
+/**
+ * @param draftRect 操作中の矩形（ワールドpx）
+ * @param mode 'move' | 'resize'
+ * @param zoom 現在のズーム。画面px→ワールドpx換算に使用
+ * @returns スナップ適用後のRect/アクティブガイド
+ */
+export const useSnapToGuides = (
+  draftRect: Rect,
+  mode: 'move' | 'resize',
+  zoom: number
+): SnapResult => {
+  const { guides, visible, snapPx } = useGuidesStore((s) => ({
+    guides: s.guides,
+    visible: s.visible,
+    snapPx: s.snapPx,
+  }))
+  const thresholdWorld = snapPx / Math.max(zoom, 0.01)
+
+  return useMemo(() => {
+    if (!visible || guides.length === 0) {
+      return { rect: draftRect, snapped: false, active: [] }
+    }
+
+    const candidatesX = [draftRect.x, draftRect.x + draftRect.w / 2, draftRect.x + draftRect.w]
+    const candidatesY = [draftRect.y, draftRect.y + draftRect.h / 2, draftRect.y + draftRect.h]
+
+    let dx = 0, dy = 0
+    let ax: { axis:'x'|'y'; at:number } | null = null
+    let ay: { axis:'x'|'y'; at:number } | null = null
+
+    // 最小差分を探す
+    let minX = thresholdWorld + 1
+    let minY = thresholdWorld + 1
+
+    for (const g of guides) {
+      if (g.axis === 'x') {
+        for (const c of candidatesX) {
+          const diff = g.pos - (c + dx)
+          const ad = Math.abs(diff)
+          if (ad <= thresholdWorld && ad < minX) {
+            minX = ad
+            dx = diff
+            ax = { axis: 'x', at: g.pos }
+          }
+        }
+      } else {
+        for (const c of candidatesY) {
+          const diff = g.pos - (c + dy)
+          const ad = Math.abs(diff)
+          if (ad <= thresholdWorld && ad < minY) {
+            minY = ad
+            dy = diff
+            ay = { axis: 'y', at: g.pos }
+          }
+        }
+      }
+    }
+
+    if (dx === 0 && dy === 0) {
+      return { rect: draftRect, snapped: false, active: [] }
+    }
+
+    // move/resize どちらでもドラフト矩形を平行移動で合わせる簡易版
+    // （resize で片辺だけ合わせたい場合は、呼び出し側で draftRect の生成段階で
+    //   固定辺を維持するようにしてください）
+    const rect = { ...draftRect, x: draftRect.x + dx, y: draftRect.y + dy }
+    const active = [ax, ay].filter(Boolean) as {axis:'x'|'y'; at:number}[]
+
+    return { rect, snapped: true, active }
+  }, [draftRect, visible, guides, thresholdWorld])
+}

--- a/web/lib/units.ts
+++ b/web/lib/units.ts
@@ -1,0 +1,33 @@
+export type Unit = 'px' | '%' | 'rem'
+
+export const toWorldPx = (
+  value: number,
+  unit: Unit,
+  canvasSizePx: number,   // xなら幅、yなら高さで呼ぶ
+  baseRemPx = 16
+) => {
+  switch (unit) {
+    case 'px':
+      return value
+    case '%':
+      return (value / 100) * canvasSizePx
+    case 'rem':
+      return value * baseRemPx
+  }
+}
+
+export const fromWorldPx = (
+  px: number,
+  unit: Unit,
+  canvasSizePx: number,
+  baseRemPx = 16
+) => {
+  switch (unit) {
+    case 'px':
+      return px
+    case '%':
+      return (px / canvasSizePx) * 100
+    case 'rem':
+      return px / baseRemPx
+  }
+}

--- a/web/store/guidesStore.ts
+++ b/web/store/guidesStore.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+
+export type Unit = 'px' | '%' | 'rem'
+export type Guide = {
+  id: string
+  axis: 'x' | 'y'   // x=垂直ガイド, y=水平ガイド
+  pos: number       // ワールド(px)座標。%やremは変換後にここへ格納
+}
+
+type GuidesState = {
+  guides: Guide[]
+  visible: boolean
+  locked: boolean
+  unit: Unit
+  baseRemPx: number
+  snapPx: number     // 画面(px)でのスナップしきい値
+  addGuide: (g: Omit<Guide, 'id'> & { id?: string }) => string
+  moveGuide: (id: string, pos: number) => void
+  removeGuide: (id: string) => void
+  clearGuides: () => void
+  setVisible: (v: boolean) => void
+  setLocked: (v: boolean) => void
+  setUnit: (u: Unit) => void
+  setBaseRemPx: (px: number) => void
+  setSnapPx: (px: number) => void
+}
+
+const uid = () => Math.random().toString(36).slice(2, 9)
+
+export const useGuidesStore = create<GuidesState>((set, get) => ({
+  guides: [
+    // 例: 初期ガイド（必要なければ空配列でOK）
+    // { id: uid(), axis: 'x', pos: 0 },
+    // { id: uid(), axis: 'y', pos: 0 },
+  ],
+  visible: true,
+  locked: false,
+  unit: 'px',
+  baseRemPx: 16,
+  snapPx: 6,
+
+  addGuide: (g) => {
+    const id = g.id ?? uid()
+    set((s) => ({ guides: [...s.guides, { id, axis: g.axis, pos: g.pos }] }))
+    return id
+  },
+
+  moveGuide: (id, pos) => {
+    if (get().locked) return
+    set((s) => ({
+      guides: s.guides.map((gg) => (gg.id === id ? { ...gg, pos } : gg)),
+    }))
+  },
+
+  removeGuide: (id) =>
+    set((s) => ({ guides: s.guides.filter((g) => g.id !== id) })),
+
+  clearGuides: () => set({ guides: [] }),
+
+  setVisible: (v) => set({ visible: v }),
+  setLocked: (v) => set({ locked: v }),
+  setUnit: (u) => set({ unit: u }),
+  setBaseRemPx: (px) => set({ baseRemPx: px }),
+  setSnapPx: (px) => set({ snapPx: px }),
+}))


### PR DESCRIPTION
## Summary
- add guides store with visibility, unit, and snap controls
- provide unit conversion helpers and snap-to-guide hook
- render guides and ruler overlays with unit selection

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8bc1c0f8832cb7cc47732ceddc8b