### PR TITLE
feat: add hover effect builder

### DIFF
--- a/lib/hoverCss.ts
+++ b/lib/hoverCss.ts
@@ -1,0 +1,56 @@
+import type { HoverEffect } from '../types/interactions'
+
+const shadowMap = {
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+} as const
+
+const esc = (id: string) => CSS.escape(id)
+
+export function buildHoverCss(nodeId: string, effects: HoverEffect[] = [], transitionMs = 120) {
+  if (!effects.length) return ''
+  let decls: string[] = []
+  let transforms: string[] = []
+
+  for (const ef of effects) {
+    switch (ef.kind) {
+      case 'bgColor':
+        decls.push(`background-color:${ef.value} !important`)
+        break
+      case 'textColor':
+        decls.push(`color:${ef.value} !important`)
+        break
+      case 'borderColor':
+        decls.push(`border-color:${ef.value} !important`)
+        break
+      case 'shadow':
+        decls.push(`box-shadow:${shadowMap[ef.value]} !important`)
+        break
+      case 'scale':
+        transforms.push(`scale(${ef.value})`)
+        break
+      case 'opacity':
+        decls.push(`opacity:${ef.value}`)
+        break
+      case 'translate':
+        transforms.push(`translate(${ef.x ?? 0}px, ${ef.y ?? 0}px)`)
+        break
+      case 'rotate':
+        transforms.push(`rotate(${ef.deg}deg)`)
+        break
+      case 'outline':
+        decls.push(`outline:${ef.width}px ${ef.style ?? 'solid'} ${ef.color}`)
+        decls.push('outline-offset:0')
+        break
+      case 'cursor':
+        decls.push(`cursor:${ef.value}`)
+        break
+    }
+  }
+  if (transforms.length) decls.push(`transform:${transforms.join(' ')} !important`)
+  decls.push(`transition: all ${transitionMs}ms cubic-bezier(.2,.8,.2,1)`)
+
+  return `[data-node-id="${esc(nodeId)}"]:hover{${decls.join(';')}}`
+}

--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { ComponentNode, PropBinding } from './store';
 import { useDataSources, DataSource } from './dataSources';
+import { buildHoverCss } from '../lib/hoverCss';
+import type { HoverEffect } from '../types/interactions';
 
 function getByPath(obj: any, path: string) {
   if (!path || !path.startsWith('$.')) return undefined;
@@ -75,6 +77,10 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
     }
   }
 
+  const effects = (node.props?.hoverEffects as HoverEffect[] | undefined) ?? [];
+  const transitionMs = (node.props?.hoverTransitionMs as number | undefined) ?? 120;
+  const css = effects.length ? buildHoverCss(node.id, effects, transitionMs) : '';
+
   // ✅ 両方を統合: registry からコンポーネントを解決 + previewHover を継承
   const type = node.type;
   const Comp =
@@ -82,9 +88,10 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
       ? type // div, span などネイティブ要素
       : (require('../lib/registry').components as any)[type] || type;
 
-  const children = node.children?.map((c) => (
+  const childrenArr = node.children?.map((c) => (
     <NodeRenderer key={c.id} node={c} previewHover={previewHover} />
-  ));
+  )) || [];
+  if (css) childrenArr.push(<style key="_h" dangerouslySetInnerHTML={{ __html: css }} />);
   return React.createElement(
     Comp as any,
     {
@@ -93,7 +100,7 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
       'data-node-type': node.type,
       'data-node-name': (node as any).props?.name,
     },
-    children,
+    childrenArr,
   );
 };
 

