### PR TITLE
feat: add grid settings and snapping controls

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -3,15 +3,14 @@ import React from 'react'
 import { useDroppable, useDraggable } from '@dnd-kit/core'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
+import { useGridStore } from '@/store/gridStore'
 import { CanvasOverlay } from './CanvasOverlay'
 import { HeaderView } from './header/HeaderView'
 import { FooterView } from './footer/FooterView'
 import { SidebarView } from '@/components/app/SidebarView'
 import NodeWrapper from './NodeWrapper'
 
-const GRID = 8
-function bgGridStyle() {
-  const s = GRID
+function bgGridStyle(s: number) {
   return {
     backgroundImage:
       'linear-gradient(to right, rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.05) 1px, transparent 1px)',
@@ -293,6 +292,8 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const nudge = useBuilderStore((s) => s.nudge)
   const align = useBuilderStore((s) => s.align)
   const { setNodeRef } = useDroppable({ id: 'CANVAS' })
+  const gridSize = useGridStore((s) => s.size)
+  const gridVisible = useGridStore((s) => s.visible)
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -308,14 +309,14 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         if (e.key === 'ArrowUp' || e.key === 'ArrowDown') align('vSpace')
         return
       }
-      if (e.key === 'ArrowUp') nudge(0, -GRID)
-      if (e.key === 'ArrowDown') nudge(0, GRID)
-      if (e.key === 'ArrowLeft') nudge(-GRID, 0)
-      if (e.key === 'ArrowRight') nudge(GRID, 0)
+      if (e.key === 'ArrowUp') nudge(0, -gridSize)
+      if (e.key === 'ArrowDown') nudge(0, gridSize)
+      if (e.key === 'ArrowLeft') nudge(-gridSize, 0)
+      if (e.key === 'ArrowRight') nudge(gridSize, 0)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [nudge, align])
+  }, [nudge, align, gridSize])
 
   return (
     <div className="h-full w-full flex items-center justify-center bg-black">
@@ -331,7 +332,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
           if (e.target === e.currentTarget) select(null)
         }}
         className="relative w-[1200px] h-[720px] border border-zinc-800 rounded-lg overflow-hidden"
-        style={bgGridStyle()}
+        style={gridVisible ? bgGridStyle(gridSize) : undefined}
       >
         {/* page base pseudo preview */}
         <div className="absolute inset-0 pointer-events-none" />

--- a/web/components/builder/CanvasOverlay.tsx
+++ b/web/components/builder/CanvasOverlay.tsx
@@ -1,12 +1,14 @@
 'use client'
 import React from 'react'
 import { useBuilderStore } from '@/store/builderStore'
