### PR TITLE
feat: enable interaction css without gate

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -1,9 +1,11 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { ComponentNode, PropBinding } from './store';
 import { useDataSources, DataSource } from './dataSources';
-import { buildCombinedCss } from '../web/lib/interactionCss';
-import type { Effect } from '../web/types/interactions';
-import { useInteractionRegistry } from '../web/store/interactionRegistry';
+import { buildCombinedCss } from '@/lib/interactionCss';
+import type { Effect } from '@/types/interactions';
+import { useInteractionRegistry } from '@/store/interactionRegistry';
 
 function getByPath(obj: any, path: string) {
   if (!path || !path.startsWith('$.')) return undefined;
@@ -85,7 +87,11 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
   const chosen = presets.filter((p) => ids.includes(p.id));
   const inlineHover = node.props?.hoverEffects as Effect[] | undefined;
   const inlineMs = node.props?.hoverTransitionMs as number | undefined;
-  const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs);
+  const [gate, setGate] = useState(true);
+  useEffect(() => {
+    setGate(!!document.querySelector('[data-actions-enabled="true"]'));
+  }, []);
+  const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs, { gate });
 
   // ✅ 両方を統合: registry からコンポーネントを解決 + previewHover を継承
   const type = node.type;

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -1,71 +1,20 @@
 'use client'
-import React, { useEffect, useRef, useState } from 'react'
-import { useEditorState, useEditorActions, ComponentNode } from './store'
-import { registry } from '../lib/registry'
-import { buildCombinedCss } from '@/lib/interactionCss'
-import type { Effect } from '@/types/interactions'
-import { useInteractionRegistry } from '@/store/interactionRegistry'
-import { useEditorUIStore } from '@/store/editorUIStore'
+import React, { useRef, useState } from 'react'
+import { useEditorState, ComponentNode } from './store'
 import SelectionOverlay from './canvas/SelectionOverlay'
 import Viewport from './canvas/Viewport'
 import HUDContainer from './hud/HUDContainer'
 import { ViewportProvider, useViewport } from './canvas/ViewportStore'
 import { GridOverlay } from '@/components/overlays/GridOverlay'
 import { Rulers } from './Rulers'
-import { RectsProvider, useRects } from './canvas/RectsStore'
+import { RectsProvider } from './canvas/RectsStore'
 import SmartGuidesOverlay from './canvas/SmartGuidesOverlay'
 import { GuidesOverlay } from './overlays/GuidesOverlay'
 import type { Guide } from './canvas/snap'
 import { OutlineOverlay } from './overlays/OutlineOverlay'
 import { GridToolbar } from '@/components/GridToolbar'
