### PR TITLE
feat: add static builder registry with metadata

### DIFF
--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -10,7 +10,8 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
   const { setRect } = useRects()
   const ref = React.useRef<HTMLDivElement>(null)
-  const Comp = (registry as any)[node.type] || ((p: any) => <div {...p}>{p.children}</div>)
+  const entry = (registry as any)[node.type]
+  const Comp = entry?.Comp || ((p: any) => <div {...p}>{p.children}</div>)
   const style = node.props?.style || {}
 
  

--- a/web/components/blocks/Button.tsx
+++ b/web/components/blocks/Button.tsx
@@ -1,0 +1,17 @@
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Button({ text, className, onClick }: { text: string; className?: string; onClick?: () => void }) {
+  return (
+    <button className={className} onClick={onClick}>
+      {text}
+    </button>
+  )
+}
+
+export const ButtonMeta: BuilderNodeMeta = {
+  displayName: 'Button',
+  defaultSize: { w: 120, h: 40 },
+  resizable: false,
+  snap: 'grid',
+  events: ['click'],
+}

--- a/web/components/blocks/Container.tsx
+++ b/web/components/blocks/Container.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react'
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Container({ className, children }: PropsWithChildren<{ className?: string }>) {
+  return <div className={className}>{children}</div>
+}
+
+export const ContainerMeta: BuilderNodeMeta = {
+  displayName: 'Container',
+  defaultSize: { w: 320, h: 200 },
+  resizable: true,
+  snap: 'grid',
+  allowChildren: true,
+}

--- a/web/components/blocks/Footer.tsx
+++ b/web/components/blocks/Footer.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react'
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Footer({ className, children }: PropsWithChildren<{ className?: string }>) {
+  return <footer className={className}>{children}</footer>
+}
+
+export const FooterMeta: BuilderNodeMeta = {
+  displayName: 'Footer',
+  defaultSize: { w: 960, h: 56 },
+  resizable: false,
+  snap: 'grid',
+}

--- a/web/components/blocks/Header.tsx
+++ b/web/components/blocks/Header.tsx
@@ -1,0 +1,13 @@
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Header({ text, level = 1, className }: { text: string; level?: number; className?: string }) {
+  const Tag = `h${level}` as keyof JSX.IntrinsicElements
+  return <Tag className={className}>{text}</Tag>
+}
+
+export const HeaderMeta: BuilderNodeMeta = {
+  displayName: 'Header',
+  defaultSize: { w: 960, h: 64 },
+  resizable: false,
+  snap: 'grid',
+}

--- a/web/components/blocks/Hud.tsx
+++ b/web/components/blocks/Hud.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react'
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Hud({ className, children }: PropsWithChildren<{ className?: string }>) {
+  return <div className={className}>{children}</div>
+}
+
+export const HudMeta: BuilderNodeMeta = {
+  displayName: 'HUD',
+  defaultSize: { w: 280, h: 44 },
+  resizable: false,
+  snap: 'grid',
+  allowChildren: true,
+}

--- a/web/components/blocks/Sidebar.tsx
+++ b/web/components/blocks/Sidebar.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react'
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Sidebar({ className, children }: PropsWithChildren<{ className?: string }>) {
+  return <aside className={className}>{children}</aside>
+}
+
+export const SidebarMeta: BuilderNodeMeta = {
+  displayName: 'Sidebar',
+  defaultSize: { w: 240, h: 600 },
+  resizable: true,
+  snap: 'grid',
+  allowChildren: true,
+}

--- a/web/components/blocks/Text.tsx
+++ b/web/components/blocks/Text.tsx
@@ -1,0 +1,12 @@
+import type { BuilderNodeMeta } from '@/types/builder'
+
+export function Text({ text, className }: { text: string; className?: string }) {
+  return <div className={className}>{text}</div>
+}
+
+export const TextMeta: BuilderNodeMeta = {
+  displayName: 'Text',
+  defaultSize: { w: 200, h: 24 },
+  resizable: false,
+  snap: 'grid',
+}

