### PR TITLE
feat: introduce NodeWrapper and props-driven preset styles

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -99,7 +99,13 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
       }}
     >
       {React.createElement(Comp as any, props, childrenArr)}
-      <PresetStyle nodeId={node.id} />
+      <PresetStyle
+        nodeId={node.id}
+        presetIds={node.props?.presetIds}
+        presetId={node.props?.presetId}
+        hoverEffects={node.props?.hoverEffects}
+        hoverTransitionMs={node.props?.hoverTransitionMs}
+      />
     </div>
   );
 };

--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -43,7 +43,13 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
           <NodeRenderer key={child.id} node={child} />
         ))}
       </Comp>
-      <PresetStyle nodeId={node.id} />
+      <PresetStyle
+        nodeId={node.id}
+        presetIds={node.props?.presetIds}
+        presetId={node.props?.presetId}
+        hoverEffects={node.props?.hoverEffects}
+        hoverTransitionMs={node.props?.hoverTransitionMs}
+      />
     </div>
   )
 }

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -3,12 +3,11 @@ import React from 'react'
 import { useDroppable, useDraggable } from '@dnd-kit/core'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
-import { useInteractionRegistry } from '@/store/interactionRegistry'
-import { buildCombinedCss } from '@/lib/interactionCss'
 import { CanvasOverlay } from './CanvasOverlay'
 import { HeaderView } from './header/HeaderView'
 import { FooterView } from './footer/FooterView'
 import { SidebarView } from '@/components/app/SidebarView'
+import NodeWrapper from './NodeWrapper'
 
 const GRID = 8
 function bgGridStyle() {
@@ -236,15 +235,6 @@ function ElmView({ elm }: { elm: Elm }) {
     data: { from: 'canvas', id: elm.id, anchorX: elm.w / 2, anchorY: elm.h / 2 },
   })
 
-  const { presets } = useInteractionRegistry()
-  const ids = Array.isArray(elm.props?.presetIds)
-    ? elm.props?.presetIds ?? []
-    : elm.props?.presetId
-      ? [elm.props.presetId]
-      : []
-  const chosen = presets.filter((p) => ids.includes(p.id))
-  const css = buildCombinedCss(elm.id, chosen)
-
   const common = 'absolute rounded border text-[12px] select-none'
   const border = isSel ? 'border-amber-400' : 'border-zinc-700'
   const shadow = isSel ? 'shadow-[0_0_0_1px_rgba(251,191,36,0.6)]' : ''
@@ -264,14 +254,22 @@ function ElmView({ elm }: { elm: Elm }) {
   }
 
   return (
-    <div
+    <NodeWrapper
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       onMouseDown={() => select(elm.id)}
       className={`${common} ${border} ${shadow} cursor-move ${isDragging ? 'opacity-60' : ''}`}
+      id={elm.id}
+      type={elm.type}
+      name={elm.props?.name}
       style={baseStyle}
-      data-node-id={elm.id}
+      presetProps={{
+        presetIds: elm.props?.presetIds,
+        presetId: elm.props?.presetId,
+        hoverEffects: elm.props?.hoverEffects,
+        hoverTransitionMs: elm.props?.hoverTransitionMs,
+      }}
     >
       {elm.type === 'header' && <HeaderView elm={elm} />}
       {elm.type === 'footer' && <FooterView elm={elm} />}
@@ -284,8 +282,7 @@ function ElmView({ elm }: { elm: Elm }) {
       {elm.type === 'text' && <div className="h-full flex items-center px-2">{elm.props?.text ?? 'Text'}</div>}
       {elm.type === 'code' && <CodePreview elm={elm} />}
       {isSel && <ResizeHandles elm={elm} />}
-      {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
-    </div>
+    </NodeWrapper>
   )
 }
 

--- a/web/components/builder/NodeWrapper.tsx
+++ b/web/components/builder/NodeWrapper.tsx
@@ -1,0 +1,42 @@
+'use client'
+import * as React from 'react'
+import PresetStyle from '@/components/interaction/PresetStyle'
+import type { Effect } from '@/types/interactions'
+
+type PresetProps = {
+  presetIds?: string[] | null
+  presetId?: string | null
+  hoverEffects?: Effect[] | null
+  hoverTransitionMs?: number | null
+}
+
+export interface NodeWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+  id: string
+  type: string
+  name?: string
+  style?: React.CSSProperties
+  presetProps?: PresetProps
+  children: React.ReactNode
+}
+
+const NodeWrapper = React.forwardRef<HTMLDivElement, NodeWrapperProps>(function NodeWrapper(
+  { id, type, name, style, presetProps, children, ...rest },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      data-node-id={id}
+      data-node-type={type}
+      data-node-name={name}
+      style={{ position: 'absolute', ...style }}
+      {...rest}
+    >
+      {children}
+      <PresetStyle nodeId={id} {...(presetProps || {})} />
+    </div>
+  )
+})
+
+export default NodeWrapper
+

