### PR TITLE
feat: add outline overlay and UI toggles

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -85,7 +85,16 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
   const children = node.children?.map((c) => (
     <NodeRenderer key={c.id} node={c} previewHover={previewHover} />
   ));
-  return React.createElement(Comp as any, { ...props, 'data-node-id': node.id }, children);
+  return React.createElement(
+    Comp as any,
+    {
+      ...props,
+      'data-node-id': node.id,
+      'data-node-type': node.type,
+      'data-node-name': (node as any).props?.name,
+    },
+    children,
+  );
 };
 
 interface PageRendererProps {

--- a/src/features/uibuilder/editor/Canvas.tsx
+++ b/src/features/uibuilder/editor/Canvas.tsx
@@ -20,6 +20,9 @@ const RenderNode: React.FC<{ node: EditorNode }> = ({ node }) => {
   return (
     <Tag
       className={`${buildClass(node)} ${selectedId === node.id ? 'outline outline-blue-500' : ''}`}
+      data-node-id={node.id}
+      data-node-type={node.type}
+      data-node-name={node.props?.name}
       onClick={(e: React.MouseEvent) => {
         e.stopPropagation();
         select(node.id);

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -12,6 +12,7 @@ import { RectsProvider, useRects } from './canvas/RectsStore'
 import SmartGuidesOverlay from './canvas/SmartGuidesOverlay'
 import { GuidesOverlay } from './overlays/GuidesOverlay'
 import type { Guide } from './canvas/snap'
+import { OutlineOverlay } from './overlays/OutlineOverlay'
 
 function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
@@ -35,6 +36,8 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
     <div
       ref={ref}
       data-node-id={node.id}
+      data-node-type={node.type}
+      data-node-name={node.props?.name}
       style={{ position: 'absolute', ...style }}
       onMouseDown={e => { e.stopPropagation(); selectComponent(node.id) }}
     >
@@ -50,16 +53,18 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
 export default function Canvas() {
   const { tree } = useEditorState()
   const [guides, setGuides] = useState<Guide[]>([])
+  const canvasRef = useRef<HTMLDivElement>(null)
   return (
     <ViewportProvider>
       <RectsProvider>
         <div className="relative h-full w-full">
           <Viewport>
-            <div data-canvas-root className="relative w-[2000px] h-[2000px]">
+            <div ref={canvasRef} data-canvas-root className="relative w-[2000px] h-[2000px]">
               {tree.map(n => (
                 <NodeRenderer key={n.id} node={n} />
               ))}
               <SelectionOverlay setGuides={setGuides} />
+              <OutlineOverlay canvasRef={canvasRef} />
             </div>
           </Viewport>
           <GridOverlay />

--- a/web/components/OutlineToggles.tsx
+++ b/web/components/OutlineToggles.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React, { useEffect } from 'react'
+import { useEditorUIStore } from '@/store/editorUIStore'
+
+export function OutlineToggles() {
+  const { showOutline, setShowOutline, outlineMode, setOutlineMode } = useEditorUIStore()
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'o') {
+        if (e.altKey) {
+          setOutlineMode((m) => (m === 'selection' ? 'hover' : m === 'hover' ? 'all' : 'selection'))
+        } else {
+          setShowOutline((v) => !v)
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [setOutlineMode, setShowOutline])
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <label className="flex items-center gap-1">
+        <input type="checkbox" checked={showOutline} onChange={(e) => setShowOutline(e.target.checked)} />
+        Outline
+      </label>
+      <select
+        value={outlineMode}
+        onChange={(e) => setOutlineMode(e.target.value as any)}
+        className="bg-neutral-800 text-neutral-100 rounded px-1 py-[2px]"
+        title="Outline Mode"
+      >
+        <option value="selection">Selection</option>
+        <option value="hover">Hover</option>
+        <option value="all">All</option>
+      </select>
+    </div>
+  )
+}

--- a/web/components/Toolbar.tsx
+++ b/web/components/Toolbar.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { useEditorState, useEditorActions } from './store'
 import { apiFetch, getToken, clearToken } from '../lib/api'
 import LoginModal from './Auth/LoginModal'
+import { OutlineToggles } from './OutlineToggles'
 
 const PAGE_ID = 'home'
 
@@ -49,12 +50,13 @@ const Toolbar: React.FC = () => {
       <div className="sticky top-0 z-20 bg-white/80 backdrop-blur border-b">
         <div className="flex items-center gap-2 p-2">
           <button className="px-3 py-1 rounded border" onClick={()=>setLoginOpen(true)}>Login</button>
-          <button className="px-3 py-1 rounded border" onClick={logout}>Logout</button>
-          <div className="mx-2 w-px h-6 bg-gray-200" />
-          <button className="px-3 py-1 rounded border" onClick={undo}>Undo</button>
-          <button className="px-3 py-1 rounded border" onClick={redo}>Redo</button>
-          <div className="mx-2 w-px h-6 bg-gray-200" />
-          <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={publish}>Publish</button>
+        <button className="px-3 py-1 rounded border" onClick={logout}>Logout</button>
+        <div className="mx-2 w-px h-6 bg-gray-200" />
+        <button className="px-3 py-1 rounded border" onClick={undo}>Undo</button>
+        <button className="px-3 py-1 rounded border" onClick={redo}>Redo</button>
+        <OutlineToggles />
+        <div className="mx-2 w-px h-6 bg-gray-200" />
+        <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={publish}>Publish</button>
           <button className="px-3 py-1 rounded bg-emerald-600 text-white" onClick={deploy}>Deploy</button>
           <button className="px-3 py-1 rounded border" onClick={loadLatest}>Load (Edge)</button>
           {dirty && <span className="ml-2 text-xs text-orange-600">● Unsaved</span>}

--- a/web/components/overlays/OutlineOverlay.tsx
+++ b/web/components/overlays/OutlineOverlay.tsx
@@ -1,0 +1,113 @@
+'use client'
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useEditorUIStore } from '@/store/editorUIStore'
+import { useEditorStore } from '@/store/editorStore'
+
+type Box = { id: string; x: number; y: number; w: number; h: number; label?: string }
+
+function collectBoxes(container: HTMLElement): Box[] {
+  const els = container.querySelectorAll<HTMLElement>('[data-node-id]')
+  const boxes: Box[] = []
+  els.forEach((el) => {
+    const id = el.dataset.nodeId!
+    const r = el.getBoundingClientRect()
+    const cr = container.getBoundingClientRect()
+    boxes.push({
+      id,
+      x: r.left - cr.left,
+      y: r.top - cr.top,
+      w: r.width,
+      h: r.height,
+      label: el.dataset.nodeName || el.dataset.nodeType || id,
+    })
+  })
+  return boxes
+}
+
+export function OutlineOverlay({
+  canvasRef,
+}: {
+  /** キャンバスのスクロール・ズーム対象のルート（DOM） */
+  canvasRef: React.RefObject<HTMLElement>
+}) {
+  const { showOutline, outlineMode } = useEditorUIStore()
+  const { selectedIds, hoverId } = useEditorStore((s) => ({
+    selectedIds: (s as any).selectedIds as string[] | undefined,
+    hoverId: (s as any).hoverId as string | undefined,
+  }))
+  const [boxes, setBoxes] = useState<Box[]>([])
+  const rafRef = useRef<number | null>(null)
+
+  useLayoutEffect(() => {
+    if (!canvasRef.current) return
+    const root = canvasRef.current
+
+    const pump = () => {
+      setBoxes(collectBoxes(root))
+      rafRef.current = requestAnimationFrame(pump)
+    }
+    pump()
+
+    const ro = new ResizeObserver(() => setBoxes(collectBoxes(root)))
+    ro.observe(root)
+
+    const mo = new MutationObserver(() => setBoxes(collectBoxes(root)))
+    mo.observe(root, { attributes: true, childList: true, subtree: true })
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+      ro.disconnect()
+      mo.disconnect()
+    }
+  }, [canvasRef])
+
+  const filtered = useMemo(() => {
+    if (!showOutline) return []
+    if (outlineMode === 'all') return boxes
+    if (outlineMode === 'hover') {
+      return hoverId ? boxes.filter((b) => b.id === hoverId) : []
+    }
+    const set = new Set(selectedIds ?? [])
+    return boxes.filter((b) => set.has(b.id))
+  }, [showOutline, outlineMode, boxes, selectedIds, hoverId])
+
+  if (!canvasRef.current) return null
+
+  return createPortal(
+    <div className="pointer-events-none absolute inset-0">
+      {filtered.map((b) => {
+        const isSelected = selectedIds?.includes(b.id)
+        const isHover = hoverId === b.id
+        const color = isSelected
+          ? 'rgb(59 130 246)'
+          : isHover
+            ? 'rgb(20 184 166)'
+            : 'rgb(148 163 184)'
+        return (
+          <div
+            key={b.id}
+            className="absolute"
+            style={{
+              left: b.x,
+              top: b.y,
+              width: b.w,
+              height: b.h,
+              outline: `1px dashed ${color}`,
+              outlineOffset: 0,
+              boxShadow: `inset 0 0 0 1px ${color}`,
+            }}
+          >
+            <div
+              className="absolute -top-5 left-0 px-1.5 py-[2px] text-[10px] leading-none rounded bg-black/70 text-white"
+              style={{ border: `1px solid ${color}` }}
+            >
+              {b.label} · {Math.round(b.w)}×{Math.round(b.h)}
+            </div>
+          </div>
+        )
+      })}
+    </div>,
+    canvasRef.current
+  )
+}

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -58,6 +58,9 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
     return (
       <div
         style={style}
+        data-node-id={node.id}
+        data-node-type={node.type}
+        data-node-name={(node as any).props?.name}
         onClick={handleClick}
         onMouseEnter={handleHover}
         className={link ? 'cursor-pointer' : undefined}
@@ -70,6 +73,9 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
     return (
       <div
         style={style}
+        data-node-id={node.id}
+        data-node-type={node.type}
+        data-node-name={(node as any).props?.name}
         onClick={handleClick}
         onMouseEnter={handleHover}
         className={link ? 'cursor-pointer' : undefined}
@@ -81,6 +87,9 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
   return (
     <div
       style={style}
+      data-node-id={node.id}
+      data-node-type={node.type}
+      data-node-name={(node as any).props?.name}
       onClick={handleClick}
       onMouseEnter={handleHover}
       className={link ? 'cursor-pointer' : undefined}

--- a/web/store/editorUIStore.ts
+++ b/web/store/editorUIStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+type OutlineMode = 'selection' | 'hover' | 'all'
+
+type UIState = {
+  showOutline: boolean
+  outlineMode: OutlineMode
+  setShowOutline: (v: boolean) => void
+  setOutlineMode: (m: OutlineMode) => void
+}
+
+export const useEditorUIStore = create<UIState>((set) => ({
+  showOutline: true,
+  outlineMode: 'selection',
+  setShowOutline: (v) => set({ showOutline: v }),
+  setOutlineMode: (m) => set({ outlineMode: m }),
+}))


### PR DESCRIPTION
## Summary
- add Zustand editor UI store with outline options
- render OutlineOverlay on canvas and expose node data attributes
- add outline toggles with keyboard shortcut to toolbar

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ada654aa1c832c8f1054eaf43bf8a6