### PR TITLE
feat: add autosave for builder state

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -19,6 +19,7 @@ import { usePageStore } from '@/store/pageStore'
 import { DeviceFrame } from '@/components/hud/DeviceFrame'
 import { GridOverlay } from '@/components/hud/GridOverlay'
 import { BuilderHUD } from '@/components/hud/BuilderHUD'
+import { useAutosave } from '@/hooks/useAutosave'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -30,6 +31,7 @@ export default function BuilderPage() {
   const setGuides = useBuilderStore((s) => s.setGuides)
   const clearGuides = useBuilderStore((s) => s.clearGuides)
   const setElements = useBuilderStore((s) => s.setElements)
+  useAutosave()
 
   const currentPageId = usePageStore((s) => s.currentPageId)
   const getTree = usePageStore((s) => s.getTree)

--- a/web/hooks/useAutosave.ts
+++ b/web/hooks/useAutosave.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useBuilderStore } from '@/store/builderStore'
+
+const storage = {
+  get(key: string) {
+    if (typeof window === 'undefined') return null
+    try {
+      return window.localStorage.getItem(key)
+    } catch {
+      return null
+    }
+  },
+  set(key: string, val: string) {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(key, val)
+    } catch {}
+  },
+}
+
+const KEY = 'builder:doc'
+
+export function useAutosave() {
+  useEffect(() => {
+    const saved = storage.get(KEY)
+    if (saved && useBuilderStore.getState().elements.length === 0) {
+      if (window.confirm('Restore previous session?')) {
+        useBuilderStore.getState().hydrate(saved)
+      }
+    }
+
+    let timer: number | null = null
+    const unsub = useBuilderStore.subscribe(
+      (s) => s.elements,
+      () => {
+        if (timer) window.clearTimeout(timer)
+        timer = window.setTimeout(() => {
+          const json = useBuilderStore.getState().serialize()
+          storage.set(KEY, json)
+        }, 1500)
+      },
+    )
+
+    return () => {
+      unsub()
+      if (timer) window.clearTimeout(timer)
+    }
+  }, [])
+}
+

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -82,6 +82,8 @@ type BuilderActions = {
   sendToBack: (id: string) => void
   nudge: (dx: number, dy: number) => void
   setElements: (els: Elm[]) => void
+  serialize: () => string
+  hydrate: (json: string) => void
 }
 
 function snapToGrid(n: number) {
@@ -363,6 +365,21 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
         draft.elements = els
       }),
     )
+  },
+
+  serialize() {
+    return JSON.stringify({ elements: get().elements })
+  },
+
+  hydrate(json) {
+    try {
+      const data = JSON.parse(json)
+      if (Array.isArray(data.elements)) {
+        set({ elements: data.elements, selectedId: null, selectedIds: [], ui: { guides: [] } })
+      }
+    } catch (e) {
+      console.error('Failed to hydrate builder state', e)
+    }
   },
 }))
 


### PR DESCRIPTION
## Summary
- add serialize/hydrate helpers to builder store
- introduce `useAutosave` hook saving state to localStorage
- wire autosave into builder page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3077b3f7c832c813da3fd2c68bdd5