--- a/types/interactions.ts
+++ b/types/interactions.ts
@@ -1,0 +1,36 @@
+export type HoverEffect =
+  | { kind: 'bgColor'; value: string }
+  | { kind: 'textColor'; value: string }
+  | { kind: 'borderColor'; value: string }
+  | { kind: 'shadow'; value: 'sm' | 'md' | 'lg' | 'xl' }
+  | { kind: 'scale'; value: number }
+  | { kind: 'opacity'; value: number }
+  | { kind: 'translate'; x?: number; y?: number }
+  | { kind: 'rotate'; deg: number }
+  | { kind: 'outline'; color: string; width: number; style?: 'solid' | 'dashed' | 'dotted' }
+  | { kind: 'cursor'; value: 'default' | 'pointer' | 'move' | 'grab' | 'text' }
+
+export const defaultEffect = (k: HoverEffect['kind']): HoverEffect => {
+  switch (k) {
+    case 'bgColor':
+      return { kind: 'bgColor', value: '#0f172a' }
+    case 'textColor':
+      return { kind: 'textColor', value: '#e5e7eb' }
+    case 'borderColor':
+      return { kind: 'borderColor', value: '#334155' }
+    case 'shadow':
+      return { kind: 'shadow', value: 'md' }
+    case 'scale':
+      return { kind: 'scale', value: 1.05 }
+    case 'opacity':
+      return { kind: 'opacity', value: 0.9 }
+    case 'translate':
+      return { kind: 'translate', x: 0, y: -2 }
+    case 'rotate':
+      return { kind: 'rotate', deg: 1 }
+    case 'outline':
+      return { kind: 'outline', color: '#22d3ee', width: 1, style: 'dashed' }
+    case 'cursor':
+      return { kind: 'cursor', value: 'pointer' }
+  }
+}

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -2,6 +2,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useEditorState, useEditorActions, ComponentNode } from './store'
 import { registry } from '../lib/registry'
+import { buildHoverCss } from '@/lib/hoverCss'
+import type { HoverEffect } from '@/types/interactions'
 import SelectionOverlay from './canvas/SelectionOverlay'
 import Viewport from './canvas/Viewport'
 import HUDContainer from './hud/HUDContainer'
@@ -19,8 +21,12 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
   const { setRect } = useRects()
   const ref = useRef<HTMLDivElement>(null)
-  const Comp = (registry as any)[node.type] || ((p:any)=><div {...p}>{p.children}</div>)
+  const Comp = (registry as any)[node.type] || ((p: any) => <div {...p}>{p.children}</div>)
   const style = node.props?.style || {}
+
+  const effects = (node.props?.hoverEffects as HoverEffect[] | undefined) ?? []
+  const transitionMs = (node.props?.hoverTransitionMs as number | undefined) ?? 120
+  const css = effects.length ? buildHoverCss(node.id, effects, transitionMs) : ''
 
   useEffect(() => {
     const el = ref.current
@@ -47,6 +53,7 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
           <NodeRenderer key={child.id} node={child} />
         ))}
       </Comp>
+      {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
     </div>
   )
 }

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -13,6 +13,8 @@ import { mapNodesForSwap } from "@/lib/override/compat";
 import { listOverridable } from "@/lib/override/util";
 import { findNode } from "@/lib/tree";
 import ExportPanel from "@/components/editor/ExportPanel";
+import { HoverEffectsSection } from "@/components/props/HoverEffectsSection";
+import type { HoverEffect } from "@/types/interactions";
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedIds[0]);
@@ -332,6 +334,19 @@ export default function RightPane() {
             )}
           </div>
         </div>
+      </div>
+
+      <div>
+        <HoverEffectsSection
+          value={inst.props?.hoverEffects as HoverEffect[] | undefined}
+          onChange={(next) =>
+            updateNode(inst.id, { props: { ...(inst.props || {}), hoverEffects: next } })
+          }
+          transitionMs={inst.props?.hoverTransitionMs ?? 120}
+          onChangeTransition={(ms) =>
+            updateNode(inst.id, { props: { ...(inst.props || {}), hoverTransitionMs: ms } })
+          }
+        />
       </div>
 
       <div>

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -8,6 +8,8 @@ import { applyOverrides } from '@/lib/overrideMerge';
 import { resolveBinding } from '@/lib/binding/resolve';
 import { PresenterHUD } from '@/components/preview/PresenterHUD';
 import { buildPoseMap, diffPoses, easeStandard } from '@/lib/animate/smart';
