### PR TITLE
feat: add grid overlay and snapping

### DIFF
--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -5,14 +5,15 @@ import { registry } from '../lib/registry'
 import SelectionOverlay from './canvas/SelectionOverlay'
 import Viewport from './canvas/Viewport'
 import HUDContainer from './hud/HUDContainer'
-import { ViewportProvider } from './canvas/ViewportStore'
-import GridOverlay from './canvas/GridOverlay'
+import { ViewportProvider, useViewport } from './canvas/ViewportStore'
+import { GridOverlay } from '@/components/overlays/GridOverlay'
 import { Rulers } from './Rulers'
 import { RectsProvider, useRects } from './canvas/RectsStore'
 import SmartGuidesOverlay from './canvas/SmartGuidesOverlay'
 import { GuidesOverlay } from './overlays/GuidesOverlay'
 import type { Guide } from './canvas/snap'
 import { OutlineOverlay } from './overlays/OutlineOverlay'
+import { GridToolbar } from '@/components/GridToolbar'
 
 function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
@@ -54,26 +55,52 @@ export default function Canvas() {
   const { tree } = useEditorState()
   const [guides, setGuides] = useState<Guide[]>([])
   const canvasRef = useRef<HTMLDivElement>(null)
+
   return (
     <ViewportProvider>
       <RectsProvider>
-        <div className="relative h-full w-full">
-          <Viewport>
-            <div ref={canvasRef} data-canvas-root className="relative w-[2000px] h-[2000px]">
-              {tree.map(n => (
-                <NodeRenderer key={n.id} node={n} />
-              ))}
-              <SelectionOverlay setGuides={setGuides} />
-              <OutlineOverlay canvasRef={canvasRef} />
-            </div>
-          </Viewport>
-          <GridOverlay />
-          <Rulers width={2000} height={2000} canvasRef={canvasRef} />
-          <HUDContainer />
-          <SmartGuidesOverlay guides={guides} />
-          <GuidesOverlay width={2000} height={2000} canvasRef={canvasRef} />
-        </div>
+        <CanvasInner tree={tree} guides={guides} setGuides={setGuides} canvasRef={canvasRef} />
       </RectsProvider>
     </ViewportProvider>
+  )
+}
+
+function CanvasInner({
+  tree,
+  guides,
+  setGuides,
+  canvasRef,
+}: {
+  tree: ComponentNode[]
+  guides: Guide[]
+  setGuides: (g: Guide[]) => void
+  canvasRef: React.RefObject<HTMLDivElement>
+}) {
+  const { vp } = useViewport()
+  return (
+    <div className="relative h-full w-full">
+      <Viewport>
+        <div ref={canvasRef} data-canvas-root className="relative w-[2000px] h-[2000px]">
+          {tree.map(n => (
+            <NodeRenderer key={n.id} node={n} />
+          ))}
+          <SelectionOverlay setGuides={setGuides} />
+          <OutlineOverlay canvasRef={canvasRef} />
+        </div>
+      </Viewport>
+      <GridOverlay
+        width={2000}
+        height={2000}
+        zoom={vp.zoom}
+        worldToScreenOffset={(wx, wy) => ({ sx: wx * vp.zoom + vp.x, sy: wy * vp.zoom + vp.y })}
+      />
+      <Rulers width={2000} height={2000} canvasRef={canvasRef} />
+      <HUDContainer />
+      <SmartGuidesOverlay guides={guides} />
+      <GuidesOverlay width={2000} height={2000} canvasRef={canvasRef} />
+      <div className="absolute top-2 left-2 z-50">
+        <GridToolbar />
+      </div>
+    </div>
   )
 }