-
-function NodeRenderer({ node }: { node: ComponentNode }) {
-  const { selectComponent } = useEditorActions()
-  const { setRect } = useRects()
-  const ref = useRef<HTMLDivElement>(null)
-  const Comp = (registry as any)[node.type] || ((p: any) => <div {...p}>{p.children}</div>)
-  const style = node.props?.style || {}
-
-  const { presets, projectDefaultPresetIds } = useInteractionRegistry()
-  const ownIds: string[] =
-    (node.props?.presetIds || (node.props?.presetId ? [node.props.presetId] : [])) as string[]
-  const ids = ownIds.length ? ownIds : projectDefaultPresetIds
-  const chosen = presets.filter(p => ids.includes(p.id))
-  const inlineHover = node.props?.hoverEffects as Effect[] | undefined
-  const inlineMs = node.props?.hoverTransitionMs as number | undefined
-  const interacting = useEditorUIStore((s) => s.interactingIds.has(node.id))
-  const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const root = el.closest('[data-canvas-root]') as HTMLElement | null
-    const r = el.getBoundingClientRect()
-    const base = root?.getBoundingClientRect()
-    const x = base ? r.left - base.left : r.left
-    const y = base ? r.top - base.top : r.top
-    setRect(node.id, { x, y, w: r.width, h: r.height })
-  })
-
-  return (
-    <div
-      ref={ref}
-      data-node-id={node.id}
-      data-node-type={node.type}
-      data-node-name={node.props?.name}
-      data-interacting={interacting ? 'true' : undefined}
-      style={{ position: 'absolute', ...style }}
-      onMouseDown={e => { e.stopPropagation(); selectComponent(node.id) }}
-    >
-      <Comp {...node.props}>
-        {node.children?.map(child => (
-          <NodeRenderer key={child.id} node={child} />
-        ))}
-      </Comp>
-      {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
-    </div>
-  )
-}
+import { CanvasRoot } from '@/components/CanvasRoot'
+import { NodeRenderer } from '@/components/NodeRenderer'
 
 export default function Canvas() {
   const { tree } = useEditorState()
@@ -93,15 +42,11 @@ function CanvasInner({
   canvasRef: React.RefObject<HTMLDivElement>
 }) {
   const { vp } = useViewport()
-  const actionsEnabled = useEditorUIStore((s) => s.actionsEnabled)
   return (
-    <div
-      className="relative h-full w-full"
-      data-actions-enabled={actionsEnabled ? 'true' : 'false'}
-    >
+    <CanvasRoot>
       <Viewport>
         <div ref={canvasRef} data-canvas-root className="relative w-[2000px] h-[2000px]">
-          {tree.map(n => (
+          {tree.map((n) => (
             <NodeRenderer key={n.id} node={n} />
           ))}
           <SelectionOverlay setGuides={setGuides} />
@@ -121,6 +66,6 @@ function CanvasInner({
       <div className="absolute top-2 left-2 z-50">
         <GridToolbar />
       </div>
-    </div>
+    </CanvasRoot>
   )
 }

--- a/web/components/CanvasRoot.tsx
+++ b/web/components/CanvasRoot.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import React from 'react'
+
+export function CanvasRoot({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative w-full h-full" data-actions-enabled="true">
+      {children}
+    </div>
+  )
+}
+
+export default CanvasRoot

--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import React from 'react'
+import { useEditorActions, ComponentNode } from './store'
+import { registry } from '@/lib/registry'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
+import { buildCombinedCss } from '@/lib/interactionCss'
+import type { Effect } from '@/types/interactions'
+import { useEditorUIStore } from '@/store/editorUIStore'
+import { useRects } from './canvas/RectsStore'
+
+export function NodeRenderer({ node }: { node: ComponentNode }) {
+  const { selectComponent } = useEditorActions()
+  const { setRect } = useRects()
+  const ref = React.useRef<HTMLDivElement>(null)
+  const Comp = (registry as any)[node.type] || ((p: any) => <div {...p}>{p.children}</div>)
+  const style = node.props?.style || {}
+
+  const { presets, projectDefaultPresetIds } = useInteractionRegistry()
+  const ownIds: string[] = Array.isArray(node.props?.presetIds)
+    ? (node.props?.presetIds as string[])
+    : node.props?.presetId
+    ? [node.props.presetId]
+    : []
+  const effectiveIds = ownIds.length ? ownIds : projectDefaultPresetIds ?? []
+  const chosen = presets.filter((p) => effectiveIds.includes(p.id))
+
+  const inlineHover = node.props?.hoverEffects as Effect[] | undefined
+  const inlineMs = node.props?.hoverTransitionMs as number | undefined
+  const interacting = useEditorUIStore((s) => s.interactingIds.has(node.id))
+
+  const [gate, setGate] = React.useState(true)
+  React.useEffect(() => {
+    setGate(!!document.querySelector('[data-actions-enabled="true"]'))
+  }, [])
+
+  const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs, { gate })
+
+  React.useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const root = el.closest('[data-canvas-root]') as HTMLElement | null
+    const r = el.getBoundingClientRect()
+    const base = root?.getBoundingClientRect()
+    const x = base ? r.left - base.left : r.left
+    const y = base ? r.top - base.top : r.top
+    setRect(node.id, { x, y, w: r.width, h: r.height })
+  })
+
+  return (
+    <div
+      ref={ref}
+      data-node-id={node.id}
+      data-node-type={node.type}
+      data-node-name={node.props?.name}
+      data-interacting={interacting ? 'true' : undefined}
+      style={{ position: 'absolute', ...style }}
+      onMouseDown={(e) => {
+        e.stopPropagation()
+        selectComponent(node.id)
+      }}
+    >
+      <Comp {...node.props}>
+        {node.children?.map((child) => (
+          <NodeRenderer key={child.id} node={child} />
+        ))}
+      </Comp>
+      {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
+    </div>
+  )
+}
+
+export default NodeRenderer

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -45,7 +45,11 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
   const chosen = presets.filter((p) => ids.includes(p.id));
   const inlineHover = node.props?.hoverEffects as Effect[] | undefined;
   const inlineMs = node.props?.hoverTransitionMs as number | undefined;
-  const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs);
+  const [gate, setGate] = useState(true);
+  useEffect(() => {
+    setGate(!!document.querySelector('[data-actions-enabled="true"]'));
+  }, []);
+  const css = buildCombinedCss(node.id, chosen, inlineHover, inlineMs, { gate });
   const link = node.prototypeLink;
   const handleClick = (e: any) => {
     if (!link) return;

--- a/web/lib/interactionCss.ts
+++ b/web/lib/interactionCss.ts
@@ -18,9 +18,12 @@ const safeEscape = (s: string) => {
 }
 const GATE = '[data-actions-enabled="true"]'
 
+type BuildOpts = { gate?: boolean }
+
 // 操作中ノードは除外して、キャンバス全体のゲートがONの時のみ効かせる
-function target(nodeId: string) {
-  return `${GATE} [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
+function target(nodeId: string, withGate: boolean) {
+  const base = `[data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
+  return withGate ? `${GATE} ${base}` : base
 }
 
 function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-bezier(.2,.8,.2,1)') {
@@ -45,8 +48,8 @@ function effectsToDecls(effects: Effect[], transitionMs = 120, easing = 'cubic-b
   return decls.join(';')
 }
 
-function triggerSelector(nodeId: string, t: Trigger) {
-  const base = target(nodeId)
+function triggerSelector(nodeId: string, t: Trigger, withGate: boolean) {
+  const base = target(nodeId, withGate)
   switch (t) {
     case 'hover':
       return `${base}:hover`
@@ -57,23 +60,39 @@ function triggerSelector(nodeId: string, t: Trigger) {
     case 'focusWithin':
       return `${base}:focus-within`
     case 'groupHover':
-      return `${GATE} .group:hover [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
+      return withGate
+        ? `${GATE} .group:hover [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
+        : `.group:hover [data-node-id="${safeEscape(nodeId)}"]:not([data-interacting="true"])`
   }
 }
 
-export function buildPresetCss(nodeId: string, preset: InteractionPreset) {
+export function buildPresetCss(nodeId: string, preset: InteractionPreset, opts: BuildOpts = {}) {
   if (!preset.effects?.length || !preset.triggers?.length) return ''
-  const decls = effectsToDecls(preset.effects, preset.transitionMs ?? 120, preset.easing ?? 'cubic-bezier(.2,.8,.2,1)')
-  return preset.triggers.map(t => `${triggerSelector(nodeId, t)}{${decls}}`).join('\n')
+  const gate = opts.gate ?? true
+  const decls = effectsToDecls(
+    preset.effects,
+    preset.transitionMs ?? 120,
+    preset.easing ?? 'cubic-bezier(.2,.8,.2,1)'
+  )
+  return preset.triggers
+    .map((t) => `${triggerSelector(nodeId, t, gate)}{${decls}}`)
+    .join('\n')
 }
 
-export function buildCombinedCss(nodeId: string, presets: InteractionPreset[] = [], inlineHoverEffects?: Effect[], inlineMs?: number) {
+export function buildCombinedCss(
+  nodeId: string,
+  presets: InteractionPreset[] = [],
+  inlineHoverEffects?: Effect[],
+  inlineMs?: number,
+  opts: BuildOpts = {}
+) {
+  const gate = opts.gate ?? true
   let css = ''
-  for (const p of presets) css += buildPresetCss(nodeId, p) + '\n'
+  for (const p of presets) css += buildPresetCss(nodeId, p, { gate }) + '\n'
   // 後方互換（旧 hoverEffects）
   if (inlineHoverEffects?.length) {
     const decls = effectsToDecls(inlineHoverEffects, inlineMs ?? 120)
-    css += `${triggerSelector(nodeId,'hover')}{${decls}}\n`
+    css += `${triggerSelector(nodeId, 'hover', gate)}{${decls}}\n`
   }
   return css
 }


### PR DESCRIPTION
## Summary
- add CanvasRoot to always enable interaction actions
- move NodeRenderer to client component and auto-toggle gate
- allow interaction CSS builder to fall back when gate missing

## Testing
- `pnpm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68b030cd1430832ca5e102582d3e6f10