### PR TITLE
feat: add guide interactions

### DIFF
--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -68,10 +68,10 @@ export default function Canvas() {
             </div>
           </Viewport>
           <GridOverlay />
-          <Rulers width={2000} height={2000} />
+          <Rulers width={2000} height={2000} canvasRef={canvasRef} />
           <HUDContainer />
           <SmartGuidesOverlay guides={guides} />
-          <GuidesOverlay width={2000} height={2000} />
+          <GuidesOverlay width={2000} height={2000} canvasRef={canvasRef} />
         </div>
       </RectsProvider>
     </ViewportProvider>

--- a/web/components/Rulers.tsx
+++ b/web/components/Rulers.tsx
@@ -2,20 +2,79 @@
 import React from 'react'
 import { useGuidesStore } from '@/store/guidesStore'
 
-export function Rulers({ width, height }: { width: number; height: number }) {
-  const { unit, setUnit, baseRemPx } = useGuidesStore((s) => ({
+type ScreenToWorld = (p: number, axis: 'x'|'y') => number
+
+export function Rulers({
+  width,
+  height,
+  canvasRef,
+  screenToWorld,
+}: {
+  width: number
+  height: number
+  canvasRef?: React.RefObject<HTMLElement>
+  screenToWorld?: ScreenToWorld
+}) {
+  const { unit, setUnit, baseRemPx, addGuide, locked, setPreview } = useGuidesStore((s) => ({
     unit: s.unit,
     setUnit: s.setUnit,
     baseRemPx: s.baseRemPx,
+    addGuide: s.addGuide,
+    locked: s.locked,
+    setPreview: s.setPreview,
   }))
+
+  const toWorld: ScreenToWorld = (p, axis) => {
+    if (!canvasRef?.current) return p
+    if (screenToWorld) return screenToWorld(p, axis)
+    const r = canvasRef.current.getBoundingClientRect()
+    return axis === 'x' ? p - r.left : p - r.top
+  }
+
+  const startDrag = (axis: 'x'|'y') => (e: React.MouseEvent) => {
+    if (locked) return
+    if ((e.target as HTMLElement).tagName === 'SELECT') return
+    e.preventDefault()
+    const move = (ev: MouseEvent) => {
+      const pos = toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis)
+      setPreview({ axis, pos })
+    }
+    const up = (ev: MouseEvent) => {
+      const pos = toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis)
+      addGuide({ axis, pos })
+      setPreview(null)
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+    move(e.nativeEvent as MouseEvent)
+  }
+
+  const onDoubleClickX = (e: React.MouseEvent) => {
+    if (locked) return
+    const pos = toWorld(e.clientX, 'x')
+    addGuide({ axis: 'x', pos })
+  }
+
+  const onDoubleClickY = (e: React.MouseEvent) => {
+    if (locked) return
+    const pos = toWorld(e.clientY, 'y')
+    addGuide({ axis: 'y', pos })
+  }
 
   const ticksX = getTicks(width, unit, baseRemPx)
   const ticksY = getTicks(height, unit, baseRemPx)
 
   return (
     <div className="absolute top-0 left-0 select-none">
-      {/* 水平ルーラー */}
-      <div className="relative h-6 w-full bg-neutral-900/70 text-neutral-200">
+      {/* 水平ルーラー（X） */}
+      <div
+        className="relative h-6 w-full bg-neutral-900/70 text-neutral-200 cursor-crosshair"
+        onMouseDown={startDrag('x')}
+        onDoubleClick={onDoubleClickX}
+        title="ドラッグで垂直ガイド／ダブルクリックで追加"
+      >
         <select
           className="absolute left-1 top-1 h-4 text-[10px] bg-neutral-800 rounded px-1"
           value={unit}
@@ -38,8 +97,13 @@ export function Rulers({ width, height }: { width: number; height: number }) {
         </svg>
       </div>
 
-      {/* 垂直ルーラー */}
-      <div className="absolute top-0 left-0 w-6 h-full bg-neutral-900/70 text-neutral-200">
+      {/* 垂直ルーラー（Y） */}
+      <div
+        className="absolute top-0 left-0 w-6 h-full bg-neutral-900/70 text-neutral-200 cursor-crosshair"
+        onMouseDown={startDrag('y')}
+        onDoubleClick={onDoubleClickY}
+        title="ドラッグで水平ガイド／ダブルクリックで追加"
+      >
         <svg className="absolute left-0 top-0" width={24} height={height}>
           {ticksY.map((t) => (
             <g key={t.px}>

--- a/web/components/overlays/GuidesOverlay.tsx
+++ b/web/components/overlays/GuidesOverlay.tsx
@@ -2,37 +2,101 @@
 import React, { memo } from 'react'
 import { useGuidesStore } from '@/store/guidesStore'
 
-/** 画面→SVG変換など既存の座標系があればそれを使用。
- * ここではシンプルにワールド(px)＝SVG座標として描く例。
- */
+type Active = { axis: 'x'|'y'; at: number }
+type ScreenToWorld = (p: number, axis: 'x'|'y') => number
+
 export const GuidesOverlay = memo(function GuidesOverlay({
   width,
   height,
   active = [],
+  canvasRef,
+  screenToWorld,
 }: {
   width: number
   height: number
-  active?: { axis: 'x'|'y'; at: number }[]
+  active?: Active[]
+  canvasRef?: React.RefObject<HTMLElement>
+  screenToWorld?: ScreenToWorld
 }) {
-  const { guides, visible } = useGuidesStore((s) => ({ guides: s.guides, visible: s.visible }))
+  const { guides, visible, locked, preview, moveGuide, removeGuide } = useGuidesStore((s) => ({
+    guides: s.guides, visible: s.visible, locked: s.locked,
+    preview: s.preview,
+    moveGuide: s.moveGuide, removeGuide: s.removeGuide,
+  }))
   if (!visible) return null
 
-  const activeKey = (g: {axis:'x'|'y'; at:number}) => `${g.axis}:${Math.round(g.at)}`
+  const toWorld: ScreenToWorld = (p, axis) => {
+    if (!canvasRef?.current) return p
+    if (screenToWorld) return screenToWorld(p, axis)
+    const r = canvasRef.current.getBoundingClientRect()
+    return axis === 'x' ? (p - r.left) : (p - r.top)
+  }
 
+  const activeKey = (g: Active) => `${g.axis}:${Math.round(g.at)}`
   const activeMap = new Set(active.map(activeKey))
+
+  const startDrag = (gId: string, axis: 'x'|'y') => (e: React.MouseEvent<SVGLineElement>) => {
+    if (locked) return
+    e.preventDefault()
+    const onMove = (ev: MouseEvent) => moveGuide(gId, toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis))
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
+
+  const onContext = (id: string) => (e: React.MouseEvent) => {
+    e.preventDefault()
+    removeGuide(id)
+  }
+
   return (
-    <svg className="pointer-events-none absolute inset-0" width={width} height={height}>
-      {guides.map((g) => {
-        const key = `${g.axis}:${Math.round(g.pos)}`
-        const isActive = activeMap.has(key)
-        const stroke = isActive ? 'rgba(32,148,243,1)' : 'rgba(32,148,243,.5)'
-        const dash = isActive ? '0' : '6,6'
-        return g.axis === 'x' ? (
-          <line key={key} x1={g.pos} y1={0} x2={g.pos} y2={height} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
-        ) : (
-          <line key={key} x1={0} y1={g.pos} x2={width} y2={g.pos} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
-        )
-      })}
-    </svg>
+    <div className="absolute inset-0">
+      {/* ▼ ビジュアル（非インタラクティブ） */}
+      <svg className="absolute inset-0 pointer-events-none" width={width} height={height}>
+        {guides.map((g) => {
+          const key = `${g.axis}:${Math.round(g.pos)}`
+          const isActive = activeMap.has(key)
+          const stroke = isActive ? 'rgba(32,148,243,1)' : 'rgba(32,148,243,.5)'
+          const dash = isActive ? '0' : '6,6'
+          return g.axis === 'x' ? (
+            <line key={key} x1={g.pos} y1={0} x2={g.pos} y2={height} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+          ) : (
+            <line key={key} x1={0} y1={g.pos} x2={width} y2={g.pos} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+          )
+        })}
+        {preview && (
+          preview.axis === 'x' ? (
+            <line x1={preview.pos} y1={0} x2={preview.pos} y2={height} stroke="rgba(255,255,255,.9)" strokeWidth={1} strokeDasharray="2,2" />
+          ) : (
+            <line x1={0} y1={preview.pos} x2={width} y2={preview.pos} stroke="rgba(255,255,255,.9)" strokeWidth={1} strokeDasharray="2,2" />
+          )
+        )}
+      </svg>
+
+      {/* ▼ インタラクティブ（太いヒットエリア） */}
+      <div className="absolute inset-0 pointer-events-auto">
+        <svg className="absolute inset-0" width={width} height={height}>
+          {guides.map((g) => {
+            // 透明の太い線をヒットエリアに（見た目は上のSVGが担う）
+            const common = {
+              onMouseDown: startDrag(g.id, g.axis),
+              onContextMenu: onContext(g.id),
+              style: { cursor: g.axis === 'x' ? 'col-resize' as const : 'row-resize' as const },
+              stroke: 'rgba(0,0,0,0)', // 透明
+              strokeWidth: 12,        // 太いヒット
+            }
+            return g.axis === 'x' ? (
+              <line key={g.id} x1={g.pos} y1={0} x2={g.pos} y2={height} {...common} />
+            ) : (
+              <line key={g.id} x1={0} y1={g.pos} x2={width} y2={g.pos} {...common} />
+            )
+          })}
+        </svg>
+      </div>
+    </div>
   )
 })
+

--- a/web/store/guidesStore.ts
+++ b/web/store/guidesStore.ts
@@ -14,6 +14,7 @@ type GuidesState = {
   unit: Unit
   baseRemPx: number
   snapPx: number     // 画面(px)でのスナップしきい値
+  preview: { axis: 'x'|'y'; pos: number } | null
   addGuide: (g: Omit<Guide, 'id'> & { id?: string }) => string
   moveGuide: (id: string, pos: number) => void
   removeGuide: (id: string) => void
@@ -23,6 +24,7 @@ type GuidesState = {
   setUnit: (u: Unit) => void
   setBaseRemPx: (px: number) => void
   setSnapPx: (px: number) => void
+  setPreview: (g: { axis: 'x'|'y'; pos: number } | null) => void
 }
 
 const uid = () => Math.random().toString(36).slice(2, 9)
@@ -38,6 +40,7 @@ export const useGuidesStore = create<GuidesState>((set, get) => ({
   unit: 'px',
   baseRemPx: 16,
   snapPx: 6,
+  preview: null,
 
   addGuide: (g) => {
     const id = g.id ?? uid()
@@ -62,4 +65,5 @@ export const useGuidesStore = create<GuidesState>((set, get) => ({
   setUnit: (u) => set({ unit: u }),
   setBaseRemPx: (px) => set({ baseRemPx: px }),
   setSnapPx: (px) => set({ snapPx: px }),
+  setPreview: (g) => set({ preview: g }),
 }))


### PR DESCRIPTION
## Summary
- add drag and double-click guide creation in Rulers
- add interactive GuidesOverlay with drag, right-click removal, and preview
- track guide preview state and expose canvas ref for proper positioning

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68afda529fac832cbcba1bbe7609abda