### PR TITLE
Allow builder to supply interaction presets

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -100,7 +100,13 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
       }}
     >
       {React.createElement(Comp as any, props, childrenArr)}
-      <PresetStyle nodeId={node.id} />
+      <PresetStyle
+        nodeId={node.id}
+        presetIds={(node as any).props?.presetIds}
+        presetId={(node as any).props?.presetId}
+        hoverEffects={(node as any).props?.hoverEffects}
+        hoverTransitionMs={(node as any).props?.hoverTransitionMs}
+      />
     </div>
   );
 };

--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -43,7 +43,13 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
           <NodeRenderer key={child.id} node={child} />
         ))}
       </Comp>
-      <PresetStyle nodeId={node.id} />
+      <PresetStyle
+        nodeId={node.id}
+        presetIds={node.props?.presetIds}
+        presetId={node.props?.presetId}
+        hoverEffects={node.props?.hoverEffects}
+        hoverTransitionMs={node.props?.hoverTransitionMs}
+      />
     </div>
   )
 }

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -24,7 +24,13 @@ export function Canvas() {
           {node.children?.map((c: any) => render(c))}
         </Comp>
         {/* ここでプリセットCSSを必ず注入 */}
-        <PresetStyle nodeId={node.id} />
+        <PresetStyle
+          nodeId={node.id}
+          presetIds={node.props?.presetIds}
+          presetId={node.props?.presetId}
+          hoverEffects={node.props?.hoverEffects}
+          hoverTransitionMs={node.props?.hoverTransitionMs}
+        />
       </div>
     )
   }

--- a/web/components/builder/Inspector.tsx
+++ b/web/components/builder/Inspector.tsx
@@ -5,6 +5,7 @@ import { loadDocgenMeta, parseValue, type DocgenProp } from '@/lib/builder/docge
 import { HeaderInspector } from './header/HeaderInspector'
 import { FooterInspector } from './footer/FooterInspector'
 import { SidebarInspector } from '@/components/app/SidebarInspector'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
 
 export function Inspector() {
   const selId = useBuilderStore((s) => s.selectedId)
@@ -25,6 +26,7 @@ export function Inspector() {
       (m) => m.displayName === elm.code?.displayName && m.importPath === elm.code?.importPath,
     )
   }, [docgen, elm])
+  const { presets } = useInteractionRegistry()
 
   if (!selId || !elm) {
     return <div className="text-xs text-zinc-400">要素を選択すると編集できます。</div>
@@ -104,6 +106,27 @@ export function Inspector() {
                 type="text"
                 placeholder="#e5e7eb"
               />
+            </label>
+            <label className="flex flex-col gap-1 col-span-2">
+              action preset
+              <select
+                className="px-2 py-1 rounded bg-zinc-900 border border-zinc-800"
+                value={elm.props?.presetId ?? ''}
+                onChange={(e) => {
+                  const pid = e.target.value
+                  updateProps(elm.id, {
+                    presetId: pid || null,
+                    presetIds: pid ? [pid] : [],
+                  })
+                }}
+              >
+                <option value="">（なし）</option>
+                {presets.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
             </label>
           </div>
         </>

--- a/web/components/interaction/PresetStyle.tsx
+++ b/web/components/interaction/PresetStyle.tsx
@@ -1,24 +1,37 @@
 'use client'
 import * as React from 'react'
 import { useInteractionRegistry } from '@/store/interactionRegistry'
-import { useEditorStore } from '@/store/editorStore'
 import { buildCombinedCss } from '@/lib/interactionCss'
 import type { Effect } from '@/types/interactions'
 
-export default function PresetStyle({ nodeId }: { nodeId: string }) {
-  const node = useEditorStore((s) => s.tree.find((n:any) => n.id === nodeId))
-  const { presets } = useInteractionRegistry()
-  if (!node) return null
+type Props = {
+  nodeId: string
+  // これらが渡ってきたらストアは参照しない（/builder 用）
+  presetIds?: string[] | null
+  presetId?: string | null
+  hoverEffects?: Effect[] | null
+  hoverTransitionMs?: number | null
+}
 
-  const props: any = node.props || {}
-  const ids: string[] = Array.isArray(props.presetIds)
-    ? props.presetIds
-    : (props.presetId ? [props.presetId] : [])
+export default function PresetStyle({
+  nodeId,
+  presetIds,
+  presetId,
+  hoverEffects,
+  hoverTransitionMs,
+}: Props) {
+  const { presets } = useInteractionRegistry()
+
+  const ids =
+    (presetIds && presetIds.length ? presetIds : (presetId ? [presetId] : [])) ?? []
 
   const chosen = presets.filter((p) => ids.includes(p.id))
-  const inline = props.hoverEffects as Effect[] | undefined
-  const ms = props.hoverTransitionMs as number | undefined
-  const css = buildCombinedCss(node.id, chosen, inline, ms)
+  const css = buildCombinedCss(
+    nodeId,
+    chosen,
+    hoverEffects ?? undefined,
+    hoverTransitionMs ?? undefined
+  )
 
   return css ? <style dangerouslySetInnerHTML={{ __html: css }} /> : null
 }

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -68,7 +68,13 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         className={link ? 'cursor-pointer' : undefined}
       >
         <div className="w-full h-full bg-gray-300" />
-        <PresetStyle nodeId={node.id} />
+        <PresetStyle
+          nodeId={node.id}
+          presetIds={node.props?.presetIds}
+          presetId={node.props?.presetId}
+          hoverEffects={node.props?.hoverEffects}
+          hoverTransitionMs={node.props?.hoverTransitionMs}
+        />
       </div>
     );
   }
@@ -84,7 +90,13 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         className={link ? 'cursor-pointer' : undefined}
       >
         {node.props?.text}
-        <PresetStyle nodeId={node.id} />
+        <PresetStyle
+          nodeId={node.id}
+          presetIds={node.props?.presetIds}
+          presetId={node.props?.presetId}
+          hoverEffects={node.props?.hoverEffects}
+          hoverTransitionMs={node.props?.hoverTransitionMs}
+        />
       </div>
     );
   }
@@ -101,7 +113,13 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       {node.children?.map((c) => (
         <NodeRenderer key={c.id} node={c} onLink={onLink} />
       ))}
-      <PresetStyle nodeId={node.id} />
+      <PresetStyle
+        nodeId={node.id}
+        presetIds={node.props?.presetIds}
+        presetId={node.props?.presetId}
+        hoverEffects={node.props?.hoverEffects}
+        hoverTransitionMs={node.props?.hoverTransitionMs}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- generalize `PresetStyle` to accept preset and hover props directly
- forward preset props from builders and renderers
- add Action Preset dropdown in builder Inspector

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16da63c68832c944f69cca3682f2f