### PR TITLE
harden interaction preset handling

### DIFF
--- a/lib/interactionCss.ts
+++ b/lib/interactionCss.ts
@@ -1,17 +1,23 @@
 import type { Effect, InteractionPreset, Trigger } from '../types/interactions'
 
 const shadowMap = {
-  sm:'0 1px 2px 0 rgb(0 0 0 / 0.05)',
-  md:'0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  lg:'0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
-  xl:'0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
 } as const
 
-const esc = (s: string) => (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(s) : s)
+const safeEscape = (s: string) => {
+  try {
+    // @ts-ignore
+    if (typeof CSS !== 'undefined' && CSS?.escape) return CSS.escape(s)
+  } catch {}
+  return s.replace(/[^a-zA-Z0-9_-]/g, (m) => `\\${m}`)
+}
 const GATE = '[data-actions-enabled="true"]'
 
 function target(nodeId: string) {
-  return `${GATE} [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
+  return `${GATE} [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
 }
 
 function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-bezier(.2,.8,.2,1)') {
@@ -48,7 +54,7 @@ function triggerSelector(nodeId: string, t: Trigger) {
     case 'focusWithin':
       return `${base}:focus-within`
     case 'groupHover':
-      return `${GATE} .group:hover [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
+      return `${GATE} .group:hover [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
   }
 }
 

--- a/web/lib/interactionCss.ts
+++ b/web/lib/interactionCss.ts
@@ -1,17 +1,24 @@
 import type { Effect, InteractionPreset, Trigger } from '@/types/interactions'
 
 const shadowMap = {
-  sm:'0 1px 2px 0 rgb(0 0 0 / 0.05)',
-  md:'0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  lg:'0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
-  xl:'0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
 } as const
 
-const esc = (s: string) => (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(s) : s)
+const safeEscape = (s: string) => {
+  try {
+    // @ts-ignore
+    if (typeof CSS !== 'undefined' && CSS?.escape) return CSS.escape(s)
+  } catch {}
+  // フォールバック：CSSセレクタで問題になる文字をエスケープ
+  return s.replace(/[^a-zA-Z0-9_-]/g, (m) => `\\${m}`)
+}
 const GATE = '[data-actions-enabled="true"]'
 
 function target(nodeId: string) {
-  return `${GATE} [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
+  return `${GATE} [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
 }
 
 function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-bezier(.2,.8,.2,1)') {
@@ -48,7 +55,7 @@ function triggerSelector(nodeId: string, t: Trigger) {
     case 'focusWithin':
       return `${base}:focus-within`
     case 'groupHover':
-      return `${GATE} .group:hover [data-node-id="${esc(nodeId)}"]:not([data-interacting="true"])`
+      return `${GATE} .group:hover [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
   }
 }
 

--- a/web/lib/presetChannel.ts
+++ b/web/lib/presetChannel.ts
@@ -1,27 +1,28 @@
-export type ApplyMode = 'replace' | 'append' | 'remove'
-export type ApplyScope = 'selection' | 'all' | 'set-project-default'
-export type PresetMsg = {
-  type: 'apply'
-  presetId: string
-  mode: ApplyMode
-  scope: ApplyScope
-}
+export type ApplyMode = 'replace'|'append'|'remove'
+export type ApplyScope = 'selection'|'all'|'set-project-default'
+export type PresetMsg = { type:'apply'; presetId:string; mode:ApplyMode; scope:ApplyScope }
 
-export function emitApply(
-  presetId: string,
-  mode: ApplyMode,
-  scope: ApplyScope = 'selection',
-) {
-  const ch = new BroadcastChannel('action-presets')
-  ch.postMessage({ type: 'apply', presetId, mode, scope } satisfies PresetMsg)
-  ch.close()
-}
+const hasBC = () => typeof window !== 'undefined' && 'BroadcastChannel' in window
 
-export function subscribeApply(onMsg: (m: PresetMsg) => void) {
-  const ch = new BroadcastChannel('action-presets')
-  ch.onmessage = (ev) => {
-    const m = ev.data as PresetMsg
-    if (m?.type === 'apply') onMsg(m)
+export function emitApply(presetId: string, mode: ApplyMode, scope: ApplyScope = 'selection') {
+  const msg: PresetMsg = { type:'apply', presetId, mode, scope }
+  if (hasBC()) {
+    const ch = new BroadcastChannel('action-presets'); ch.postMessage(msg); ch.close()
+  } else if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent<PresetMsg>('ap-apply', { detail: msg }))
   }
-  return () => ch.close()
+}
+
+export function subscribeApply(onMsg:(m:PresetMsg)=>void) {
+  if (hasBC()) {
+    const ch = new BroadcastChannel('action-presets')
+    ch.onmessage = (ev) => { const m = ev.data as PresetMsg; if (m?.type==='apply') onMsg(m) }
+    return () => ch.close()
+  }
+  const h = (e: Event) => {
+    const ce = e as CustomEvent<PresetMsg>
+    if (ce.detail?.type === 'apply') onMsg(ce.detail)
+  }
+  window.addEventListener('ap-apply', h as EventListener)
+  return () => window.removeEventListener('ap-apply', h as EventListener)
 }

--- a/web/store/interactionRegistry.ts
+++ b/web/store/interactionRegistry.ts
@@ -6,100 +6,70 @@ type State = {
   selectedId?: string
   projectDefaultPresetIds: string[]
   setProjectDefaults: (ids: string[]) => void
-  add(p: Omit<InteractionPreset,'id'|'updatedAt'> & { id?: string }): string
-  update(id: string, patch: Partial<InteractionPreset>): void
-  remove(id: string): void
-  duplicate(id: string): string | undefined
-  select(id?: string): void
-  import(json: InteractionPreset[]): void
-  export(): string
+  add: (p: Omit<InteractionPreset,'id'|'updatedAt'> & { id?: string }) => string
+  update: (id: string, patch: Partial<InteractionPreset>) => void
+  remove: (id: string) => void
+  duplicate: (id: string) => string | undefined
+  select: (id?: string) => void
+  import: (json: InteractionPreset[]) => void
+  export: () => string
 }
 
 const KEY = 'action-presets-v1'
+const KEY_DEFAULTS = 'action-presets-defaults-v1'
 const uid = () => Math.random().toString(36).slice(2,9)
 
-function load(): InteractionPreset[] {
-  try { return JSON.parse(localStorage.getItem(KEY) || '[]') } catch { return [] }
+const safeParse = <T,>(raw: string | null, fallback: T): T => {
+  try { return raw ? JSON.parse(raw) as T : fallback } catch { return fallback }
 }
-function save(presets: InteractionPreset[]) {
-  try { localStorage.setItem(KEY, JSON.stringify(presets)) } catch {}
-}
+
+const loadPresets = (): InteractionPreset[] =>
+  typeof window === 'undefined' ? [] : safeParse<InteractionPreset[]>(localStorage.getItem(KEY), [])
+const savePresets = (arr: InteractionPreset[]) => { try { localStorage.setItem(KEY, JSON.stringify(arr)) } catch {} }
+
+const loadDefaults = (): string[] =>
+  typeof window === 'undefined' ? [] : safeParse<string[]>(localStorage.getItem(KEY_DEFAULTS), [])
+const saveDefaults = (ids: string[]) => { try { localStorage.setItem(KEY_DEFAULTS, JSON.stringify(ids)) } catch {} }
 
 export const useInteractionRegistry = create<State>((set, get) => ({
   presets: [],
   selectedId: undefined,
   projectDefaultPresetIds: [],
 
-  setProjectDefaults: (ids) => {
-    set({ projectDefaultPresetIds: ids })
-    try {
-      localStorage.setItem(KEY + '-defaults', JSON.stringify(ids))
-    } catch {}
-  },
+  setProjectDefaults: (ids) => { set({ projectDefaultPresetIds: ids }); saveDefaults(ids) },
 
   add: (p) => {
     const id = p.id ?? uid()
     const now = Date.now()
     const next = [...get().presets, { ...p, id, updatedAt: now }]
-    set({ presets: next, selectedId: id })
-    save(next)
-    return id
+    set({ presets: next, selectedId: id }); savePresets(next); return id
   },
-
   update: (id, patch) => {
-    const next = get().presets.map(x => x.id === id ? { ...x, ...patch, updatedAt: Date.now() } : x)
-    set({ presets: next })
-    save(next)
+    const next = get().presets.map(x => x.id===id ? { ...x, ...patch, updatedAt: Date.now() } : x)
+    set({ presets: next }); savePresets(next)
   },
-
   remove: (id) => {
     const next = get().presets.filter(x => x.id !== id)
-    set({ presets: next, selectedId: next[0]?.id })
-    save(next)
+    set({ presets: next, selectedId: next[0]?.id }); savePresets(next)
   },
-
   duplicate: (id) => {
-    const src = get().presets.find(x => x.id === id)
-    if (!src) return
-    const nid = uid()
-    const copy = { ...src, id: nid, name: src.name + ' Copy', updatedAt: Date.now() }
-    const next = [...get().presets, copy]
-    set({ presets: next, selectedId: nid })
-    save(next)
-    return nid
+    const src = get().presets.find(x => x.id===id); if (!src) return
+    const nid = uid(); const copy = { ...src, id: nid, name: src.name + ' Copy', updatedAt: Date.now() }
+    const next = [...get().presets, copy]; set({ presets: next, selectedId: nid }); savePresets(next); return nid
   },
-
   select: (id) => set({ selectedId: id }),
-
-  import: (arr) => {
-    const next = Array.isArray(arr) ? arr : []
-    set({ presets: next, selectedId: next[0]?.id })
-    save(next)
-  },
-
+  import: (arr) => { const next = Array.isArray(arr) ? arr : []; set({ presets: next, selectedId: next[0]?.id }); savePresets(next) },
   export: () => JSON.stringify(get().presets, null, 2),
 }))
 
-// 初回ハイドレーション
+// クライアント初期化＋同期
 if (typeof window !== 'undefined') {
-  const init = load()
-  useInteractionRegistry.setState({
-    presets: init,
-    selectedId: init[0]?.id,
-    projectDefaultPresetIds: JSON.parse(localStorage.getItem(KEY + '-defaults') || '[]') ?? [],
-  })
+  const presets = loadPresets()
+  const defaults = loadDefaults()
+  useInteractionRegistry.setState({ presets, selectedId: presets[0]?.id, projectDefaultPresetIds: defaults })
 
-  // 他タブで保存された内容を即時反映
   window.addEventListener('storage', (e) => {
-    if (e.key === KEY) {
-      try {
-        useInteractionRegistry.setState({ presets: JSON.parse(e.newValue || '[]') })
-      } catch {}
-    }
-    if (e.key === KEY + '-defaults') {
-      try {
-        useInteractionRegistry.setState({ projectDefaultPresetIds: JSON.parse(e.newValue || '[]') })
-      } catch {}
-    }
+    if (e.key === KEY) useInteractionRegistry.setState({ presets: safeParse(e.newValue, []) })
+    if (e.key === KEY_DEFAULTS) useInteractionRegistry.setState({ projectDefaultPresetIds: safeParse(e.newValue, []) })
   })
 }


### PR DESCRIPTION
## Summary
- guard CSS.escape and fallback escape for old environments
- add BroadcastChannel fallback using CustomEvent
- make interaction preset registry resilient to bad localStorage data

## Testing
- `pnpm test` *(fails: ELIFECYCLE  Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68b027c48054832c8ce427a5f750e7f2