### PR TITLE
feat: sync action presets across tabs and broadcast apply to editor

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -4,6 +4,7 @@ import { useInteractionRegistry } from '@/store/interactionRegistry'
 import { defaultEffect } from '@/types/interactions'
 import type { Effect, InteractionPreset, Trigger } from '@/types/interactions'
 import { buildPresetCss } from '@/lib/interactionCss'
+import { emitApply } from '@/lib/presetChannel'
 
 const ALL_TRIGGERS: Trigger[] = ['hover','active','focus','focusWithin','groupHover']
 const EFFECT_OPTIONS: Effect['kind'][] = ['bgColor','textColor','borderColor','shadow','scale','opacity','translate','rotate','outline','cursor']
@@ -67,6 +68,15 @@ export default function ActionDesignerPage() {
                 <button className="px-2 py-1 bg-red-600/80 rounded" onClick={()=>remove(sel.id)}>Delete</button>
                 <div className="ml-auto text-[12px] text-neutral-400">updated {new Date(sel.updatedAt).toLocaleString()}</div>
               </div>
+
+              {sel && (
+                <div className="mt-3 flex items-center gap-2">
+                  <span className="text-xs text-neutral-400">Apply to selection on Editor:</span>
+                  <button className="px-2 py-1 bg-sky-600/80 rounded text-sm" onClick={()=>emitApply(sel.id, 'replace')}>Replace</button>
+                  <button className="px-2 py-1 bg-neutral-800 rounded text-sm" onClick={()=>emitApply(sel.id, 'append')}>Append</button>
+                  <button className="px-2 py-1 bg-rose-700/80 rounded text-sm" onClick={()=>emitApply(sel.id, 'remove')}>Remove</button>
+                </div>
+              )}
 
               {/* Trigger */}
               <div className="mt-3 text-xs text-neutral-300">Triggers</div>

--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -13,6 +13,7 @@ import { DeviceFrame } from '@/components/hud/DeviceFrame';
 import { GridOverlay } from '@/components/hud/GridOverlay';
 import { RulersOverlay } from '@/components/hud/RulersOverlay';
 import { BuilderHUD } from '@/components/hud/BuilderHUD';
+import { PresetApplyListener } from '@/components/editor/PresetApplyListener';
 
 export default function EditorShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -83,6 +84,7 @@ export default function EditorShell() {
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <ContextMenu />
       <BuilderHUD />
+      <PresetApplyListener />
     </>
   );
 }

