### PR TITLE
refactor: route editor shortcuts through KeyboardHandler

### DIFF
--- a/web/components/editor/EditorShell.tsx
+++ b/web/components/editor/EditorShell.tsx
@@ -6,67 +6,26 @@ import CommandPalette from './CommandPalette';
 import ContextMenu from './ContextMenu';
 import ShareButton from './ShareButton';
 import { useState, useEffect, useRef } from 'react';
-import { getCommand } from '@/lib/keymap';
-import { COMMANDS, runCommand } from '@/lib/commands';
-import { useEditorStore } from '@/store/editorStore';
 import { DeviceFrame } from '@/components/hud/DeviceFrame';
 import { GridOverlay } from '@/components/hud/GridOverlay';
 import { RulersOverlay } from '@/components/hud/RulersOverlay';
 import { BuilderHUD } from '@/components/hud/BuilderHUD';
 import { PresetApplyListener } from '@/components/editor/PresetApplyListener';
+import KeyboardHandler from '@/components/shell/KeyboardHandler';
 
 export default function EditorShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const canvasRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const cmd = getCommand(e);
-      if (!cmd) return;
-      if (cmd === 'tool.pen') {
-        e.preventDefault();
-        useEditorStore.getState().startPen();
-        return;
-      }
-      if (cmd === 'tool.select') {
-        e.preventDefault();
-        useEditorStore.getState().cancelPen();
-        return;
-      }
-      if (cmd === 'path.confirm') {
-        e.preventDefault();
-        useEditorStore.getState().closePath();
-        return;
-      }
-      if (cmd === 'path.cancel') {
-        e.preventDefault();
-        useEditorStore.getState().cancelPen();
-        return;
-      }
-      if (cmd === 'path.deleteLast') {
-        e.preventDefault();
-        useEditorStore.getState().deleteLast();
-        return;
-      }
-      if (cmd === 'commandPalette') {
-        e.preventDefault();
-        setPaletteOpen(true);
-        return;
-      }
-      const found = COMMANDS.find((c) => c.id === cmd);
-      if (found) {
-        e.preventDefault();
-        runCommand(found.id);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => {
-      window.removeEventListener('keydown', handler);
-    };
+    const open = () => setPaletteOpen(true);
+    window.addEventListener('uibuilder:commandPalette', open);
+    return () => window.removeEventListener('uibuilder:commandPalette', open);
   }, []);
 
   return (
     <>
+      <KeyboardHandler />
       <div className="grid grid-cols-[280px_1fr_320px] h-screen text-white">
         <LeftPanel />
         <div className="relative h-full bg-[#0b1220]">

--- a/web/lib/input/keyRouter.ts
+++ b/web/lib/input/keyRouter.ts
@@ -1,5 +1,6 @@
 import { getCommand } from '@/lib/keymap';
 import { runCommand } from '@/lib/commands';
+import { useEditorStore } from '@/store/editorStore';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 function isEditingContext(target: EventTarget | null): boolean {
@@ -34,7 +35,40 @@ export function keyRouter(e: KeyboardEvent | ReactKeyboardEvent) {
   }
 
   const cmd = getCommand(evt);
-  if (cmd && runCommand(cmd)) {
+  if (!cmd) return;
+
+  if (cmd === 'tool.pen') {
+    evt.preventDefault();
+    useEditorStore.getState().startPen();
+    return;
+  }
+  if (cmd === 'tool.select') {
+    evt.preventDefault();
+    useEditorStore.getState().cancelPen();
+    return;
+  }
+  if (cmd === 'path.confirm') {
+    evt.preventDefault();
+    useEditorStore.getState().closePath();
+    return;
+  }
+  if (cmd === 'path.cancel') {
+    evt.preventDefault();
+    useEditorStore.getState().cancelPen();
+    return;
+  }
+  if (cmd === 'path.deleteLast') {
+    evt.preventDefault();
+    useEditorStore.getState().deleteLast();
+    return;
+  }
+  if (cmd === 'commandPalette') {
+    evt.preventDefault();
+    window.dispatchEvent(new CustomEvent('uibuilder:commandPalette'));
+    return;
+  }
+
+  if (runCommand(cmd)) {
     evt.preventDefault();
     evt.stopPropagation();
   }


### PR DESCRIPTION
## Summary
- remove EditorShell's direct keydown handler
- handle pen/path commands and command palette in keyRouter
- render KeyboardHandler inside EditorShell

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef42ebe8832c9060c6a41c91caff