--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import type { ElmType } from '@/store/builderStore'
+import { registry, type RegistryKey } from '@/lib/registry'
 import { loadDocgenMeta, type DocgenMetaItem } from '@/lib/builder/docgen'
 
 function DraggableItem({ type, label }: { type: ElmType; label: string }) {
@@ -44,15 +45,9 @@ function CodeItem({ meta }: { meta: DocgenMetaItem }) {
 }
 
 export function Palette() {
-  const items: { type: ElmType; label: string }[] = [
-    { type: 'header', label: 'Header' },
-    { type: 'footer', label: 'Footer' },
-    { type: 'sidebar', label: 'Sidebar' },
-    { type: 'hud', label: 'HUD' },
-    { type: 'container', label: 'Container' },
-    { type: 'button', label: 'Button' },
-    { type: 'text', label: 'Text' },
-  ]
+  const items: { type: RegistryKey; label: string }[] = Object.entries(registry).map(
+    ([key, value]) => ({ type: key as RegistryKey, label: value.meta.displayName }),
+  )
   const [tab, setTab] = React.useState<'basic' | 'code'>('basic')
   const [codes, setCodes] = React.useState<DocgenMetaItem[]>([])
   React.useEffect(() => {

--- a/web/lib/registry.tsx
+++ b/web/lib/registry.tsx
@@ -1,23 +1,20 @@
-import { PropsWithChildren } from 'react'
+import { Button, ButtonMeta } from '@/components/blocks/Button'
+import { Container, ContainerMeta } from '@/components/blocks/Container'
+import { Text, TextMeta } from '@/components/blocks/Text'
+import { Header, HeaderMeta } from '@/components/blocks/Header'
+import { Footer, FooterMeta } from '@/components/blocks/Footer'
+import { Sidebar, SidebarMeta } from '@/components/blocks/Sidebar'
+import { Hud, HudMeta } from '@/components/blocks/Hud'
 
-export const registry: Record<string, any> = {
-  Header: ({ text, level = 1, className }: { text: string; level?: number; className?: string }) => {
-    const Tag = `h${level}` as keyof JSX.IntrinsicElements
-    return <Tag className={className}>{text}</Tag>
-  },
-  Sidebar: ({ className, children }: PropsWithChildren<{ className?: string }>) => (
-    <aside className={className}>{children}</aside>
-  ),
-  Section: ({ className, children }: PropsWithChildren<{ className?: string }>) => (
-    <section className={className}>{children}</section>
-  ),
-  Button: ({ text, className, onClick }: { text: string; className?: string; onClick?: () => void }) => (
-    <button className={className} onClick={onClick}>{text}</button>
-  ),
-  Window: ({ title, className, children }: PropsWithChildren<{ title: string; className?: string }>) => (
-    <div className={className}><div>{title}</div><div>{children}</div></div>
-  ),
-  HUD: ({ className, children }: PropsWithChildren<{ className?: string }>) => (
-    <div className={className}>{children}</div>
-  )
-}
+export const registry = {
+  button: { Comp: Button, meta: ButtonMeta },
+  container: { Comp: Container, meta: ContainerMeta },
+  text: { Comp: Text, meta: TextMeta },
+  header: { Comp: Header, meta: HeaderMeta },
+  footer: { Comp: Footer, meta: FooterMeta },
+  sidebar: { Comp: Sidebar, meta: SidebarMeta },
+  hud: { Comp: Hud, meta: HudMeta },
+} as const
+
+export type Registry = typeof registry
+export type RegistryKey = keyof Registry

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -3,16 +3,9 @@ import { create } from 'zustand'
 import { produce } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
+import { registry, type RegistryKey } from '@/lib/registry'
 
-export type ElmType =
-  | 'header'
-  | 'footer'
-  | 'sidebar'
-  | 'hud'
-  | 'button'
-  | 'text'
-  | 'container'
-  | 'code'
+export type ElmType = RegistryKey | 'code'
 
 export type Elm = {
   id: string
@@ -85,25 +78,11 @@ function snap(n: number, step = SNAP) {
 }
 
 function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
-  switch (type) {
-    case 'header':
-      return { w: 960, h: 64, text: 'Header' }
-    case 'footer':
-      return { w: 960, h: 56, text: 'Footer' }
-    case 'sidebar':
-      return { w: 240, h: 600, text: 'Sidebar' }
-    case 'hud':
-      return { w: 280, h: 44, text: 'HUD' }
-    case 'button':
-      return { w: 120, h: 36, text: 'Button' }
-    case 'text':
-      return { w: 200, h: 24, text: 'Text' }
-    case 'code':
-      return { w: 160, h: 40 }
-    case 'container':
-    default:
-      return { w: 320, h: 200, text: 'Container' }
-  }
+  if (type === 'code') return { w: 160, h: 40 }
+  const entry = (registry as any)[type]
+  const size = entry?.meta?.defaultSize ?? { w: 320, h: 200 }
+  const text = entry?.meta?.displayName
+  return { ...size, text }
 }
 
 export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => ({

--- a/web/types/builder.ts
+++ b/web/types/builder.ts
@@ -1,0 +1,11 @@
+export type BuilderNodeMeta = {
+  displayName: string
+  icon?: string
+  defaultSize?: { w: number; h: number }
+  resizable?: boolean
+  snap?: 'grid' | 'guides' | 'none'
+  allowChildren?: boolean
+  slots?: string[]
+  propertySchema?: any
+  events?: string[]
+}


### PR DESCRIPTION
## Summary
- define `BuilderNodeMeta` to describe blocks
- add metadata exports for core blocks (button, container, text, etc.)
- replace dynamic registry with static imports and metadata
- render palette items from registry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3005b0e40832cab0eb7981000a0b6