--- a/web/components/editor/PresetApplyListener.tsx
+++ b/web/components/editor/PresetApplyListener.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { useEffect } from 'react'
+import { subscribeApply } from '@/lib/presetChannel'
+import { useEditorStore } from '@/store/editorStore'
+import { findNode } from '@/lib/tree'
+
+function useApplyPresetToSelection() {
+  const selectedIds = useEditorStore((s) => s.selectedIds || [])
+  const updateNode = useEditorStore((s) => s.updateNode)
+
+  return (presetId: string, mode: 'replace'|'append'|'remove') => {
+    if (!selectedIds.length) return
+    for (const id of selectedIds) {
+      const node = findNode(useEditorStore.getState().tree, id)
+      const cur: string[] =
+        (node?.props?.presetIds as string[] | undefined) ||
+        (node?.props?.presetId ? [node.props.presetId as string] : []) ||
+        []
+      let next = cur
+      if (mode === 'replace') {
+        next = [presetId]
+      } else if (mode === 'append') {
+        next = Array.from(new Set([...cur, presetId]))
+      } else if (mode === 'remove') {
+        next = cur.filter((x) => x !== presetId)
+      }
+      const props: any = { ...(node?.props || {}), presetIds: next }
+      if (mode !== 'remove') props.presetId = presetId
+      if (mode === 'remove' && cur.length <= 1) props.presetId = null
+      updateNode(id, { props })
+    }
+  }
+}
+
+export function PresetApplyListener() {
+  const apply = useApplyPresetToSelection()
+
+  useEffect(() => {
+    return subscribeApply((m) => apply(m.presetId, m.mode))
+  }, [apply])
+
+  return null
+}

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -340,9 +340,14 @@ export default function RightPane() {
       <div>
         <ActionPresetPicker
           nodeId={inst.id}
-          value={inst.props?.presetId as string | undefined}
-          onChange={(id) =>
-            updateNode(inst.id, { props: { ...(inst.props || {}), presetId: id } })
+          valueIds={
+            (inst.props?.presetIds as string[] | undefined) ||
+            (inst.props?.presetId ? [inst.props.presetId as string] : [])
+          }
+          onChange={(ids) =>
+            updateNode(inst.id, {
+              props: { ...(inst.props || {}), presetIds: ids, presetId: ids[0] ?? null },
+            })
           }
         />
         <HoverEffectsSection

--- a/web/components/props/ActionPresetPicker.tsx
+++ b/web/components/props/ActionPresetPicker.tsx
@@ -1,25 +1,44 @@
 'use client'
 import { useInteractionRegistry } from '@/store/interactionRegistry'
 
-export function ActionPresetPicker({ nodeId, value, onChange }:{
+export function ActionPresetPicker({ nodeId, valueIds, onChange }:{
   nodeId: string
-  value?: string | null
-  onChange: (id: string | null) => void
+  valueIds?: string[]
+  onChange: (ids: string[]) => void
 }) {
   const { presets } = useInteractionRegistry()
+  const ids = valueIds ?? []
+
+  const add = (id: string) => onChange(Array.from(new Set([...ids, id])))
+  const remove = (id: string) => onChange(ids.filter(x => x !== id))
+
   return (
     <div className="mt-3">
-      <div className="text-xs text-neutral-300 mb-1">Action Preset</div>
+      <div className="text-xs text-neutral-300 mb-1">Action Presets</div>
       <div className="flex gap-2">
         <select
           className="flex-1 bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
-          value={value ?? ''}
-          onChange={(e)=>onChange(e.target.value || null)}
+          onChange={(e)=> e.target.value && add(e.target.value)}
+          value=""
         >
-          <option value="">（なし）</option>
+          <option value="">（追加…）</option>
           {presets.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
         </select>
         <a href="/dev/actions" className="px-2 py-1 bg-neutral-800 rounded text-xs">Open Designer</a>
+      </div>
+
+      {/* 適用中のプリセット（削除可能） */}
+      <div className="mt-2 flex flex-wrap gap-1">
+        {ids.map(id => {
+          const p = presets.find(x => x.id === id)
+          return (
+            <span key={id} className="px-2 py-[2px] rounded bg-neutral-800 text-xs">
+              {p?.name ?? id}
+              <button className="ml-1 text-rose-300" onClick={()=>remove(id)}>×</button>
+            </span>
+          )
+        })}
+        {!ids.length && <span className="text-[11px] text-neutral-500">（未適用）</span>}
       </div>
     </div>
   )

--- a/web/lib/presetChannel.ts
+++ b/web/lib/presetChannel.ts
@@ -1,0 +1,17 @@
+export type ApplyMode = 'replace'|'append'|'remove'
+export type PresetMsg = { type: 'apply'; presetId: string; mode: ApplyMode }
+
+export function emitApply(presetId: string, mode: ApplyMode) {
+  const ch = new BroadcastChannel('action-presets')
+  ch.postMessage({ type: 'apply', presetId, mode } as PresetMsg)
+  ch.close()
+}
+
+export function subscribeApply(onMsg: (m: PresetMsg) => void) {
+  const ch = new BroadcastChannel('action-presets')
+  ch.onmessage = (ev) => {
+    const m = ev.data as PresetMsg
+    if (m?.type === 'apply') onMsg(m)
+  }
+  return () => ch.close()
+}

--- a/web/store/interactionRegistry.ts
+++ b/web/store/interactionRegistry.ts
@@ -74,4 +74,13 @@ export const useInteractionRegistry = create<State>((set, get) => ({
 if (typeof window !== 'undefined') {
   const init = load()
   if (init?.length) useInteractionRegistry.setState({ presets: init, selectedId: init[0]?.id })
+
+  // 他タブで保存された内容を即時反映
+  window.addEventListener('storage', (e) => {
+    if (e.key !== KEY) return
+    try {
+      const next = JSON.parse(e.newValue || '[]')
+      useInteractionRegistry.setState({ presets: next })
+    } catch {}
+  })
 }


### PR DESCRIPTION
## Summary
- sync action presets across tabs via storage events
- bridge preset apply events between designer and editor with BroadcastChannel
- allow picking multiple action presets and apply them to selection

## Testing
- `pnpm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68b01b59625c832c94a59287ab59a833