+import { buildHoverCss } from '@/lib/hoverCss';
+import type { HoverEffect } from '@/types/interactions';
 
 function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: PrototypeLink) => void }) {
   const components = useEditorStore((s) => s.components);
@@ -35,6 +37,9 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
   }
   if (node.props?.w !== undefined) style.width = node.props.w;
   if (node.props?.h !== undefined) style.height = node.props.h;
+  const effects = (node.props?.hoverEffects as HoverEffect[] | undefined) ?? [];
+  const transitionMs = (node.props?.hoverTransitionMs as number | undefined) ?? 120;
+  const css = effects.length ? buildHoverCss(node.id, effects, transitionMs) : '';
   const link = node.prototypeLink;
   const handleClick = (e: any) => {
     if (!link) return;
@@ -66,6 +71,7 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         className={link ? 'cursor-pointer' : undefined}
       >
         <div className="w-full h-full bg-gray-300" />
+        {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
       </div>
     );
   }
@@ -81,6 +87,7 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         className={link ? 'cursor-pointer' : undefined}
       >
         {node.props?.text}
+        {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
       </div>
     );
   }
@@ -97,6 +104,7 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       {node.children?.map((c) => (
         <NodeRenderer key={c.id} node={c} onLink={onLink} />
       ))}
+      {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
     </div>
   );
 }

