### PR TITLE
feat: restore draggable builder canvas

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -1,42 +1,150 @@
 'use client'
-
 import * as React from 'react'
-import { useEditorStore } from '@/store/editorStore'
-import { registry } from '@/lib/registry'
+import { useDroppable, useDraggable } from '@dnd-kit/core'
+import { useBuilderStore, type Elm } from '@/store/builderStore'
 import PresetStyle from '@/components/interaction/PresetStyle'
+import { CanvasOverlay } from './CanvasOverlay'
+import { HeaderView } from './header/HeaderView'
+import { FooterView } from './footer/FooterView'
+import { SidebarView } from '@/components/app/SidebarView'
+import ResizeHandles from './ResizeHandles'
 
-export function Canvas() {
-  const tree = useEditorStore((s) => s.tree)
+function ElmContent({ elm }: { elm: Elm }) {
+  switch (elm.type) {
+    case 'header':
+      return <HeaderView elm={elm} />
+    case 'footer':
+      return <FooterView elm={elm} />
+    case 'sidebar':
+      return <SidebarView elm={elm} />
+    case 'button':
+      return (
+        <button
+          className="h-full w-full flex items-center justify-center rounded"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {elm.props?.text ?? 'Button'}
+        </button>
+      )
+    case 'text':
+      return (
+        <div
+          className="h-full w-full flex items-center justify-center"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {elm.props?.text ?? 'Text'}
+        </div>
+      )
+    case 'container':
+      return (
+        <div
+          className="h-full w-full"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {elm.props?.text}
+        </div>
+      )
+    case 'code':
+      return (
+        <div
+          className="h-full w-full flex items-center justify-center"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {elm.code?.displayName || 'Code'}
+        </div>
+      )
+    case 'hud':
+      return (
+        <div
+          className="h-full w-full flex items-center justify-center"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          HUD
+        </div>
+      )
+    default:
+      return null
+  }
+}
 
-  const render = (node: any): React.ReactNode => {
-    const Comp = (registry as any)[node.type] || ((p: any) => <div {...p}>{p.children}</div>)
-    const style = node.props?.style || {}
+function ElmView({ elm }: { elm: Elm }) {
+  const select = useBuilderStore((s) => s.select)
+  const selectedId = useBuilderStore((s) => s.selectedId)
+  const isSel = selectedId === elm.id
+  const dragDraft = useBuilderStore((s) => s.ui.dragDraft)
 
-    return (
-      <div
-        key={node.id}
-        data-node-id={node.id}
-        data-node-type={node.type}
-        data-node-name={node.props?.name}
-        style={{ position: 'absolute', ...style }}
-      >
-        <Comp {...node.props}>
-          {node.children?.map((c: any) => render(c))}
-        </Comp>
-        {/* ここでプリセットCSSを必ず注入 */}
-        <PresetStyle
-          nodeId={node.id}
-          presetIds={node.props?.presetIds}
-          presetId={node.props?.presetId}
-          hoverEffects={node.props?.hoverEffects}
-          hoverTransitionMs={node.props?.hoverTransitionMs}
-        />
-      </div>
-    )
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `elm_${elm.id}`,
+    data: { from: 'canvas', id: elm.id, anchorX: elm.w / 2, anchorY: elm.h / 2 },
+  })
+
+  const preview = dragDraft && dragDraft.id === elm.id ? dragDraft.rect : null
+  const baseStyle: React.CSSProperties = {
+    left: elm.x,
+    top: elm.y,
+    width: preview ? preview.w : elm.w,
+    height: preview ? preview.h : elm.h,
+    background: elm.props?.bg,
+    color: elm.props?.color ?? '#e5e7eb',
+    opacity: elm.visible === false ? 0.4 : 1,
+    transform: preview
+      ? `translate3d(${preview.x - elm.x}px, ${preview.y - elm.y}px, 0)`
+      : undefined,
+    position: 'absolute',
   }
 
-  return <div data-canvas-root>{tree.map(render)}</div>
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      onMouseDown={() => select(elm.id)}
+      className={`absolute rounded border text-[12px] select-none ${
+        isSel ? 'border-amber-400 shadow-[0_0_0_1px_rgba(251,191,36,0.6)]' : 'border-zinc-700'
+      } ${isDragging ? 'opacity-60 cursor-move' : ''}`}
+      style={baseStyle}
+      data-node-id={elm.id}
+      data-node-type={elm.type}
+      data-node-name={elm.props?.name}
+      data-interacting={isDragging ? 'true' : undefined}
+    >
+      <ElmContent elm={elm} />
+      <PresetStyle
+        nodeId={elm.id}
+        presetIds={elm.props?.presetIds}
+        presetId={elm.props?.presetId}
+        hoverEffects={elm.props?.hoverEffects}
+        hoverTransitionMs={elm.props?.hoverTransitionMs}
+      />
+      {isSel && <ResizeHandles elm={elm} />}
+    </div>
+  )
+}
+
+export function Canvas({
+  canvasRef,
+}: {
+  canvasRef?: React.RefObject<HTMLDivElement>
+}) {
+  const elements = useBuilderStore((s) => s.elements)
+  const { setNodeRef } = useDroppable({ id: 'CANVAS' })
+
+  const ref = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      setNodeRef(node)
+      if (canvasRef) canvasRef.current = node
+    },
+    [setNodeRef, canvasRef],
+  )
+
+  return (
+    <div ref={ref} className="absolute inset-0" data-canvas-root>
+      {elements.map((elm) => (
+        <ElmView key={elm.id} elm={elm} />
+      ))}
+      <CanvasOverlay />
+    </div>
+  )
 }
 
 export default Canvas
-

--- a/web/components/builder/ResizeHandles.tsx
+++ b/web/components/builder/ResizeHandles.tsx
@@ -1,0 +1,24 @@
+'use client'
+import React from 'react'
+import type { Elm } from '@/store/builderStore'
+
+export default function ResizeHandles({ elm }: { elm: Elm }) {
+  const size = 6
+  const handles = [
+    { key: 'tl', left: -size, top: -size },
+    { key: 'tr', left: elm.w, top: -size },
+    { key: 'bl', left: -size, top: elm.h },
+    { key: 'br', left: elm.w, top: elm.h },
+  ]
+  return (
+    <>
+      {handles.map((h) => (
+        <div
+          key={h.key}
+          className="absolute bg-amber-400"
+          style={{ width: size, height: size, left: h.left, top: h.top }}
+        />
+      ))}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- replace builder canvas with draggable/droppable version that injects preset styles from element props
- add resize handle component for selected elements

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16f918f80832c87a751b8a867dbae