### PR TITLE
feat(builder): add alignment controls

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -291,12 +291,22 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const els = useBuilderStore((s) => s.elements)
   const select = useBuilderStore((s) => s.select)
   const nudge = useBuilderStore((s) => s.nudge)
+  const align = useBuilderStore((s) => s.align)
   const { setNodeRef } = useDroppable({ id: 'CANVAS' })
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete', 'Backspace'].includes(e.key)) {
+      if (
+        ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete', 'Backspace'].includes(
+          e.key,
+        )
+      ) {
         e.preventDefault()
+      }
+      if (e.altKey && e.shiftKey) {
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') align('hSpace')
+        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') align('vSpace')
+        return
       }
       if (e.key === 'ArrowUp') nudge(0, -GRID)
       if (e.key === 'ArrowDown') nudge(0, GRID)
@@ -305,7 +315,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [nudge])
+  }, [nudge, align])
 
   return (
     <div className="h-full w-full flex items-center justify-center bg-black">

--- a/web/components/builder/CanvasOverlay.tsx
+++ b/web/components/builder/CanvasOverlay.tsx
@@ -4,7 +4,9 @@ import { useBuilderStore } from '@/store/builderStore'
 
 export function CanvasOverlay() {
   const guides = useBuilderStore((s) => s.ui.guides)
-  if (!guides.length) return null
+  const selectedIds = useBuilderStore((s) => s.selectedIds)
+  const align = useBuilderStore((s) => s.align)
+  const showToolbar = selectedIds.length > 1
   return (
     <div className="absolute inset-0 pointer-events-none z-50">
       {guides.map((g, i) =>
@@ -21,6 +23,30 @@ export function CanvasOverlay() {
             style={{ top: g.pos }}
           />
         ),
+      )}
+      {showToolbar && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-1 pointer-events-auto">
+          {(
+            [
+              ['left', 'L'],
+              ['centerX', 'CX'],
+              ['right', 'R'],
+              ['top', 'T'],
+              ['centerY', 'CY'],
+              ['bottom', 'B'],
+              ['hSpace', 'HS'],
+              ['vSpace', 'VS'],
+            ] as const
+          ).map(([k, label]) => (
+            <button
+              key={k}
+              onClick={() => align(k)}
+              className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -40,6 +40,7 @@ export type Elm = {
 type BuilderState = {
   elements: Elm[]
   selectedId: string | null
+  selectedIds: string[]
   snap: number
   ui: {
     dragDraft?: { id: string; rect: { x: number; y: number; w: number; h: number } }
@@ -60,7 +61,18 @@ type BuilderActions = {
   ) => void
   setGuides: (lines: Array<{ axis: 'x' | 'y'; pos: number }>) => void
   clearGuides: () => void
-  select: (id: string | null) => void
+  select: (id: string | string[] | null) => void
+  align: (
+    kind:
+      | 'left'
+      | 'centerX'
+      | 'right'
+      | 'top'
+      | 'centerY'
+      | 'bottom'
+      | 'hSpace'
+      | 'vSpace',
+  ) => void
   updateProps: (
     id: string,
     patch: Partial<Elm['props']> & { code?: Partial<Elm['code']> },
@@ -88,6 +100,7 @@ function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
 export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => ({
   elements: [],
   selectedId: null,
+  selectedIds: [],
   snap: SNAP,
   ui: { guides: [] },
 
@@ -136,6 +149,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
           })
         }
         draft.selectedId = id
+        draft.selectedIds = [id]
       }),
     )
   },
@@ -187,7 +201,93 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
   },
 
   select(id) {
-    set({ selectedId: id })
+    if (Array.isArray(id)) {
+      set({ selectedId: id[id.length - 1] ?? null, selectedIds: id })
+    } else {
+      set({ selectedId: id, selectedIds: id ? [id] : [] })
+    }
+  },
+
+  align(kind) {
+    const ids = get().selectedIds
+    const els = get()
+      .elements.filter((e) => ids.includes(e.id) && e.visible !== false)
+    if (els.length < 2) return
+    const x1 = Math.min(...els.map((e) => e.x))
+    const y1 = Math.min(...els.map((e) => e.y))
+    const x2 = Math.max(...els.map((e) => e.x + e.w))
+    const y2 = Math.max(...els.map((e) => e.y + e.h))
+    set(
+      produce((draft: BuilderState) => {
+        const targets = draft.elements.filter((e) =>
+          ids.includes(e.id) && e.visible !== false,
+        )
+        switch (kind) {
+          case 'left':
+            targets.forEach((e) => {
+              e.x = x1
+            })
+            break
+          case 'centerX': {
+            const cx = (x1 + x2) / 2
+            targets.forEach((e) => {
+              e.x = Math.round(cx - e.w / 2)
+            })
+            break
+          }
+          case 'right':
+            targets.forEach((e) => {
+              e.x = x2 - e.w
+            })
+            break
+          case 'top':
+            targets.forEach((e) => {
+              e.y = y1
+            })
+            break
+          case 'centerY': {
+            const cy = (y1 + y2) / 2
+            targets.forEach((e) => {
+              e.y = Math.round(cy - e.h / 2)
+            })
+            break
+          }
+          case 'bottom':
+            targets.forEach((e) => {
+              e.y = y2 - e.h
+            })
+            break
+          case 'hSpace': {
+            const sorted = [...targets].sort((a, b) => a.x - b.x)
+            const min = sorted[0].x
+            const max = sorted[sorted.length - 1].x +
+              sorted[sorted.length - 1].w
+            const total = sorted.reduce((s, e) => s + e.w, 0)
+            const gap = sorted.length > 1 ? Math.round((max - min - total) / (sorted.length - 1)) : 0
+            let cur = min
+            sorted.forEach((e) => {
+              e.x = cur
+              cur += e.w + gap
+            })
+            break
+          }
+          case 'vSpace': {
+            const sorted = [...targets].sort((a, b) => a.y - b.y)
+            const min = sorted[0].y
+            const max = sorted[sorted.length - 1].y +
+              sorted[sorted.length - 1].h
+            const total = sorted.reduce((s, e) => s + e.h, 0)
+            const gap = sorted.length > 1 ? Math.round((max - min - total) / (sorted.length - 1)) : 0
+            let cur = min
+            sorted.forEach((e) => {
+              e.y = cur
+              cur += e.h + gap
+            })
+            break
+          }
+        }
+      }),
+    )
   },
 
   updateProps(id, patch) {


### PR DESCRIPTION
## Summary
- add alignment/spread action to builder store
- expose alignment toolbar on canvas
- support Alt+Shift+Arrow shortcuts for spacing

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30184e978832cb093543fdb213195