+import { useGridStore } from '@/store/gridStore'
 
 export function CanvasOverlay() {
   const guides = useBuilderStore((s) => s.ui.guides)
   const selectedIds = useBuilderStore((s) => s.selectedIds)
   const align = useBuilderStore((s) => s.align)
   const showToolbar = selectedIds.length > 1
+  const { visible, snap, size, setVisible, setSnap, setSize } = useGridStore()
   return (
     <div className="absolute inset-0 pointer-events-none z-50">
       {guides.map((g, i) =>
@@ -24,30 +26,56 @@ export function CanvasOverlay() {
           />
         ),
       )}
-      {showToolbar && (
-        <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-1 pointer-events-auto">
-          {(
-            [
-              ['left', 'L'],
-              ['centerX', 'CX'],
-              ['right', 'R'],
-              ['top', 'T'],
-              ['centerY', 'CY'],
-              ['bottom', 'B'],
-              ['hSpace', 'HS'],
-              ['vSpace', 'VS'],
-            ] as const
-          ).map(([k, label]) => (
-            <button
-              key={k}
-              onClick={() => align(k)}
-              className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
-            >
-              {label}
-            </button>
+      <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-1 pointer-events-auto">
+        <button
+          onClick={() => setVisible(!visible)}
+          className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${visible ? '' : "opacity-50"}`}
+        >
+          Grid
+        </button>
+        <button
+          onClick={() => setSnap(!snap)}
+          className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${snap ? '' : "opacity-50"}`}
+        >
+          Snap
+        </button>
+        <select
+          value={size}
+          onChange={(e) => setSize(parseInt(e.target.value, 10))}
+          className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
+        >
+          {[4, 8, 12, 16].map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
           ))}
-        </div>
-      )}
+        </select>
+        {showToolbar && (
+          <>
+            <div className="mx-1 w-px bg-zinc-600" />
+            {(
+              [
+                ['left', 'L'],
+                ['centerX', 'CX'],
+                ['right', 'R'],
+                ['top', 'T'],
+                ['centerY', 'CY'],
+                ['bottom', 'B'],
+                ['hSpace', 'HS'],
+                ['vSpace', 'VS'],
+              ] as const
+            ).map(([k, label]) => (
+              <button
+                key={k}
+                onClick={() => align(k)}
+                className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
+              >
+                {label}
+              </button>
+            ))}
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/web/lib/builder/snap.ts
+++ b/web/lib/builder/snap.ts
@@ -1,4 +1,5 @@
 import type { Elm } from '@/store/builderStore'
+import { useGridStore } from '@/store/gridStore'
 
 export type SnapPoints = {
   x: { left: number[]; center: number[]; right: number[] }
@@ -25,7 +26,6 @@ export function collectSnapPoints(elements: Elm[], exceptId?: string): SnapPoint
 export type Rect = { x: number; y: number; w: number; h: number }
 export type GuideLine = { axis: 'x' | 'y'; pos: number }
 
-const GRID = 8
 const SNAP_THRESHOLD = 6
 
 export function snapRect(
@@ -35,11 +35,13 @@ export function snapRect(
 ): { rect: Rect; guides: GuideLine[] } {
   const threshold = opts.threshold ?? SNAP_THRESHOLD
   const mode = opts.mode ?? 'move'
+  const { snap, size } = useGridStore.getState()
+  if (!snap) return { rect, guides: [] }
   let { x, y, w, h } = rect
-  x = Math.round(x / GRID) * GRID
-  y = Math.round(y / GRID) * GRID
-  w = Math.round(w / GRID) * GRID
-  h = Math.round(h / GRID) * GRID
+  x = Math.round(x / size) * size
+  y = Math.round(y / size) * size
+  w = Math.round(w / size) * size
+  h = Math.round(h / size) * size
 
   const left = x
   const right = x + w

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -4,6 +4,7 @@ import { produce } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
 import { registry, type RegistryKey } from '@/lib/registry'
+import { useGridStore } from '@/store/gridStore'
 
 export type ElmType = RegistryKey | 'code'
 
@@ -41,7 +42,6 @@ type BuilderState = {
   elements: Elm[]
   selectedId: string | null
   selectedIds: string[]
-  snap: number
   ui: {
     dragDraft?: { id: string; rect: { x: number; y: number; w: number; h: number } }
     guides: Array<{ axis: 'x' | 'y'; pos: number }>
@@ -84,9 +84,9 @@ type BuilderActions = {
   setElements: (els: Elm[]) => void
 }
 
-const SNAP = 8
-function snap(n: number, step = SNAP) {
-  return Math.round(n / step) * step
+function snapToGrid(n: number) {
+  const size = useGridStore.getState().size
+  return Math.round(n / size) * size
 }
 
 function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
@@ -101,14 +101,14 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
   elements: [],
   selectedId: null,
   selectedIds: [],
-  snap: SNAP,
   ui: { guides: [] },
 
   addFromPalette(type, at, meta) {
     const id = `elm_${Date.now().toString(36)}`
     const { w, h, text } = defaultSize(type)
-    const x = snap(at?.x ?? 40)
-    const y = snap(at?.y ?? 40)
+    const snapState = useGridStore.getState()
+    const x = snapState.snap ? snapToGrid(at?.x ?? 40) : at?.x ?? 40
+    const y = snapState.snap ? snapToGrid(at?.y ?? 40) : at?.y ?? 40
     set(
       produce((draft: BuilderState) => {
         if (type === 'code') {
@@ -159,8 +159,9 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
       produce((draft: BuilderState) => {
         const e = draft.elements.find((x) => x.id === id)
         if (!e) return
-        e.x = snapGrid ? snap(to.x) : to.x
-        e.y = snapGrid ? snap(to.y) : to.y
+        const { snap } = useGridStore.getState()
+        e.x = snapGrid && snap ? snapToGrid(to.x) : to.x
+        e.y = snapGrid && snap ? snapToGrid(to.y) : to.y
       }),
     )
   },
@@ -170,8 +171,9 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
       produce((draft: BuilderState) => {
         const e = draft.elements.find((x) => x.id === id)
         if (!e) return
-        e.w = Math.max(16, snapGrid ? snap(to.w) : to.w)
-        e.h = Math.max(16, snapGrid ? snap(to.h) : to.h)
+        const { snap } = useGridStore.getState()
+        e.w = Math.max(16, snapGrid && snap ? snapToGrid(to.w) : to.w)
+        e.h = Math.max(16, snapGrid && snap ? snapToGrid(to.h) : to.h)
       }),
     )
   },
@@ -351,7 +353,8 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     if (!id) return
     const el = get().elements.find((x) => x.id === id)
     if (!el) return
-    get().move(id, { x: el.x + dx, y: el.y + dy })
+    const { snap } = useGridStore.getState()
+    get().move(id, { x: el.x + dx, y: el.y + dy }, snap)
   },
 
   setElements(els) {

--- a/web/store/gridStore.ts
+++ b/web/store/gridStore.ts
@@ -1,13 +1,20 @@
+'use client'
 import { create } from 'zustand'
 
 type GridState = {
+  size: number
+  visible: boolean
+  snap: boolean
   showGrid: boolean
   snapGrid: boolean
-  pitch: number        // 主要グリッド間隔（ワールドpx）
-  subDiv: number       // マイナー何分割か（例: 4 なら 1/4 ピッチ）
-  offsetX: number      // グリッド原点のX（ワールドpx）
-  offsetY: number      // グリッド原点のY（ワールドpx）
-  minGapPx: number     // 画面pxでの最小格子間隔（描画が詰みすぎないため）
+  pitch: number
+  subDiv: number
+  offsetX: number
+  offsetY: number
+  minGapPx: number
+  setSize: (n: number) => void
+  setVisible: (v: boolean) => void
+  setSnap: (v: boolean) => void
   setShowGrid: (v: boolean) => void
   setSnapGrid: (v: boolean) => void
   setPitch: (n: number) => void
@@ -17,18 +24,23 @@ type GridState = {
 }
 
 export const useGridStore = create<GridState>((set) => ({
+  size: 8,
+  visible: true,
+  snap: true,
   showGrid: true,
-  snapGrid: false,
-  pitch: 16,
+  snapGrid: true,
+  pitch: 8,
   subDiv: 4,
   offsetX: 0,
   offsetY: 0,
   minGapPx: 8,
-  setShowGrid: (v) => set({ showGrid: v }),
-  setSnapGrid: (v) => set({ snapGrid: v }),
-  setPitch: (n) => set({ pitch: Math.max(1, Math.round(n)) }),
+  setSize: (n) => set({ size: n, pitch: n }),
+  setVisible: (v) => set({ visible: v, showGrid: v }),
+  setSnap: (v) => set({ snap: v, snapGrid: v }),
+  setShowGrid: (v) => set({ visible: v, showGrid: v }),
+  setSnapGrid: (v) => set({ snap: v, snapGrid: v }),
+  setPitch: (n) => set({ size: Math.max(1, Math.round(n)), pitch: Math.max(1, Math.round(n)) }),
   setSubDiv: (n) => set({ subDiv: Math.max(1, Math.round(n)) }),
   setOffset: (x, y) => set({ offsetX: x, offsetY: y }),
   setMinGapPx: (n) => set({ minGapPx: Math.max(2, Math.round(n)) }),
 }))
-


### PR DESCRIPTION
## Summary
- add zustand grid store to manage grid size, visibility and snapping
- render canvas grid based on store and wire arrow keys to grid step
- respect grid store in snapping logic and expose grid controls in overlay toolbar

## Testing
- `pnpm --filter ui-builder-web build` *(fails: Cannot find module '@domain-components')*


------
https://chatgpt.com/codex/tasks/task_e_68b302d758c4832cb51e8f0021ba2048