### PR TITLE
Add core editing commands to editor

### DIFF
--- a/web/lib/commands.ts
+++ b/web/lib/commands.ts
@@ -11,6 +11,30 @@ import * as zoom from '@/lib/zoom';
 
 export const COMMANDS: Command[] = [
   {
+    id: 'delete',
+    title: 'Delete Selection',
+    shortcut: 'Delete',
+    run: () => useEditorStore.getState().remove(),
+  },
+  {
+    id: 'duplicate',
+    title: 'Duplicate Selection',
+    shortcut: 'Ctrl+D',
+    run: () => useEditorStore.getState().duplicate(),
+  },
+  {
+    id: 'undo',
+    title: 'Undo',
+    shortcut: 'Ctrl+Z',
+    run: () => useEditorStore.getState().undo(),
+  },
+  {
+    id: 'redo',
+    title: 'Redo',
+    shortcut: 'Ctrl+Shift+Z',
+    run: () => useEditorStore.getState().redo(),
+  },
+  {
     id: 'align.left',
     title: 'Align Left',
     keywords: ['align', 'left'],


### PR DESCRIPTION
## Summary
- add delete, duplicate, undo and redo commands
- map existing shortcuts to these commands via editor store

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ef35cf7c832cb7b89de187312017