### PR TITLE
Wrap PageRenderer nodes in data-node-id container

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -96,19 +96,22 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
       ? type // div, span などネイティブ要素
       : (require('../lib/registry').components as any)[type] || type;
 
-  const childrenArr = node.children?.map((c) => (
-    <NodeRenderer key={c.id} node={c} previewHover={previewHover} />
-  )) || [];
-  if (css) childrenArr.push(<style key="_h" dangerouslySetInnerHTML={{ __html: css }} />);
-  return React.createElement(
-    Comp as any,
-    {
-      ...props,
-      'data-node-id': node.id,
-      'data-node-type': node.type,
-      'data-node-name': (node as any).props?.name,
-    },
-    childrenArr,
+  const childrenArr =
+    node.children?.map((c) => (
+      <NodeRenderer key={c.id} node={c} previewHover={previewHover} />
+    )) || [];
+
+  return (
+    <div
+      {...{
+        'data-node-id': node.id,
+        'data-node-type': node.type,
+        'data-node-name': (node as any).props?.name,
+      }}
+    >
+      {React.createElement(Comp as any, props, childrenArr)}
+      {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap rendered nodes in PageRenderer with a div carrying `data-node-id`, `data-node-type`, and `data-node-name`
- ensure inline preset styles are injected after the component inside this wrapper

## Testing
- `npm test` *(fails: TypeError: reject is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b67d6f4832c87b7de71f15a8418