### PR TITLE
fix: preserve action presets on property updates

### DIFF
--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -25,7 +25,8 @@ export default function RightInspector() {
   const handleChange = (key: keyof typeof form, value: number) => {
     const next = { ...form, [key]: value };
     setForm(next);
-    update(selected, { props: next });
+    // 既存 props を保持して上書き
+    update(selected, { props: { ...(node?.props || {}), ...next } });
   };
 
   const comp = node && (node as any).type === 'Instance'

--- a/web/components/props/ActionPresetField.tsx
+++ b/web/components/props/ActionPresetField.tsx
@@ -21,13 +21,13 @@ export default function ActionPresetField({ nodeId, value }: Props) {
       ids.forEach((id) => {
         const node = useEditorStore.getState().tree.find((n) => n.id === id)
         if (!node) return
-        updateNode(id, {
-          props: {
-            ...(node.props || {}),
-            presetId,
-            presetIds: presetId ? [presetId] : [],
-          },
-        })
+        const prev = node.props || {}
+        const next = {
+          ...prev,
+          presetId: presetId ?? null,
+          presetIds: presetId ? [presetId] : [],
+        }
+        updateNode(id, { props: next })
       })
     },
     [updateNode]


### PR DESCRIPTION
## Summary
- merge existing props in RightInspector numeric edits to avoid clearing presets
- safely re-read and merge node props when applying an action preset

## Testing
- `pnpm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68b144bcd8b8832c87be547b6f894dde