### PR TITLE
feat: gate canvas interactions during edits

### DIFF
--- a/lib/interactionCss.ts
+++ b/lib/interactionCss.ts
@@ -8,6 +8,11 @@ const shadowMap = {
 } as const
 
 const esc = (s: string) => (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(s) : s)
+const GATE = '[data-actions-enabled="true"]'
+
+function target(nodeId: string) {
+  return `${GATE} [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
+}
 
 function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-bezier(.2,.8,.2,1)') {
   const decls: string[] = []
@@ -32,13 +37,18 @@ function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-b
 }
 
 function triggerSelector(nodeId: string, t: Trigger) {
-  const base = `[data-node-id="${esc(nodeId)}"]`
+  const base = target(nodeId)
   switch (t) {
-    case 'hover':        return `${base}:hover`
-    case 'active':       return `${base}:active`
-    case 'focus':        return `${base}:focus`
-    case 'focusWithin':  return `${base}:focus-within`
-    case 'groupHover':   return `.group:hover ${base}`
+    case 'hover':
+      return `${base}:hover`
+    case 'active':
+      return `${base}:active`
+    case 'focus':
+      return `${base}:focus`
+    case 'focusWithin':
+      return `${base}:focus-within`
+    case 'groupHover':
+      return `${GATE} .group:hover [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
   }
 }
 

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -5,6 +5,7 @@ import { registry } from '../lib/registry'
 import { buildCombinedCss } from '@/lib/interactionCss'
 import type { Effect } from '@/types/interactions'
 import { useInteractionRegistry } from '@/store/interactionRegistry'
+import { useEditorUIStore } from '@/store/editorUIStore'
 import SelectionOverlay from './canvas/SelectionOverlay'
 import Viewport from './canvas/Viewport'
 import HUDContainer from './hud/HUDContainer'
@@ -32,6 +33,7 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
   const chosen = presets.filter(p => ids.includes(p.id))
   const inlineHover = node.props?.hoverEffects as Effect[] | undefined
   const inlineMs = node.props?.hoverTransitionMs as number | undefined
