### PR TITLE
feat(editor): add smart guide snapping hook and overlay

### DIFF
--- a/web/components/overlays/SmartGuidesOverlay.tsx
+++ b/web/components/overlays/SmartGuidesOverlay.tsx
@@ -1,0 +1,26 @@
+'use client'
+import React, { memo } from 'react'
+import type { SmartGuide } from '@/hooks/useSmartSnap'
+
+export const SmartGuidesOverlay = memo(function SmartGuidesOverlay({
+  width, height, active = [],
+}: { width:number; height:number; active: SmartGuide[] }) {
+  if (!active.length) return null
+  return (
+    <svg className="pointer-events-none absolute inset-0" width={width} height={height}>
+      {active.map((g, i) => {
+        const stroke = 'rgba(236, 72, 153, 1)' // magenta系
+        const dash   = g.kind === 'equal' ? '4,4' : '0'
+        if (g.axis === 'x') {
+          return <line key={i} x1={g.at} y1={0} x2={g.at} y2={height} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+        }
+        if (g.axis === 'y') {
+          return <line key={i} x1={0} y1={g.at} x2={width} y2={g.at} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+        }
+        // equal width/height は簡易にラベルだけ（将来拡張用）
+        return null
+      })}
+    </svg>
+  )
+})
+

--- a/web/hooks/useSmartSnap.ts
+++ b/web/hooks/useSmartSnap.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+import { useGuidesStore } from '@/store/guidesStore'
+
+export type Rect = { x: number; y: number; w: number; h: number }
+export type SmartGuide = { axis:'x'|'y'|'w'|'h'; at:number; kind:'edge'|'center'|'equal'; refId?:string }
+export type SnapResult = { rect: Rect; snapped: boolean; active: SmartGuide[] }
+
+/** 他ノードの bbox からエッジ/センター/同幅・同高のスマートガイドを作り、最小移動で吸着 */
+export function useSmartSnap(
+  draftRect: Rect,
+  mode: 'move' | 'resize',
+  zoom: number,
+  others: Array<Rect & { id?: string }>
+): SnapResult {
+  const { smartEnabled, snapPx, smartSnapPx } = useGuidesStore((s) => ({
+    smartEnabled: s.smartEnabled,
+    snapPx: s.snapPx,
+    smartSnapPx: s.smartSnapPx,
+  }))
+  const thresholdWorld = (smartSnapPx ?? snapPx) / Math.max(zoom, 0.01)
+
+  return useMemo(() => {
+    if (!smartEnabled || others.length === 0) {
+      return { rect: draftRect, snapped: false, active: [] }
+    }
+
+    const L = (r: Rect) => r.x
+    const R = (r: Rect) => r.x + r.w
+    const T = (r: Rect) => r.y
+    const B = (r: Rect) => r.y + r.h
+    const CX = (r: Rect) => r.x + r.w / 2
+    const CY = (r: Rect) => r.y + r.h / 2
+
+    const candX = [ {val:L(draftRect), kind:'edge'}, {val:CX(draftRect), kind:'center'}, {val:R(draftRect), kind:'edge'} ] as const
+    const candY = [ {val:T(draftRect), kind:'edge'}, {val:CY(draftRect), kind:'center'}, {val:B(draftRect), kind:'edge'} ] as const
+
+    let bestDx = 0, bestDy = 0
+    let minX = thresholdWorld + 1, minY = thresholdWorld + 1
+    let active: SmartGuide[] = []
+
+    for (const o of others) {
+      // Xライン
+      const xTargets = [ {val:L(o), kind:'edge'}, {val:CX(o), kind:'center'}, {val:R(o), kind:'edge'} ] as const
+      for (const c of candX) for (const t of xTargets) {
+        const d = t.val - (c.val + bestDx)
+        const ad = Math.abs(d)
+        if (ad <= thresholdWorld && ad < minX) {
+          minX = ad
+          bestDx = d
+        }
+      }
+      // Yライン
+      const yTargets = [ {val:T(o), kind:'edge'}, {val:CY(o), kind:'center'}, {val:B(o), kind:'edge'} ] as const
+      for (const c of candY) for (const t of yTargets) {
+        const d = t.val - (c.val + bestDy)
+        const ad = Math.abs(d)
+        if (ad <= thresholdWorld && ad < minY) {
+          minY = ad
+          bestDy = d
+        }
+      }
+      // 同幅/同高（equal）
+      if (Math.abs(o.w - draftRect.w) <= thresholdWorld) {
+        active.push({ axis:'w', at:o.w, kind:'equal', refId:o.id })
+      }
+      if (Math.abs(o.h - draftRect.h) <= thresholdWorld) {
+        active.push({ axis:'h', at:o.h, kind:'equal', refId:o.id })
+      }
+    }
+
+    if (minX <= thresholdWorld || minY <= thresholdWorld || active.length) {
+      const rect = { ...draftRect, x: draftRect.x + bestDx, y: draftRect.y + bestDy }
+      // 実際に吸着したX/Yラインを active に反映（簡易）
+      if (minX <= thresholdWorld) active.push({ axis:'x', at: CX({x:rect.x, y:0, w:0, h:0}), kind:'center' })
+      if (minY <= thresholdWorld) active.push({ axis:'y', at: CY({x:0, y:rect.y, w:0, h:0}), kind:'center' })
+      return { rect, snapped: true, active }
+    }
+    return { rect: draftRect, snapped: false, active: [] }
+  }, [draftRect, others, smartEnabled, thresholdWorld])
+}
+

--- a/web/store/guidesStore.ts
+++ b/web/store/guidesStore.ts
@@ -14,6 +14,8 @@ type GuidesState = {
   unit: Unit
   baseRemPx: number
   snapPx: number     // 画面(px)でのスナップしきい値
+  smartEnabled: boolean
+  smartSnapPx?: number
   preview: { axis: 'x'|'y'; pos: number } | null
   addGuide: (g: Omit<Guide, 'id'> & { id?: string }) => string
   moveGuide: (id: string, pos: number) => void
@@ -24,6 +26,8 @@ type GuidesState = {
   setUnit: (u: Unit) => void
   setBaseRemPx: (px: number) => void
   setSnapPx: (px: number) => void
+  setSmartEnabled: (v: boolean) => void
+  setSmartSnapPx: (px?: number) => void
   setPreview: (g: { axis: 'x'|'y'; pos: number } | null) => void
 }
 
@@ -40,6 +44,8 @@ export const useGuidesStore = create<GuidesState>((set, get) => ({
   unit: 'px',
   baseRemPx: 16,
   snapPx: 6,
+  smartEnabled: true,
+  smartSnapPx: undefined,
   preview: null,
 
   addGuide: (g) => {
@@ -65,5 +71,7 @@ export const useGuidesStore = create<GuidesState>((set, get) => ({
   setUnit: (u) => set({ unit: u }),
   setBaseRemPx: (px) => set({ baseRemPx: px }),
   setSnapPx: (px) => set({ snapPx: px }),
+  setSmartEnabled: (v) => set({ smartEnabled: v }),
+  setSmartSnapPx: (px) => set({ smartSnapPx: px }),
   setPreview: (g) => set({ preview: g }),
 }))


### PR DESCRIPTION
## Summary
- extend guides store with smart snapping flags
- add `useSmartSnap` hook for node-to-node snapping
- add `SmartGuidesOverlay` to visualize smart guides

## Testing
- `pnpm --filter ui-builder-web build` *(fails: Cannot find module 'source-map-support'; ESLint invalid options; missing '@domain-components')*

------
https://chatgpt.com/codex/tasks/task_e_68afdc696230832cb002091ff911bc32