### PR TITLE
feat: add project default action presets

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -78,9 +78,11 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
     }
   }
 
-  const { presets } = useInteractionRegistry();
-  const presetIds: string[] = (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[];
-  const chosen = presets.filter(p => presetIds.includes(p.id));
+  const { presets, projectDefaultPresetIds } = useInteractionRegistry();
+  const ownIds: string[] =
+    (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[];
+  const ids = ownIds.length ? ownIds : projectDefaultPresetIds;
+  const chosen = presets.filter((p) => ids.includes(p.id));
   const inlineHover = node.props?.hoverEffects as Effect[] | undefined;
   const inlineMs = node.props?.hoverTransitionMs as number | undefined;
   const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs);

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -70,11 +70,51 @@ export default function ActionDesignerPage() {
               </div>
 
               {sel && (
-                <div className="mt-3 flex items-center gap-2">
-                  <span className="text-xs text-neutral-400">Apply to selection on Editor:</span>
-                  <button className="px-2 py-1 bg-sky-600/80 rounded text-sm" onClick={()=>emitApply(sel.id, 'replace')}>Replace</button>
-                  <button className="px-2 py-1 bg-neutral-800 rounded text-sm" onClick={()=>emitApply(sel.id, 'append')}>Append</button>
-                  <button className="px-2 py-1 bg-rose-700/80 rounded text-sm" onClick={()=>emitApply(sel.id, 'remove')}>Remove</button>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <span className="text-xs text-neutral-400">Apply:</span>
+                  <button
+                    className="px-2 py-1 bg-sky-600/80 rounded text-sm"
+                    onClick={() => emitApply(sel.id, 'replace', 'selection')}
+                  >
+                    Replace Selection
+                  </button>
+                  <button
+                    className="px-2 py-1 bg-neutral-800 rounded text-sm"
+                    onClick={() => emitApply(sel.id, 'append', 'selection')}
+                  >
+                    Append Selection
+                  </button>
+                  <button
+                    className="px-2 py-1 bg-rose-700/80 rounded text-sm"
+                    onClick={() => emitApply(sel.id, 'remove', 'selection')}
+                  >
+                    Remove Selection
+                  </button>
+
+                  <div className="w-px h-5 bg-neutral-700 mx-1" />
+
+                  <button
+                    className="px-2 py-1 bg-sky-700/80 rounded text-sm"
+                    onClick={() => emitApply(sel.id, 'replace', 'all')}
+                  >
+                    Replace All
+                  </button>
+                  <button
+                    className="px-2 py-1 bg-neutral-800 rounded text-sm"
+                    onClick={() => emitApply(sel.id, 'append', 'all')}
+                  >
+                    Append All
+                  </button>
+                  <button
+                    className="px-2 py-1 bg-rose-800/80 rounded text-sm"
+                    onClick={() => emitApply(sel.id, 'remove', 'all')}
+                  >
+                    Remove All
+                  </button>
+
+                  <div className="w-px h-5 bg-neutral-700 mx-1" />
+
+                  <ProjectDefaultPicker currentId={sel.id} />
                 </div>
               )}
 
@@ -132,6 +172,37 @@ export default function ActionDesignerPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+function ProjectDefaultPicker({ currentId }: { currentId: string }) {
+  const { projectDefaultPresetIds, setProjectDefaults } = useInteractionRegistry()
+  const onToggle = () => {
+    const has = projectDefaultPresetIds.includes(currentId)
+    const next = has
+      ? projectDefaultPresetIds.filter((id) => id !== currentId)
+      : [...projectDefaultPresetIds, currentId]
+    setProjectDefaults(next)
+  }
+  const onSetOnlyThis = () => setProjectDefaults([currentId])
+
+  return (
+    <>
+      <button
+        className="px-2 py-1 bg-emerald-700/80 rounded text-sm"
+        onClick={onSetOnlyThis}
+      >
+        Set as Project Default
+      </button>
+      <button
+        className="px-2 py-1 bg-neutral-800 rounded text-sm"
+        onClick={onToggle}
+      >
+        {projectDefaultPresetIds.includes(currentId)
+          ? 'Remove from Defaults'
+          : 'Add to Defaults'}
+      </button>
+    </>
   )
 }
 

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -25,9 +25,11 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
   const Comp = (registry as any)[node.type] || ((p: any) => <div {...p}>{p.children}</div>)
   const style = node.props?.style || {}
 
-  const { presets } = useInteractionRegistry()
-  const presetIds: string[] = (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[]
-  const chosen = presets.filter(p => presetIds.includes(p.id))
+  const { presets, projectDefaultPresetIds } = useInteractionRegistry()
+  const ownIds: string[] =
+    (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[]
+  const ids = ownIds.length ? ownIds : projectDefaultPresetIds
+  const chosen = presets.filter(p => ids.includes(p.id))
   const inlineHover = node.props?.hoverEffects as Effect[] | undefined
   const inlineMs = node.props?.hoverTransitionMs as number | undefined
   const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs)

--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -84,7 +84,7 @@ export default function EditorShell() {
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <ContextMenu />
       <BuilderHUD />
-      <PresetApplyListener />
+      <PresetApplyListener canvasRef={canvasRef} />
     </>
   );
 }

--- a/web/components/editor/PresetApplyListener.tsx
+++ b/web/components/editor/PresetApplyListener.tsx
@@ -1,43 +1,53 @@
 'use client'
 import { useEffect } from 'react'
 import { subscribeApply } from '@/lib/presetChannel'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
 import { useEditorStore } from '@/store/editorStore'
 import { findNode } from '@/lib/tree'
 
-function useApplyPresetToSelection() {
-  const selectedIds = useEditorStore((s) => s.selectedIds || [])
-  const updateNode = useEditorStore((s) => s.updateNode)
-
-  return (presetId: string, mode: 'replace'|'append'|'remove') => {
-    if (!selectedIds.length) return
-    for (const id of selectedIds) {
-      const node = findNode(useEditorStore.getState().tree, id)
-      const cur: string[] =
-        (node?.props?.presetIds as string[] | undefined) ||
-        (node?.props?.presetId ? [node.props.presetId as string] : []) ||
-        []
-      let next = cur
-      if (mode === 'replace') {
-        next = [presetId]
-      } else if (mode === 'append') {
-        next = Array.from(new Set([...cur, presetId]))
-      } else if (mode === 'remove') {
-        next = cur.filter((x) => x !== presetId)
-      }
-      const props: any = { ...(node?.props || {}), presetIds: next }
-      if (mode !== 'remove') props.presetId = presetId
-      if (mode === 'remove' && cur.length <= 1) props.presetId = null
-      updateNode(id, { props })
-    }
-  }
+function getAllNodeIdsFromDOM(root: HTMLElement) {
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-node-id]'))
+    .map(el => el.dataset.nodeId!)
+    .filter(Boolean)
 }
 
-export function PresetApplyListener() {
-  const apply = useApplyPresetToSelection()
+function applyIds(ids: string[], presetId: string, mode: 'replace'|'append'|'remove') {
+  const updateNode = useEditorStore.getState().updateNode
+  const tree = useEditorStore.getState().tree
+  ids.forEach((id) => {
+    const node = findNode(tree, id) as any
+    const cur: string[] =
+      node?.props?.presetIds ??
+      (node?.props?.presetId ? [node.props.presetId] : []) ??
+      []
+    let next = cur
+    if (mode === 'replace') next = [presetId]
+    if (mode === 'append') next = Array.from(new Set([...cur, presetId]))
+    if (mode === 'remove') next = cur.filter(x => x !== presetId)
+    const props: any = { ...(node?.props || {}), presetIds: next }
+    if (mode !== 'remove') props.presetId = presetId
+    if (mode === 'remove' && cur.length <= 1) props.presetId = null
+    updateNode(id, { props })
+  })
+}
 
+export function PresetApplyListener({ canvasRef }:{ canvasRef: React.RefObject<HTMLElement> }) {
+  const { setProjectDefaults } = useInteractionRegistry()
   useEffect(() => {
-    return subscribeApply((m) => apply(m.presetId, m.mode))
-  }, [apply])
-
+    return subscribeApply((m) => {
+      if (m.scope === 'set-project-default') {
+        setProjectDefaults([m.presetId])
+        return
+      }
+      const root = canvasRef.current || document.body
+      if (!root) return
+      if (m.scope === 'all') {
+        applyIds(getAllNodeIdsFromDOM(root), m.presetId, m.mode)
+      } else {
+        const selected = (useEditorStore.getState().selectedIds as string[]) || []
+        if (selected.length) applyIds(selected, m.presetId, m.mode)
+      }
+    })
+  }, [canvasRef, setProjectDefaults])
   return null
 }

--- a/web/components/editor/RightPane.tsx
+++ b/web/components/editor/RightPane.tsx
@@ -341,12 +341,12 @@ export default function RightPane() {
         <ActionPresetPicker
           nodeId={inst.id}
           valueIds={
-            (inst.props?.presetIds as string[] | undefined) ||
-            (inst.props?.presetId ? [inst.props.presetId as string] : [])
+            (inst.props?.presetIds as string[] | undefined) ??
+            (inst.props?.presetId ? [inst.props.presetId as string] : undefined)
           }
           onChange={(ids) =>
             updateNode(inst.id, {
-              props: { ...(inst.props || {}), presetIds: ids, presetId: ids[0] ?? null },
+              props: { ...(inst.props || {}), presetIds: ids, presetId: ids?.[0] ?? null },
             })
           }
         />

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -38,9 +38,11 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
   }
   if (node.props?.w !== undefined) style.width = node.props.w;
   if (node.props?.h !== undefined) style.height = node.props.h;
-  const { presets } = useInteractionRegistry();
-  const presetIds: string[] = (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[];
-  const chosen = presets.filter(p => presetIds.includes(p.id));
+  const { presets, projectDefaultPresetIds } = useInteractionRegistry();
+  const ownIds: string[] =
+    (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[];
+  const ids = ownIds.length ? ownIds : projectDefaultPresetIds;
+  const chosen = presets.filter((p) => ids.includes(p.id));
   const inlineHover = node.props?.hoverEffects as Effect[] | undefined;
   const inlineMs = node.props?.hoverTransitionMs as number | undefined;
   const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs);

--- a/web/components/props/ActionPresetPicker.tsx
+++ b/web/components/props/ActionPresetPicker.tsx
@@ -4,41 +4,34 @@ import { useInteractionRegistry } from '@/store/interactionRegistry'
 export function ActionPresetPicker({ nodeId, valueIds, onChange }:{
   nodeId: string
   valueIds?: string[]
-  onChange: (ids: string[]) => void
+  onChange: (ids: string[] | undefined) => void // undefined = 既定に従う
 }) {
-  const { presets } = useInteractionRegistry()
+  const { presets, projectDefaultPresetIds } = useInteractionRegistry()
   const ids = valueIds ?? []
 
-  const add = (id: string) => onChange(Array.from(new Set([...ids, id])))
-  const remove = (id: string) => onChange(ids.filter(x => x !== id))
+  const add = (id: string) => onChange(Array.from(new Set([...(ids || []), id])))
+  const remove = (id: string) => onChange((ids || []).filter(x => x !== id))
 
   return (
     <div className="mt-3">
       <div className="text-xs text-neutral-300 mb-1">Action Presets</div>
       <div className="flex gap-2">
-        <select
-          className="flex-1 bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
-          onChange={(e)=> e.target.value && add(e.target.value)}
-          value=""
-        >
+        <select className="flex-1 bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm" onChange={(e)=> e.target.value && add(e.target.value)} value="">
           <option value="">（追加…）</option>
           {presets.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
         </select>
         <a href="/dev/actions" className="px-2 py-1 bg-neutral-800 rounded text-xs">Open Designer</a>
       </div>
-
-      {/* 適用中のプリセット（削除可能） */}
       <div className="mt-2 flex flex-wrap gap-1">
-        {ids.map(id => {
+        {(ids.length ? ids : projectDefaultPresetIds).map(id => {
           const p = presets.find(x => x.id === id)
-          return (
-            <span key={id} className="px-2 py-[2px] rounded bg-neutral-800 text-xs">
-              {p?.name ?? id}
-              <button className="ml-1 text-rose-300" onClick={()=>remove(id)}>×</button>
-            </span>
-          )
+          return <span key={id} className="px-2 py-[2px] rounded bg-neutral-800 text-xs">{p?.name ?? id}{ids.length ? <button className="ml-1 text-rose-300" onClick={()=>remove(id)}>×</button> : null}</span>
         })}
-        {!ids.length && <span className="text-[11px] text-neutral-500">（未適用）</span>}
+        {!ids.length && <span className="text-[11px] text-neutral-500">(project default)</span>}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <button className="px-2 py-1 bg-neutral-800 rounded text-xs" onClick={()=>onChange(undefined)}>Use Project Default</button>
+        <button className="px-2 py-1 bg-rose-700/80 rounded text-xs" onClick={()=>onChange([])}>Clear (No Preset)</button>
       </div>
     </div>
   )

--- a/web/lib/presetChannel.ts
+++ b/web/lib/presetChannel.ts
@@ -1,9 +1,19 @@
-export type ApplyMode = 'replace'|'append'|'remove'
-export type PresetMsg = { type: 'apply'; presetId: string; mode: ApplyMode }
+export type ApplyMode = 'replace' | 'append' | 'remove'
+export type ApplyScope = 'selection' | 'all' | 'set-project-default'
+export type PresetMsg = {
+  type: 'apply'
+  presetId: string
+  mode: ApplyMode
+  scope: ApplyScope
+}
 
-export function emitApply(presetId: string, mode: ApplyMode) {
+export function emitApply(
+  presetId: string,
+  mode: ApplyMode,
+  scope: ApplyScope = 'selection',
+) {
   const ch = new BroadcastChannel('action-presets')
-  ch.postMessage({ type: 'apply', presetId, mode } as PresetMsg)
+  ch.postMessage({ type: 'apply', presetId, mode, scope } satisfies PresetMsg)
   ch.close()
 }
 

--- a/web/store/interactionRegistry.ts
+++ b/web/store/interactionRegistry.ts
@@ -4,6 +4,8 @@ import type { InteractionPreset } from '../types/interactions'
 type State = {
   presets: InteractionPreset[]
   selectedId?: string
+  projectDefaultPresetIds: string[]
+  setProjectDefaults: (ids: string[]) => void
   add(p: Omit<InteractionPreset,'id'|'updatedAt'> & { id?: string }): string
   update(id: string, patch: Partial<InteractionPreset>): void
   remove(id: string): void
@@ -26,6 +28,14 @@ function save(presets: InteractionPreset[]) {
 export const useInteractionRegistry = create<State>((set, get) => ({
   presets: [],
   selectedId: undefined,
+  projectDefaultPresetIds: [],
+
+  setProjectDefaults: (ids) => {
+    set({ projectDefaultPresetIds: ids })
+    try {
+      localStorage.setItem(KEY + '-defaults', JSON.stringify(ids))
+    } catch {}
+  },
 
   add: (p) => {
     const id = p.id ?? uid()
@@ -73,14 +83,23 @@ export const useInteractionRegistry = create<State>((set, get) => ({
 // 初回ハイドレーション
 if (typeof window !== 'undefined') {
   const init = load()
-  if (init?.length) useInteractionRegistry.setState({ presets: init, selectedId: init[0]?.id })
+  useInteractionRegistry.setState({
+    presets: init,
+    selectedId: init[0]?.id,
+    projectDefaultPresetIds: JSON.parse(localStorage.getItem(KEY + '-defaults') || '[]') ?? [],
+  })
 
   // 他タブで保存された内容を即時反映
   window.addEventListener('storage', (e) => {
-    if (e.key !== KEY) return
-    try {
-      const next = JSON.parse(e.newValue || '[]')
-      useInteractionRegistry.setState({ presets: next })
-    } catch {}
+    if (e.key === KEY) {
+      try {
+        useInteractionRegistry.setState({ presets: JSON.parse(e.newValue || '[]') })
+      } catch {}
+    }
+    if (e.key === KEY + '-defaults') {
+      try {
+        useInteractionRegistry.setState({ projectDefaultPresetIds: JSON.parse(e.newValue || '[]') })
+      } catch {}
+    }
   })
 }


### PR DESCRIPTION
## Summary
- expand preset apply channel with selection, all and project-default scopes
- store project default preset IDs and allow designer UI to set them
- apply project default presets to nodes without explicit presets and update pickers

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d5dbf28832c867864dc77a287f9