--- a/web/components/interaction/PresetStyle.tsx
+++ b/web/components/interaction/PresetStyle.tsx
@@ -1,24 +1,38 @@
 'use client'
 import * as React from 'react'
 import { useInteractionRegistry } from '@/store/interactionRegistry'
-import { useEditorStore } from '@/store/editorStore'
 import { buildCombinedCss } from '@/lib/interactionCss'
 import type { Effect } from '@/types/interactions'
 
-export default function PresetStyle({ nodeId }: { nodeId: string }) {
-  const node = useEditorStore((s) => s.tree.find((n:any) => n.id === nodeId))
-  const { presets } = useInteractionRegistry()
-  if (!node) return null
+interface Props {
+  nodeId: string
+  presetIds?: string[] | null
+  presetId?: string | null
+  hoverEffects?: Effect[] | null
+  hoverTransitionMs?: number | null
+}
 
-  const props: any = node.props || {}
-  const ids: string[] = Array.isArray(props.presetIds)
-    ? props.presetIds
-    : (props.presetId ? [props.presetId] : [])
+export default function PresetStyle({
+  nodeId,
+  presetIds,
+  presetId,
+  hoverEffects,
+  hoverTransitionMs,
+}: Props) {
+  const { presets } = useInteractionRegistry()
+  const ids = Array.isArray(presetIds)
+    ? presetIds
+    : presetId
+      ? [presetId]
+      : []
 
   const chosen = presets.filter((p) => ids.includes(p.id))
-  const inline = props.hoverEffects as Effect[] | undefined
-  const ms = props.hoverTransitionMs as number | undefined
-  const css = buildCombinedCss(node.id, chosen, inline, ms)
+  const css = buildCombinedCss(
+    nodeId,
+    chosen,
+    hoverEffects || undefined,
+    hoverTransitionMs || undefined,
+  )
 
   return css ? <style dangerouslySetInnerHTML={{ __html: css }} /> : null
 }

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -68,7 +68,13 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         className={link ? 'cursor-pointer' : undefined}
       >
         <div className="w-full h-full bg-gray-300" />
-        <PresetStyle nodeId={node.id} />
+        <PresetStyle
+          nodeId={node.id}
+          presetIds={node.props?.presetIds}
+          presetId={node.props?.presetId}
+          hoverEffects={node.props?.hoverEffects}
+          hoverTransitionMs={node.props?.hoverTransitionMs}
+        />
       </div>
     );
   }
@@ -84,7 +90,13 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         className={link ? 'cursor-pointer' : undefined}
       >
         {node.props?.text}
-        <PresetStyle nodeId={node.id} />
+        <PresetStyle
+          nodeId={node.id}
+          presetIds={node.props?.presetIds}
+          presetId={node.props?.presetId}
+          hoverEffects={node.props?.hoverEffects}
+          hoverTransitionMs={node.props?.hoverTransitionMs}
+        />
       </div>
     );
   }
@@ -101,7 +113,13 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       {node.children?.map((c) => (
         <NodeRenderer key={c.id} node={c} onLink={onLink} />
       ))}
-      <PresetStyle nodeId={node.id} />
+      <PresetStyle
+        nodeId={node.id}
+        presetIds={node.props?.presetIds}
+        presetId={node.props?.presetId}
+        hoverEffects={node.props?.hoverEffects}
+        hoverTransitionMs={node.props?.hoverTransitionMs}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add NodeWrapper component to wrap nodes with data attributes and preset styles
- refactor PresetStyle to derive CSS purely from props
- update builder, preview, and legacy renderers to pass preset data through props

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fe6c495c832cae66da27f3c61755