### PR TITLE
feat(builder): show and apply action presets

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -19,6 +19,7 @@ import { usePageStore } from '@/store/pageStore'
 import { DeviceFrame } from '@/components/hud/DeviceFrame'
 import { GridOverlay } from '@/components/hud/GridOverlay'
 import { BuilderHUD } from '@/components/hud/BuilderHUD'
+import PresetApplyListener from '@/components/builder/PresetApplyListener'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -187,6 +188,7 @@ export default function BuilderPage() {
             </div>
           </DeviceFrame>
           <BuilderHUD />
+          <PresetApplyListener canvasRef={canvasRef} />
         </main>
         <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3 flex flex-col">
           <h2 className="text-sm font-semibold mb-2">プロパティ</h2>

--- a/web/components/builder/PresetApplyListener.tsx
+++ b/web/components/builder/PresetApplyListener.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import { subscribeApply } from '@/lib/presetChannel'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
+import { useBuilderStore } from '@/store/builderStore'
+
+function getAllNodeIds(root: HTMLElement) {
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-node-id]'))
+    .map((el) => el.dataset.nodeId!)
+    .filter(Boolean)
+}
+
+export default function PresetApplyListener({ canvasRef }: { canvasRef: React.RefObject<HTMLElement> }) {
+  const { setProjectDefaults } = useInteractionRegistry()
+
+  useEffect(() => {
+    return subscribeApply((m) => {
+      if (m.scope === 'set-project-default') {
+        setProjectDefaults([m.presetId])
+        return
+      }
+
+      const apply = (ids: string[]) => {
+        ids.forEach((id) => {
+          const node = useBuilderStore.getState().elements.find((e) => e.id === id)
+          if (!node) return
+          const cur =
+            node.props?.presetIds ??
+            (node.props?.presetId ? [node.props.presetId] : []) ??
+            []
+          let next = cur
+          if (m.mode === 'replace') next = [m.presetId]
+          if (m.mode === 'append') next = Array.from(new Set([...cur, m.presetId]))
+          if (m.mode === 'remove') next = cur.filter((x) => x !== m.presetId)
+          useBuilderStore.getState().updateProps(id, {
+            presetIds: next,
+            presetId: m.mode === 'remove' && next.length === 0 ? null : m.presetId,
+          })
+        })
+      }
+
+      const root = canvasRef.current || document.body
+      if (!root) return
+      if (m.scope === 'all') {
+        apply(getAllNodeIds(root))
+      } else {
+        const sel = useBuilderStore.getState().selectedId
+        if (sel) apply([sel])
+      }
+    })
+  }, [canvasRef, setProjectDefaults])
+
+  return null
+}

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand'
 import { produce } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
+import type { Effect } from '@/types/interactions'
 
 export type ElmType =
   | 'header'
@@ -33,6 +34,10 @@ export type Elm = {
       variant: 'solid' | 'outline'
       href?: string
     }
+    presetId?: string | null
+    presetIds?: string[]
+    hoverEffects?: Effect[]
+    hoverTransitionMs?: number
   }
   code?: {
     displayName: string


### PR DESCRIPTION
## Summary
- support interaction preset props in builder elements
- listen for preset apply events in builder and apply them to selected nodes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2e2e2baac832c902eca9c02ce4cb5