+  const interacting = useEditorUIStore((s) => s.interactingIds.has(node.id))
   const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs)
 
   useEffect(() => {
@@ -51,6 +53,7 @@ function NodeRenderer({ node }: { node: ComponentNode }) {
       data-node-id={node.id}
       data-node-type={node.type}
       data-node-name={node.props?.name}
+      data-interacting={interacting ? 'true' : undefined}
       style={{ position: 'absolute', ...style }}
       onMouseDown={e => { e.stopPropagation(); selectComponent(node.id) }}
     >
@@ -90,8 +93,12 @@ function CanvasInner({
   canvasRef: React.RefObject<HTMLDivElement>
 }) {
   const { vp } = useViewport()
+  const actionsEnabled = useEditorUIStore((s) => s.actionsEnabled)
   return (
-    <div className="relative h-full w-full">
+    <div
+      className="relative h-full w-full"
+      data-actions-enabled={actionsEnabled ? 'true' : 'false'}
+    >
       <Viewport>
         <div ref={canvasRef} data-canvas-root className="relative w-[2000px] h-[2000px]">
           {tree.map(n => (

--- a/web/components/canvas/SelectionOverlay.tsx
+++ b/web/components/canvas/SelectionOverlay.tsx
@@ -4,6 +4,7 @@ import { useEditorState, useEditorActions } from '../store'
 import { useRects } from './RectsStore'
 import { getSmartSnap, Guide } from './snap'
 import { useGridStore } from '@/store/gridStore'
+import { useEditorUIStore } from '@/store/editorUIStore'
 
 type DragState = { dx:number, dy:number }
 
@@ -27,6 +28,8 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
   const overlayRef = useRef<HTMLDivElement>(null)
   const [drag, setDrag] = useState<DragState|null>(null)
   const [resize, setResize] = useState<ResizeState|null>(null)
+  const begin = useEditorUIStore((s) => s.beginInteraction)
+  const end = useEditorUIStore((s) => s.endInteraction)
   const style = node?.props?.style || {}
 
   const { snapGrid, pitch } = useGridStore()
@@ -53,15 +56,19 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
     return ()=> window.removeEventListener('keydown', handler)
   },[selectedComponentId, rect, style, setProp, snap])
 
-  const startDrag = (e:React.MouseEvent) => {
-    if(!rect) return
+  const startDrag = (e:React.PointerEvent) => {
+    if(!rect || !selectedComponentId) return
     e.stopPropagation()
+    ;(e.currentTarget as Element).setPointerCapture?.(e.pointerId)
+    begin(selectedComponentId)
     setDrag({dx: e.clientX - rect.x - (containerRect?.left||0), dy: e.clientY - rect.y - (containerRect?.top||0)})
   }
 
-  const startResize = (dir:string)=>(e:React.MouseEvent)=>{
-    if(!rect) return
+  const startResize = (dir:string)=>(e:React.PointerEvent)=>{
+    if(!rect || !selectedComponentId) return
     e.stopPropagation()
+    ;(e.currentTarget as Element).setPointerCapture?.(e.pointerId)
+    begin(selectedComponentId)
     setResize({
       dir,
       startX: e.clientX,
@@ -73,7 +80,7 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
     })
   }
 
-  const onMouseMove = useCallback((ev:MouseEvent)=>{
+  const onPointerMove = useCallback((ev:PointerEvent)=>{
     if(drag && selectedComponentId && rect){
       let left = ev.clientX - drag.dx - (containerRect?.left||0)
       let top  = ev.clientY - drag.dy - (containerRect?.top||0)
@@ -95,16 +102,17 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
   },[drag, resize, selectedComponentId, rect, setProp, containerRect, siblings, setGuides, style, snap])
 
   const stopAll = useCallback(()=>{
+    if (selectedComponentId) end(selectedComponentId)
     setDrag(null); setResize(null); setGuides([])
-  },[setGuides])
+  },[setGuides, end, selectedComponentId])
 
   useEffect(()=>{
     if(drag||resize){
-      window.addEventListener('mousemove', onMouseMove)
-      window.addEventListener('mouseup', stopAll)
-      return ()=>{ window.removeEventListener('mousemove', onMouseMove); window.removeEventListener('mouseup', stopAll) }
+      window.addEventListener('pointermove', onPointerMove)
+      window.addEventListener('pointerup', stopAll)
+      return ()=>{ window.removeEventListener('pointermove', onPointerMove); window.removeEventListener('pointerup', stopAll) }
     }
-  },[drag, resize, onMouseMove, stopAll])
+  },[drag, resize, onPointerMove, stopAll])
 
   if (!rect) return null
 
@@ -124,10 +132,10 @@ export default function SelectionOverlay({setGuides}:{setGuides:(g:Guide[])=>voi
       <div
         className="pointer-events-auto border-2 border-blue-500"
         style={{position:'absolute', left:rect.x, top:rect.y, width:rect.w, height:rect.h}}
-        onMouseDown={startDrag}
+        onPointerDown={startDrag}
       />
       {handlePos.map(h=> (
-        <div key={h.dir} className="absolute w-2 h-2 bg-white border border-blue-500 rounded-full pointer-events-auto" style={{left:h.style.left-4, top:h.style.top-4, cursor:h.dir+'-resize'}} onMouseDown={startResize(h.dir)} />
+        <div key={h.dir} className="absolute w-2 h-2 bg-white border border-blue-500 rounded-full pointer-events-auto" style={{left:h.style.left-4, top:h.style.top-4, cursor:h.dir+'-resize'}} onPointerDown={startResize(h.dir)} />
       ))}
     </div>
   )

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -233,7 +233,7 @@ export default function Player() {
 
   if (!current) return null;
   return (
-    <div className="relative w-full h-full">
+    <div className="relative w-full h-full" data-actions-enabled="true">
       <PresenterHUD
         title={(current as any).name ?? current.id}
         index={currentIndex}

--- a/web/lib/interactionCss.ts
+++ b/web/lib/interactionCss.ts
@@ -8,6 +8,11 @@ const shadowMap = {
 } as const
 
 const esc = (s: string) => (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(s) : s)
+const GATE = '[data-actions-enabled="true"]'
+
+function target(nodeId: string) {
+  return `${GATE} [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
+}
 
 function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-bezier(.2,.8,.2,1)') {
   const decls: string[] = []
@@ -32,13 +37,18 @@ function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-b
 }
 
 function triggerSelector(nodeId: string, t: Trigger) {
-  const base = `[data-node-id="${esc(nodeId)}"]`
+  const base = target(nodeId)
   switch (t) {
-    case 'hover':        return `${base}:hover`
-    case 'active':       return `${base}:active`
-    case 'focus':        return `${base}:focus`
-    case 'focusWithin':  return `${base}:focus-within`
-    case 'groupHover':   return `.group:hover ${base}`
+    case 'hover':
+      return `${base}:hover`
+    case 'active':
+      return `${base}:active`
+    case 'focus':
+      return `${base}:focus`
+    case 'focusWithin':
+      return `${base}:focus-within`
+    case 'groupHover':
+      return `${GATE} .group:hover [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
   }
 }
 

--- a/web/store/editorUIStore.ts
+++ b/web/store/editorUIStore.ts
@@ -5,13 +5,34 @@ type OutlineMode = 'selection' | 'hover' | 'all'
 type UIState = {
   showOutline: boolean
   outlineMode: OutlineMode
+  actionsEnabled: boolean
+  interactingIds: Set<string>
   setShowOutline: (v: boolean) => void
   setOutlineMode: (m: OutlineMode) => void
+  setActionsEnabled: (v: boolean) => void
+  beginInteraction: (ids: string | string[]) => void
+  endInteraction: (ids?: string | string[]) => void
+  clearInteraction: () => void
 }
 
-export const useEditorUIStore = create<UIState>((set) => ({
+export const useEditorUIStore = create<UIState>((set, get) => ({
   showOutline: true,
   outlineMode: 'selection',
+  actionsEnabled: true,
+  interactingIds: new Set(),
   setShowOutline: (v) => set({ showOutline: v }),
   setOutlineMode: (m) => set({ outlineMode: m }),
+  setActionsEnabled: (v) => set({ actionsEnabled: v }),
+  beginInteraction: (ids) => {
+    const setIds = new Set(get().interactingIds)
+    ;(Array.isArray(ids) ? ids : [ids]).forEach((id) => setIds.add(id))
+    set({ interactingIds: setIds, actionsEnabled: false })
+  },
+  endInteraction: (ids) => {
+    const setIds = new Set(get().interactingIds)
+    if (ids)
+      (Array.isArray(ids) ? ids : [ids]).forEach((id) => setIds.delete(id))
+    set({ interactingIds: setIds, actionsEnabled: setIds.size === 0 })
+  },
+  clearInteraction: () => set({ interactingIds: new Set(), actionsEnabled: true }),
 }))


### PR DESCRIPTION
## Summary
- track active interaction state in editor UI store
- gate hover/active CSS and nodes with data attributes
- disable interactions while dragging or resizing with pointer capture

## Testing
- `pnpm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b0237e27c4832ca61dccba350fa248