--- a/web/components/GridToolbar.tsx
+++ b/web/components/GridToolbar.tsx
@@ -1,0 +1,54 @@
+'use client'
+import React from 'react'
+import { useGridStore } from '@/store/gridStore'
+
+export function GridToolbar() {
+  const {
+    showGrid, snapGrid, pitch, subDiv, minGapPx,
+    setShowGrid, setSnapGrid, setPitch, setSubDiv, setMinGapPx
+  } = useGridStore()
+
+  const box = 'px-2 py-1 rounded bg-neutral-900/70 text-neutral-100 flex items-center gap-2'
+
+  return (
+    <div className={box}>
+      <label className="flex items-center gap-1 text-xs">
+        <input type="checkbox" checked={showGrid} onChange={(e)=>setShowGrid(e.target.checked)} />
+        Show Grid
+      </label>
+      <label className="flex items-center gap-1 text-xs">
+        <input type="checkbox" checked={snapGrid} onChange={(e)=>setSnapGrid(e.target.checked)} />
+        Snap to Grid
+      </label>
+      <div className="flex items-center gap-1 text-xs">
+        pitch
+        <input
+          type="number" min={1} step={1} value={pitch}
+          onChange={(e)=>setPitch(parseInt(e.target.value || '16', 10))}
+          className="w-16 bg-neutral-800 rounded px-1 py-[2px]"
+        />
+        px
+      </div>
+      <div className="flex items-center gap-1 text-xs">
+        subDiv
+        <select
+          value={subDiv}
+          onChange={(e)=>setSubDiv(parseInt(e.target.value, 10))}
+          className="bg-neutral-800 rounded px-1 py-[2px]"
+        >
+          {[2,4,5,10].map(n => <option key={n} value={n}>{n}</option>)}
+        </select>
+      </div>
+      <div className="flex items-center gap-1 text-xs">
+        minGap
+        <input
+          type="number" min={2} step={1} value={minGapPx}
+          onChange={(e)=>setMinGapPx(parseInt(e.target.value || '8', 10))}
+          className="w-14 bg-neutral-800 rounded px-1 py-[2px]"
+        />
+        px
+      </div>
+    </div>
+  )
+}
+

--- a/web/components/canvas/SelectionOverlay.tsx
+++ b/web/components/canvas/SelectionOverlay.tsx
@@ -3,9 +3,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { useEditorState, useEditorActions } from '../store'
 import { useRects } from './RectsStore'
 import { getSmartSnap, Guide } from './snap'
-
-const GRID = 8
-const snap = (v:number)=> Math.round(v/GRID)*GRID
+import { useGridStore } from '@/store/gridStore'
 
 type DragState = { dx:number, dy:number }
 
@@ -31,6 +29,9 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
   const [resize, setResize] = useState<ResizeState|null>(null)
   const style = node?.props?.style || {}
 
+  const { snapGrid, pitch } = useGridStore()
+  const snap = useCallback((v:number)=> (snapGrid ? Math.round(v/pitch)*pitch : v), [snapGrid, pitch])
+
   const containerRect = overlayRef.current?.getBoundingClientRect()
 
   // keyboard move
@@ -50,7 +51,7 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
     }
     window.addEventListener('keydown', handler)
     return ()=> window.removeEventListener('keydown', handler)
-  },[selectedComponentId, rect, style, setProp])
+  },[selectedComponentId, rect, style, setProp, snap])
 
   const startDrag = (e:React.MouseEvent) => {
     if(!rect) return
@@ -91,7 +92,7 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
       if(dir.includes('n')){ height = snap(startH - dy); top = snap(startTop + dy) }
       setProp(selectedComponentId, 'style', { ...style, position:'absolute', left, top, width, height })
     }
