### PR TITLE
Refactor Canvas export

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -10,7 +10,7 @@ import {
   DragMoveEvent,
 } from '@dnd-kit/core'
 import { Palette } from '@/components/builder/Palette'
-import { Canvas } from '@/components/builder/Canvas'
+import Canvas from '@/components/builder/Canvas'
 import { Inspector } from '@/components/builder/Inspector'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -121,7 +121,7 @@ function ElmView({ elm }: { elm: Elm }) {
   )
 }
 
-export function Canvas({
+export default function Canvas({
   canvasRef,
 }: {
   canvasRef?: React.RefObject<HTMLDivElement>
@@ -146,5 +146,3 @@ export function Canvas({
     </div>
   )
 }
-
-export default Canvas


### PR DESCRIPTION
## Summary
- simplify Canvas component export
- adjust builder page to use new Canvas default export

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e216ae30832cb1663eb86e34ed2b