### PR TITLE
refactor: use static component registry

### DIFF
--- a/lib/registry.tsx
+++ b/lib/registry.tsx
@@ -1,13 +1,10 @@
 import meta from '../component-meta.json'
 import type { ComponentType } from 'react'
+import MyCard from '../src/components/custom/MyCard'
 
 export const library = meta as { displayName: string; description?: string }[]
 
-export const components: Record<string, ComponentType<any>> = {}
-for (const m of library) {
-  components[m.displayName] = (props: any) => {
-    const React = require('react')
-    const Mod = require(`../src/components/custom/${m.displayName}.tsx`).default
-    return React.createElement(Mod, props)
-  }
+// Static registry of available components
+export const components: Record<string, ComponentType<any>> = {
+  MyCard,
 }

--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { ComponentNode, PropBinding } from './store';
 import { useDataSources, DataSource } from './dataSources';
+import { components as registry } from '../lib/registry';
 import PresetStyle from '@/components/interaction/PresetStyle';
 
 function getByPath(obj: any, path: string) {
@@ -83,7 +84,7 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
   const Comp =
     typeof type === 'string' && type[0] === type[0].toLowerCase()
       ? type // div, span などネイティブ要素
-      : (require('../lib/registry').components as any)[type] || type;
+      : (registry as any)[type] || type;
 
   const childrenArr =
     node.children?.map((c) => (

--- a/src/components/custom/MyCard.tsx
+++ b/src/components/custom/MyCard.tsx
@@ -4,6 +4,8 @@ interface MyCardProps {
   title: string
   highlighted: boolean
   tone: 'info' | 'warn'
+  children?: React.ReactNode
+  className?: string
 }
 
 const MyCard: React.FC<MyCardProps> = ({ title, highlighted, tone, children, className }) => {

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -7,6 +7,7 @@ import { CanvasOverlay } from './CanvasOverlay'
 import { HeaderView } from './header/HeaderView'
 import { FooterView } from './footer/FooterView'
 import { SidebarView } from '@/components/app/SidebarView'
+import PresetStyle from '@/components/interaction/PresetStyle'
 
 const GRID = 8
 function bgGridStyle() {
@@ -260,6 +261,9 @@ function ElmView({ elm }: { elm: Elm }) {
       onMouseDown={() => select(elm.id)}
       className={`${common} ${border} ${shadow} cursor-move ${isDragging ? 'opacity-60' : ''}`}
       style={baseStyle}
+      data-node-id={elm.id}
+      data-node-type={elm.type}
+      data-node-name={elm.props?.name}
     >
       {elm.type === 'header' && <HeaderView elm={elm} />}
       {elm.type === 'footer' && <FooterView elm={elm} />}
@@ -271,6 +275,7 @@ function ElmView({ elm }: { elm: Elm }) {
       )}
       {elm.type === 'text' && <div className="h-full flex items-center px-2">{elm.props?.text ?? 'Text'}</div>}
       {elm.type === 'code' && <CodePreview elm={elm} />}
+      <PresetStyle nodeId={elm.id} />
       {isSel && <ResizeHandles elm={elm} />}
     </div>
   )


### PR DESCRIPTION
## Summary
- add PresetStyle wrapper and node metadata in builder canvas
- replace dynamic component loading with static registry
- update MyCard typing to accept children and className

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b168168ed0832c81be38f8d6d40191