-  },[drag, resize, selectedComponentId, rect, setProp, containerRect, siblings, setGuides, style])
+  },[drag, resize, selectedComponentId, rect, setProp, containerRect, siblings, setGuides, style, snap])
 
   const stopAll = useCallback(()=>{
     setDrag(null); setResize(null); setGuides([])

--- a/web/components/canvas/snap.ts
+++ b/web/components/canvas/snap.ts
@@ -1,11 +1,31 @@
 import type { R } from './RectsStore'
+import { useGridStore } from '@/store/gridStore'
+import { useGuidesStore } from '@/store/guidesStore'
+
 export type Guide = { type:'v'|'h'; pos:number; from:number; to:number }
-export function getSmartSnap(target:R, others:R[], grid=8, tol=6){
-  // 1) grid snap
-  const gdx = Math.round(target.x/grid)*grid - target.x
-  const gdy = Math.round(target.y/grid)*grid - target.y
-  let dx=gdx, dy=gdy
-  const guides:Guide[]=[]
+
+export function getSmartSnap(target:R, others:R[]){
+  const { snapGrid, pitch, offsetX, offsetY } = useGridStore.getState()
+  const { snapPx } = useGuidesStore.getState()
+  const threshold = snapPx
+
+  // ▼ グリッド候補
+  let gdx = 0, gdy = 0
+  if (snapGrid) {
+    const roundTo = (v:number, step:number, offset:number) => {
+      const t = (v - offset) / step
+      return Math.round(t) * step + offset
+    }
+    const nx = roundTo(target.x, pitch, offsetX)
+    const ny = roundTo(target.y, pitch, offsetY)
+    if (Math.abs(nx - target.x) <= threshold) gdx = nx - target.x
+    if (Math.abs(ny - target.y) <= threshold) gdy = ny - target.y
+  }
+  const gridDist = Math.abs(gdx) + Math.abs(gdy)
+
+  // ▼ スマートガイド候補
+  let sdx = 0, sdy = 0
+  const guides:Guide[] = []
   const tCenterX = target.x + target.w/2
   const tCenterY = target.y + target.h/2
   const candidatesX:number[] = [], candidatesY:number[] = []
@@ -13,7 +33,6 @@ export function getSmartSnap(target:R, others:R[], grid=8, tol=6){
     candidatesX.push(o.x, o.x+o.w, o.x+o.w/2)
     candidatesY.push(o.y, o.y+o.h, o.y+o.h/2)
   })
-  // 2) edge/center snap (closest within tol)
   const best = (arr:number[], val:number)=> {
     let d=Infinity, p=val; for(const v of arr){ const dd=Math.abs(v-val); if(dd<d){d=dd;p=v} }
     return {d,p}
@@ -24,11 +43,16 @@ export function getSmartSnap(target:R, others:R[], grid=8, tol=6){
   const by1 = best(candidatesY, target.y)
   const by2 = best(candidatesY, target.y+target.h)
   const byc = best(candidatesY, tCenterY)
-  if(bx1.d<tol){ dx = (bx1.p - target.x); guides.push({type:'v',pos:bx1.p,from:target.y-2000,to:target.y+target.h+2000}) }
-  else if(bx2.d<tol){ dx = (bx2.p - (target.x+target.w)); guides.push({type:'v',pos:bx2.p,from:target.y-2000,to:target.y+target.h+2000}) }
-  else if(bxc.d<tol){ dx = (bxc.p - tCenterX); guides.push({type:'v',pos:bxc.p,from:target.y-2000,to:target.y+target.h+2000}) }
-  if(by1.d<tol){ dy = (by1.p - target.y); guides.push({type:'h',pos:by1.p,from:target.x-2000,to:target.x+target.w+2000}) }
-  else if(by2.d<tol){ dy = (by2.p - (target.y+target.h)); guides.push({type:'h',pos:by2.p,from:target.x-2000,to:target.x+target.w+2000}) }
-  else if(byc.d<tol){ dy = (byc.p - tCenterY); guides.push({type:'h',pos:byc.p,from:target.x-2000,to:target.x+target.w+2000}) }
-  return {dx,dy,guides}
+  if(bx1.d<threshold){ sdx = (bx1.p - target.x); guides.push({type:'v',pos:bx1.p,from:target.y-2000,to:target.y+target.h+2000}) }
+  else if(bx2.d<threshold){ sdx = (bx2.p - (target.x+target.w)); guides.push({type:'v',pos:bx2.p,from:target.y-2000,to:target.y+target.h+2000}) }
+  else if(bxc.d<threshold){ sdx = (bxc.p - tCenterX); guides.push({type:'v',pos:bxc.p,from:target.y-2000,to:target.y+target.h+2000}) }
+  if(by1.d<threshold){ sdy = (by1.p - target.y); guides.push({type:'h',pos:by1.p,from:target.x-2000,to:target.x+target.w+2000}) }
+  else if(by2.d<threshold){ sdy = (by2.p - (target.y+target.h)); guides.push({type:'h',pos:by2.p,from:target.x-2000,to:target.x+target.w+2000}) }
+  else if(byc.d<threshold){ sdy = (byc.p - tCenterY); guides.push({type:'h',pos:byc.p,from:target.x-2000,to:target.x+target.w+2000}) }
+  const smartDist = Math.abs(sdx) + Math.abs(sdy)
+
+  if (smartDist && smartDist < gridDist) {
+    return {dx: sdx, dy: sdy, guides}
+  }
+  return {dx: gdx, dy: gdy, guides: []}
 }

--- a/web/components/overlays/GridOverlay.tsx
+++ b/web/components/overlays/GridOverlay.tsx
@@ -1,0 +1,82 @@
+'use client'
+import React, { useEffect, useRef } from 'react'
+import { useGridStore } from '@/store/gridStore'
+
+type OffsetFn = (wx: number, wy: number) => { sx: number; sy: number }
+
+/** 注意: 親のパン/ズームが transform でかかっている場合、
+ *  world→screen オフセット関数を渡すとずれません（未指定なら 1:1 前提）。
+ */
+export function GridOverlay({
+  width,
+  height,
+  zoom = 1,
+  worldToScreenOffset,
+}: {
+  width: number
+  height: number
+  zoom?: number
+  worldToScreenOffset?: OffsetFn
+}) {
+  const { showGrid, pitch, subDiv, offsetX, offsetY, minGapPx } = useGridStore()
+  const cv = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    if (!showGrid || !cv.current) return
+    const canvas = cv.current
+    const ctx = canvas.getContext('2d')!
+    const dpr = window.devicePixelRatio || 1
+
+    canvas.width = Math.floor(width * dpr)
+    canvas.height = Math.floor(height * dpr)
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${height}px`
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, width, height)
+
+    // 画面pxのグリッド間隔（ズーム反映）
+    let step = pitch * zoom
+    let minor = step
+    while (minor < minGapPx) minor *= subDiv
+    const major = minor * subDiv
+
+    // ワールド原点のスクリーン位置
+    const origin = worldToScreenOffset
+      ? worldToScreenOffset(offsetX, offsetY)
+      : { sx: offsetX * zoom, sy: offsetY * zoom }
+
+    // 最初の描画位置（0 から見て負の方向にずらした mod）
+    const mod = (a: number, n: number) => ((a % n) + n) % n
+    const startX = mod(-origin.sx, minor)
+    const startY = mod(-origin.sy, minor)
+
+    // マイナー
+    ctx.beginPath()
+    ctx.strokeStyle = 'rgba(148,163,184,0.35)' // slate-400相当
+    ctx.lineWidth = 1
+    for (let x = startX; x <= width; x += minor) {
+      ctx.moveTo(x, 0); ctx.lineTo(x, height)
+    }
+    for (let y = startY; y <= height; y += minor) {
+      ctx.moveTo(0, y); ctx.lineTo(width, y)
+    }
+    ctx.stroke()
+
+    // メジャー
+    const startXMaj = mod(-origin.sx, major)
+    const startYMaj = mod(-origin.sy, major)
+    ctx.beginPath()
+    ctx.strokeStyle = 'rgba(148,163,184,0.65)'
+    for (let x = startXMaj; x <= width; x += major) {
+      ctx.moveTo(x, 0); ctx.lineTo(x, height)
+    }
+    for (let y = startYMaj; y <= height; y += major) {
+      ctx.moveTo(0, y); ctx.lineTo(width, y)
+    }
+    ctx.stroke()
+  }, [showGrid, width, height, zoom, pitch, subDiv, offsetX, offsetY, minGapPx, worldToScreenOffset])
+
+  if (!showGrid) return null
+  return <canvas ref={cv} className="pointer-events-none absolute inset-0" />
+}
+

--- a/web/hooks/useGridSnap.ts
+++ b/web/hooks/useGridSnap.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import { useGridStore } from '@/store/gridStore'
+import { useGuidesStore } from '@/store/guidesStore' // snapPx を流用
+
+export type Rect = { x: number; y: number; w: number; h: number }
+export type GridActive = { axis: 'x'|'y'; at: number }
+export type SnapResult = { rect: Rect; snapped: boolean; active: GridActive[] }
+
+/** グリッドへ最小移動で吸着（平行移動の簡易版） */
+export function useGridSnap(
+  draftRect: Rect,
+  mode: 'move' | 'resize',
+  zoom: number
+): SnapResult {
+  const { snapGrid, pitch, offsetX, offsetY } = useGridStore()
+  const { snapPx } = useGuidesStore((s) => ({ snapPx: s.snapPx }))
+  const thresholdWorld = snapPx / Math.max(zoom, 0.01)
+
+  return useMemo(() => {
+    if (!snapGrid) return { rect: draftRect, snapped: false, active: [] }
+
+    const roundTo = (v: number, step: number, offset: number) => {
+      const t = (v - offset) / step
+      return Math.round(t) * step + offset
+    }
+
+    let dx = 0, dy = 0
+    const nx = roundTo(draftRect.x, pitch, offsetX)
+    const ny = roundTo(draftRect.y, pitch, offsetY)
+
+    if (Math.abs(nx - draftRect.x) <= thresholdWorld) dx = nx - draftRect.x
+    if (Math.abs(ny - draftRect.y) <= thresholdWorld) dy = ny - draftRect.y
+
+    if (dx === 0 && dy === 0) return { rect: draftRect, snapped: false, active: [] }
+
+    const rect = { ...draftRect, x: draftRect.x + dx, y: draftRect.y + dy }
+    const active: GridActive[] = []
+    if (dx) active.push({ axis: 'x', at: rect.x })
+    if (dy) active.push({ axis: 'y', at: rect.y })
+    return { rect, snapped: true, active }
+  }, [snapGrid, draftRect, pitch, offsetX, offsetY, thresholdWorld])
+}
+

--- a/web/store/gridStore.ts
+++ b/web/store/gridStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+
+type GridState = {
+  showGrid: boolean
+  snapGrid: boolean
+  pitch: number        // 主要グリッド間隔（ワールドpx）
+  subDiv: number       // マイナー何分割か（例: 4 なら 1/4 ピッチ）
+  offsetX: number      // グリッド原点のX（ワールドpx）
+  offsetY: number      // グリッド原点のY（ワールドpx）
+  minGapPx: number     // 画面pxでの最小格子間隔（描画が詰みすぎないため）
+  setShowGrid: (v: boolean) => void
+  setSnapGrid: (v: boolean) => void
+  setPitch: (n: number) => void
+  setSubDiv: (n: number) => void
+  setOffset: (x: number, y: number) => void
+  setMinGapPx: (n: number) => void
+}
+
+export const useGridStore = create<GridState>((set) => ({
+  showGrid: true,
+  snapGrid: false,
+  pitch: 16,
+  subDiv: 4,
+  offsetX: 0,
+  offsetY: 0,
+  minGapPx: 8,
+  setShowGrid: (v) => set({ showGrid: v }),
+  setSnapGrid: (v) => set({ snapGrid: v }),
+  setPitch: (n) => set({ pitch: Math.max(1, Math.round(n)) }),
+  setSubDiv: (n) => set({ subDiv: Math.max(1, Math.round(n)) }),
+  setOffset: (x, y) => set({ offsetX: x, offsetY: y }),
+  setMinGapPx: (n) => set({ minGapPx: Math.max(2, Math.round(n)) }),
+}))
+


### PR DESCRIPTION
## Summary
- add Zustand grid store with toolbar controls for pitch, subdivisions, and visibility
- implement canvas-based grid overlay and grid snapping hook
- integrate grid snapping into selection and snapping logic alongside guides

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68afde30ccd4832c826048ec511923c2