--- a/web/components/props/HoverEffectsSection.tsx
+++ b/web/components/props/HoverEffectsSection.tsx
@@ -1,0 +1,271 @@
+'use client'
+import React from 'react'
+import type { HoverEffect } from '@/types/interactions'
+import { defaultEffect } from '@/types/interactions'
+
+type Props = {
+  value: HoverEffect[] | undefined
+  onChange: (next: HoverEffect[]) => void
+  transitionMs?: number
+  onChangeTransition?: (ms: number) => void
+}
+
+const OPTIONS: { key: HoverEffect['kind']; label: string }[] = [
+  { key: 'bgColor', label: '背景色' },
+  { key: 'textColor', label: '文字色' },
+  { key: 'borderColor', label: '枠線色' },
+  { key: 'shadow', label: 'シャドウ' },
+  { key: 'scale', label: '拡大縮小' },
+  { key: 'opacity', label: '透明度' },
+  { key: 'translate', label: '移動（px）' },
+  { key: 'rotate', label: '回転（deg）' },
+  { key: 'outline', label: 'アウトライン' },
+  { key: 'cursor', label: 'カーソル' },
+]
+
+export function HoverEffectsSection({ value, onChange, transitionMs = 120, onChangeTransition }: Props) {
+  const effects = value ?? []
+  const [pick, setPick] = React.useState<HoverEffect['kind']>('scale')
+
+  const add = () => onChange([...(effects), defaultEffect(pick)])
+  const remove = (i: number) => onChange(effects.filter((_, idx) => idx !== i))
+  const patch = <K extends keyof HoverEffect>(i: number, key: K, v: any) => {
+    const next = effects.slice()
+    next[i] = { ...next[i], [key]: v } as HoverEffect
+    onChange(next)
+  }
+
+  return (
+    <div className="mt-3 rounded border border-neutral-700 p-2">
+      <div className="mb-2 text-xs font-semibold text-neutral-300">Hover（ホバー時の見た目）</div>
+
+      <div className="flex items-center gap-2 mb-2">
+        <select
+          className="bg-neutral-800 text-neutral-100 rounded px-2 py-1 text-xs"
+          value={pick}
+          onChange={(e) => setPick(e.target.value as any)}
+        >
+          {OPTIONS.map((o) => (
+            <option key={o.key} value={o.key}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <button
+          className="px-2 py-1 rounded bg-neutral-700 text-xs hover:bg-neutral-600"
+          onClick={add}
+        >
+          追加
+        </button>
+
+        <div className="ml-auto flex items-center gap-1 text-xs">
+          <span>transition</span>
+          <input
+            type="number"
+            min={0}
+            step={10}
+            value={transitionMs}
+            onChange={(e) => onChangeTransition?.(parseInt(e.target.value || '0', 10))}
+            className="w-16 bg-neutral-800 rounded px-1 py-[2px]"
+          />
+          <span>ms</span>
+        </div>
+      </div>
+
+      {!effects.length && (
+        <div className="text-[11px] text-neutral-400">（追加してね）</div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {effects.map((ef, i) => (
+          <div key={i} className="rounded bg-neutral-900/60 p-2 border border-neutral-700">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs text-neutral-300">
+                {OPTIONS.find((o) => o.key === ef.kind)?.label}
+              </div>
+              <button
+                className="text-[10px] text-red-300 hover:text-red-200"
+                onClick={() => remove(i)}
+              >
+                削除
+              </button>
+            </div>
+
+            {ef.kind === 'bgColor' && (
+              <ColorRow label="背景色" value={ef.value} onChange={(v) => patch(i, 'value', v)} />
+            )}
+            {ef.kind === 'textColor' && (
+              <ColorRow label="文字色" value={ef.value} onChange={(v) => patch(i, 'value', v)} />
+            )}
+            {ef.kind === 'borderColor' && (
+              <ColorRow label="枠線色" value={ef.value} onChange={(v) => patch(i, 'value', v)} />
+            )}
+            {ef.kind === 'shadow' && (
+              <SelectRow
+                label="シャドウ"
+                value={ef.value}
+                options={['sm', 'md', 'lg', 'xl']}
+                onChange={(v) => patch(i, 'value', v)}
+              />
+            )}
+            {ef.kind === 'scale' && (
+              <NumRow
+                label="倍率"
+                min={0.5}
+                max={2}
+                step={0.01}
+                value={ef.value}
+                onChange={(v) => patch(i, 'value', v)}
+              />
+            )}
+            {ef.kind === 'opacity' && (
+              <NumRow
+                label="不透明度"
+                min={0}
+                max={1}
+                step={0.05}
+                value={ef.value}
+                onChange={(v) => patch(i, 'value', v)}
+              />
+            )}
+            {ef.kind === 'translate' && (
+              <div className="flex gap-2">
+                <NumRow
+                  label="x(px)"
+                  min={-200}
+                  max={200}
+                  step={1}
+                  value={ef.x ?? 0}
+                  onChange={(v) => patch(i, 'x', v)}
+                />
+                <NumRow
+                  label="y(px)"
+                  min={-200}
+                  max={200}
+                  step={1}
+                  value={ef.y ?? 0}
+                  onChange={(v) => patch(i, 'y', v)}
+                />
+              </div>
+            )}
+            {ef.kind === 'rotate' && (
+              <NumRow
+                label="角度(deg)"
+                min={-45}
+                max={45}
+                step={1}
+                value={ef.deg}
+                onChange={(v) => patch(i, 'deg', v)}
+              />
+            )}
+            {ef.kind === 'outline' && (
+              <div className="flex flex-wrap items-center gap-2">
+                <ColorRow label="色" value={ef.color} onChange={(v) => patch(i, 'color', v)} />
+                <NumRow
+                  label="太さ(px)"
+                  min={0}
+                  max={8}
+                  step={1}
+                  value={ef.width}
+                  onChange={(v) => patch(i, 'width', v)}
+                />
+                <SelectRow
+                  label="スタイル"
+                  value={ef.style ?? 'solid'}
+                  options={['solid', 'dashed', 'dotted']}
+                  onChange={(v) => patch(i, 'style', v as any)}
+                />
+              </div>
+            )}
+            {ef.kind === 'cursor' && (
+              <SelectRow
+                label="カーソル"
+                value={ef.value}
+                options={['default', 'pointer', 'move', 'grab', 'text']}
+                onChange={(v) => patch(i, 'value', v as any)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ColorRow({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-16 text-neutral-400">{label}</span>
+      <input
+        type="color"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-6 w-10 bg-transparent border border-neutral-700 rounded"
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="flex-1 bg-neutral-800 rounded px-2 py-[2px]"
+      />
+    </div>
+  )
+}
+function NumRow({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  onChange: (v: number) => void
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-16 text-neutral-400">{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-24 bg-neutral-800 rounded px-2 py-[2px]"
+      />
+    </div>
+  )
+}
+function SelectRow({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: string[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-16 text-neutral-400">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="bg-neutral-800 rounded px-2 py-[2px]"
+      >
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/web/lib/hoverCss.ts
+++ b/web/lib/hoverCss.ts
@@ -1,0 +1,56 @@
+import type { HoverEffect } from '@/types/interactions'
+
+const shadowMap = {
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+} as const
+
+const esc = (id: string) => CSS.escape(id)
+
+export function buildHoverCss(nodeId: string, effects: HoverEffect[] = [], transitionMs = 120) {
+  if (!effects.length) return ''
+  let decls: string[] = []
+  let transforms: string[] = []
+
+  for (const ef of effects) {
+    switch (ef.kind) {
+      case 'bgColor':
+        decls.push(`background-color:${ef.value} !important`)
+        break
+      case 'textColor':
+        decls.push(`color:${ef.value} !important`)
+        break
+      case 'borderColor':
+        decls.push(`border-color:${ef.value} !important`)
+        break
+      case 'shadow':
+        decls.push(`box-shadow:${shadowMap[ef.value]} !important`)
+        break
+      case 'scale':
+        transforms.push(`scale(${ef.value})`)
+        break
+      case 'opacity':
+        decls.push(`opacity:${ef.value}`)
+        break
+      case 'translate':
+        transforms.push(`translate(${ef.x ?? 0}px, ${ef.y ?? 0}px)`)
+        break
+      case 'rotate':
+        transforms.push(`rotate(${ef.deg}deg)`)
+        break
+      case 'outline':
+        decls.push(`outline:${ef.width}px ${ef.style ?? 'solid'} ${ef.color}`)
+        decls.push('outline-offset:0')
+        break
+      case 'cursor':
+        decls.push(`cursor:${ef.value}`)
+        break
+    }
+  }
+  if (transforms.length) decls.push(`transform:${transforms.join(' ')} !important`)
+  decls.push(`transition: all ${transitionMs}ms cubic-bezier(.2,.8,.2,1)`)
+
+  return `[data-node-id="${esc(nodeId)}"]:hover{${decls.join(';')}}`
+}

--- a/web/types/interactions.ts
+++ b/web/types/interactions.ts
@@ -1,0 +1,36 @@
+export type HoverEffect =
+  | { kind: 'bgColor'; value: string }
+  | { kind: 'textColor'; value: string }
+  | { kind: 'borderColor'; value: string }
+  | { kind: 'shadow'; value: 'sm' | 'md' | 'lg' | 'xl' }
+  | { kind: 'scale'; value: number }
+  | { kind: 'opacity'; value: number }
+  | { kind: 'translate'; x?: number; y?: number }
+  | { kind: 'rotate'; deg: number }
+  | { kind: 'outline'; color: string; width: number; style?: 'solid' | 'dashed' | 'dotted' }
+  | { kind: 'cursor'; value: 'default' | 'pointer' | 'move' | 'grab' | 'text' }
+
+export const defaultEffect = (k: HoverEffect['kind']): HoverEffect => {
+  switch (k) {
+    case 'bgColor':
+      return { kind: 'bgColor', value: '#0f172a' }
+    case 'textColor':
+      return { kind: 'textColor', value: '#e5e7eb' }
+    case 'borderColor':
+      return { kind: 'borderColor', value: '#334155' }
+    case 'shadow':
+      return { kind: 'shadow', value: 'md' }
+    case 'scale':
+      return { kind: 'scale', value: 1.05 }
+    case 'opacity':
+      return { kind: 'opacity', value: 0.9 }
+    case 'translate':
+      return { kind: 'translate', x: 0, y: -2 }
+    case 'rotate':
+      return { kind: 'rotate', deg: 1 }
+    case 'outline':
+      return { kind: 'outline', color: '#22d3ee', width: 1, style: 'dashed' }
+    case 'cursor':
+      return { kind: 'cursor', value: 'pointer' }
+  }
+}


### PR DESCRIPTION
## Summary
- add HoverEffect types and defaults
- support building hover CSS
- expose hover effects editor and inject style rules

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68afe3840464832ca6c0da538261ff45