### PR TITLE
feat(guides): snap distance & lock/visible toggles

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -9,6 +9,7 @@ import { HeaderView } from './header/HeaderView'
 import { FooterView } from './footer/FooterView'
 import { SidebarView } from '@/components/app/SidebarView'
 import NodeWrapper from './NodeWrapper'
+import { Rulers } from './Rulers'
 
 function bgGridStyle(s: number) {
   return {
@@ -340,6 +341,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
           <ElmView key={e.id} elm={e} />
         ))}
         <CanvasOverlay />
+        <Rulers width={1200} height={720} canvasRef={canvasRef} />
         <div className="absolute left-2 bottom-2 text-[11px] text-zinc-400 bg-black/40 px-2 py-1 rounded border border-zinc-800">
           drag to move • drop from Palette • arrows to nudge • click empty = unselect
         </div>

--- a/web/components/builder/CanvasOverlay.tsx
+++ b/web/components/builder/CanvasOverlay.tsx
@@ -1,81 +1,48 @@
 'use client'
 import React from 'react'
 import { useBuilderStore } from '@/store/builderStore'
-import { useGridStore } from '@/store/gridStore'
+import { useGuidesStore } from '@/store/guidesStore'
+import { Toolbar } from './Toolbar'
 
 export function CanvasOverlay() {
-  const guides = useBuilderStore((s) => s.ui.guides)
+  const snapGuides = useBuilderStore((s) => s.ui.guides)
   const selectedIds = useBuilderStore((s) => s.selectedIds)
   const align = useBuilderStore((s) => s.align)
-  const showToolbar = selectedIds.length > 1
-  const { visible, snap, size, setVisible, setSnap, setSize } = useGridStore()
+  const showAlign = selectedIds.length > 1
+  const guides = useGuidesStore((s) => s.guides.filter((g) => g.visible))
   return (
     <div className="absolute inset-0 pointer-events-none z-50">
-      {guides.map((g, i) =>
+      {guides.map((g) =>
         g.axis === 'x' ? (
           <div
-            key={i}
-            className="absolute top-0 bottom-0 border-l border-amber-400/70"
+            key={g.id}
+            className={`absolute top-0 bottom-0 border-l ${g.locked ? 'border-red-400 border-dashed' : 'border-amber-400/70'}`}
             style={{ left: g.pos }}
           />
         ) : (
           <div
-            key={i}
-            className="absolute left-0 right-0 border-t border-amber-400/70"
+            key={g.id}
+            className={`absolute left-0 right-0 border-t ${g.locked ? 'border-red-400 border-dashed' : 'border-amber-400/70'}`}
             style={{ top: g.pos }}
           />
         ),
       )}
-      <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-1 pointer-events-auto">
-        <button
-          onClick={() => setVisible(!visible)}
-          className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${visible ? '' : "opacity-50"}`}
-        >
-          Grid
-        </button>
-        <button
-          onClick={() => setSnap(!snap)}
-          className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${snap ? '' : "opacity-50"}`}
-        >
-          Snap
-        </button>
-        <select
-          value={size}
-          onChange={(e) => setSize(parseInt(e.target.value, 10))}
-          className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
-        >
-          {[4, 8, 12, 16].map((n) => (
-            <option key={n} value={n}>
-              {n}
-            </option>
-          ))}
-        </select>
-        {showToolbar && (
-          <>
-            <div className="mx-1 w-px bg-zinc-600" />
-            {(
-              [
-                ['left', 'L'],
-                ['centerX', 'CX'],
-                ['right', 'R'],
-                ['top', 'T'],
-                ['centerY', 'CY'],
-                ['bottom', 'B'],
-                ['hSpace', 'HS'],
-                ['vSpace', 'VS'],
-              ] as const
-            ).map(([k, label]) => (
-              <button
-                key={k}
-                onClick={() => align(k)}
-                className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
-              >
-                {label}
-              </button>
-            ))}
-          </>
-        )}
-      </div>
+      {snapGuides.map((g, i) =>
+        g.axis === 'x' ? (
+          <div
+            key={`snap-${i}`}
+            className="absolute top-0 bottom-0 border-l border-sky-400/70"
+            style={{ left: g.pos }}
+          />
+        ) : (
+          <div
+            key={`snap-${i}`}
+            className="absolute left-0 right-0 border-t border-sky-400/70"
+            style={{ top: g.pos }}
+          />
+        ),
+      )}
+      <Toolbar align={align} showAlign={showAlign} />
     </div>
   )
 }

--- a/web/components/builder/Rulers.tsx
+++ b/web/components/builder/Rulers.tsx
@@ -1,0 +1,211 @@
+'use client'
+import React from 'react'
+import { useGuidesStore } from '@/store/guidesStore'
+
+export type ScreenToWorld = (p: number, axis: 'x'|'y') => number
+
+export function Rulers({
+  width,
+  height,
+  canvasRef,
+  screenToWorld,
+}: {
+  width: number
+  height: number
+  canvasRef?: React.RefObject<HTMLElement>
+  screenToWorld?: ScreenToWorld
+}) {
+  const {
+    unit,
+    setUnit,
+    baseRemPx,
+    addGuide,
+    locked,
+    setPreview,
+    guides,
+    toggleGuideLock,
+    toggleGuideVisible,
+  } = useGuidesStore((s) => ({
+    unit: s.unit,
+    setUnit: s.setUnit,
+    baseRemPx: s.baseRemPx,
+    addGuide: s.addGuide,
+    locked: s.locked,
+    setPreview: s.setPreview,
+    guides: s.guides,
+    toggleGuideLock: s.toggleGuideLock,
+    toggleGuideVisible: s.toggleGuideVisible,
+  }))
+
+  const [menu, setMenu] = React.useState<{ id: string; x: number; y: number } | null>(null)
+
+  const toWorld: ScreenToWorld = (p, axis) => {
+    if (!canvasRef?.current) return p
+    if (screenToWorld) return screenToWorld(p, axis)
+    const r = canvasRef.current.getBoundingClientRect()
+    return axis === 'x' ? p - r.left : p - r.top
+  }
+
+  const startDrag = (axis: 'x'|'y') => (e: React.MouseEvent) => {
+    if (locked) return
+    if ((e.target as HTMLElement).tagName === 'SELECT') return
+    e.preventDefault()
+    const move = (ev: MouseEvent) => {
+      const pos = toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis)
+      setPreview({ axis, pos })
+    }
+    const up = (ev: MouseEvent) => {
+      const pos = toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis)
+      addGuide({ axis, pos })
+      setPreview(null)
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+    move(e.nativeEvent as MouseEvent)
+  }
+
+  const onDoubleClickX = (e: React.MouseEvent) => {
+    if (locked) return
+    const pos = toWorld(e.clientX, 'x')
+    addGuide({ axis: 'x', pos })
+  }
+
+  const onDoubleClickY = (e: React.MouseEvent) => {
+    if (locked) return
+    const pos = toWorld(e.clientY, 'y')
+    addGuide({ axis: 'y', pos })
+  }
+
+  const openMenu = (axis: 'x'|'y') => (e: React.MouseEvent) => {
+    e.preventDefault()
+    const pos = toWorld(axis === 'x' ? e.clientX : e.clientY, axis)
+    const g = guides.find((gg) => gg.axis === axis && Math.abs(gg.pos - pos) < 4)
+    if (g) setMenu({ id: g.id, x: e.clientX, y: e.clientY })
+  }
+
+  const menuGuide = menu ? guides.find((g) => g.id === menu.id) : null
+
+  React.useEffect(() => {
+    const close = () => setMenu(null)
+    window.addEventListener('click', close)
+    return () => window.removeEventListener('click', close)
+  }, [])
+
+  const ticksX = getTicks(width, unit, baseRemPx)
+  const ticksY = getTicks(height, unit, baseRemPx)
+
+  return (
+    <div className="absolute top-0 left-0 select-none">
+      <div
+        className="relative h-6 w-full bg-neutral-900/70 text-neutral-200 cursor-crosshair"
+        onMouseDown={startDrag('x')}
+        onDoubleClick={onDoubleClickX}
+        onContextMenu={openMenu('x')}
+        title="ドラッグで垂直ガイド／ダブルクリックで追加"
+      >
+        <select
+          className="absolute left-1 top-1 h-4 text-[10px] bg-neutral-800 rounded px-1"
+          value={unit}
+          onChange={(e) => setUnit(e.target.value as any)}
+          title="unit"
+        >
+          <option value="px">px</option>
+          <option value="%">%</option>
+          <option value="rem">rem</option>
+        </select>
+        <svg className="absolute left-0 top-0" width={width} height={24}>
+          {ticksX.map((t) => (
+            <g key={t.px}>
+              <line x1={t.px} y1={0} x2={t.px} y2={t.long ? 16 : 10} stroke="rgba(255,255,255,.5)" />
+              {t.label != null && (
+                <text x={t.px + 2} y={20} fontSize={10} fill="white">{t.label}</text>
+              )}
+            </g>
+          ))}
+        </svg>
+      </div>
+
+      <div
+        className="absolute top-0 left-0 w-6 h-full bg-neutral-900/70 text-neutral-200 cursor-crosshair"
+        onMouseDown={startDrag('y')}
+        onDoubleClick={onDoubleClickY}
+        onContextMenu={openMenu('y')}
+        title="ドラッグで水平ガイド／ダブルクリックで追加"
+      >
+        <svg className="absolute left-0 top-0" width={24} height={height}>
+          {ticksY.map((t) => (
+            <g key={t.px}>
+              <line x1={0} y1={t.px} x2={t.long ? 16 : 10} y2={t.px} stroke="rgba(255,255,255,.5)" />
+              {t.label != null && (
+                <text x={2} y={t.px - 2} fontSize={10} fill="white" transform={`rotate(-90, 8, ${t.px - 2})`}>
+                  {t.label}
+                </text>
+              )}
+            </g>
+          ))}
+        </svg>
+      </div>
+
+      {menu && menuGuide && (
+        <div
+          className="absolute z-50 bg-neutral-800 text-neutral-100 text-xs rounded shadow"
+          style={{ left: menu.x, top: menu.y }}
+        >
+          <button
+            className="block w-full text-left px-2 py-1 hover:bg-neutral-700"
+            onClick={() => {
+              toggleGuideLock(menu.id)
+              setMenu(null)
+            }}
+          >
+            {menuGuide.locked ? 'Unlock' : 'Lock'} Guide
+          </button>
+          <button
+            className="block w-full text-left px-2 py-1 hover:bg-neutral-700"
+            onClick={() => {
+              toggleGuideVisible(menu.id)
+              setMenu(null)
+            }}
+          >
+            {menuGuide.visible ? 'Hide' : 'Show'} Guide
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function getTicks(lenPx: number, unit: 'px'|'%'|'rem', baseRemPx: number) {
+  const ticks: { px: number; long: boolean; label?: string|number }[] = []
+
+  if (unit === 'px') {
+    const step = pickStepPx(lenPx)
+    for (let x = 0; x <= lenPx; x += step/5) {
+      const isLong = Math.round(x * 5) % step === 0
+      ticks.push({ px: x, long: isLong, label: isLong ? Math.round(x) : undefined })
+    }
+  } else if (unit === '%') {
+    for (let p = 0; p <= 100; p += 1) {
+      const x = (p / 100) * lenPx
+      const isLong = p % 10 === 0
+      ticks.push({ px: x, long: isLong, label: isLong ? p : undefined })
+    }
+  } else {
+    const stepRem = 1
+    const stepPx = baseRemPx * stepRem
+    for (let r = 0, x = 0; x <= lenPx; r += stepRem, x += stepPx) {
+      const isLong = r % 5 === 0
+      ticks.push({ px: x, long: isLong, label: isLong ? r : undefined })
+    }
+  }
+
+  return ticks
+}
+
+function pickStepPx(lenPx: number) {
+  if (lenPx <= 800) return 100
+  if (lenPx <= 1600) return 200
+  return 400
+}

--- a/web/components/builder/Toolbar.tsx
+++ b/web/components/builder/Toolbar.tsx
@@ -1,0 +1,89 @@
+'use client'
+import React from 'react'
+import { useGridStore } from '@/store/gridStore'
+import { useGuidesStore } from '@/store/guidesStore'
+
+export function Toolbar({
+  align,
+  showAlign,
+}: {
+  align: (kind:
+    | 'left'
+    | 'centerX'
+    | 'right'
+    | 'top'
+    | 'centerY'
+    | 'bottom'
+    | 'hSpace'
+    | 'vSpace') => void
+  showAlign: boolean
+}) {
+  const { visible, snap, size, setVisible, setSnap, setSize } = useGridStore()
+  const { snapPx, setSnapPx } = useGuidesStore((s) => ({ snapPx: s.snapPx, setSnapPx: s.setSnapPx }))
+  return (
+    <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-1 pointer-events-auto">
+      <button
+        onClick={() => setVisible(!visible)}
+        className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${
+          visible ? '' : 'opacity-50'
+        }`}
+      >
+        Grid
+      </button>
+      <button
+        onClick={() => setSnap(!snap)}
+        className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${
+          snap ? '' : 'opacity-50'
+        }`}
+      >
+        Snap
+      </button>
+      <select
+        value={size}
+        onChange={(e) => setSize(parseInt(e.target.value, 10))}
+        className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
+      >
+        {[4, 8, 12, 16].map((n) => (
+          <option key={n} value={n}>
+            {n}
+          </option>
+        ))}
+      </select>
+      <div className="flex items-center gap-1 text-xs">
+        snap
+        <input
+          type="number"
+          value={snapPx}
+          onChange={(e) => setSnapPx(parseInt(e.target.value || '0', 10))}
+          className="w-14 bg-neutral-800 rounded px-1 py-[2px]"
+        />
+        px
+      </div>
+      {showAlign && (
+        <>
+          <div className="mx-1 w-px bg-zinc-600" />
+          {(
+            [
+              ['left', 'L'],
+              ['centerX', 'CX'],
+              ['right', 'R'],
+              ['top', 'T'],
+              ['centerY', 'CY'],
+              ['bottom', 'B'],
+              ['hSpace', 'HS'],
+              ['vSpace', 'VS'],
+            ] as const
+          ).map(([k, label]) => (
+            <button
+              key={k}
+              onClick={() => align(k)}
+              className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200"
+            >
+              {label}
+            </button>
+          ))}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/overlays/GuidesOverlay.tsx
+++ b/web/components/overlays/GuidesOverlay.tsx
@@ -18,12 +18,17 @@ export const GuidesOverlay = memo(function GuidesOverlay({
   canvasRef?: React.RefObject<HTMLElement>
   screenToWorld?: ScreenToWorld
 }) {
-  const { guides, visible, locked, preview, moveGuide, removeGuide } = useGuidesStore((s) => ({
-    guides: s.guides, visible: s.visible, locked: s.locked,
-    preview: s.preview,
-    moveGuide: s.moveGuide, removeGuide: s.removeGuide,
-  }))
+  const { guides, visible, locked, preview, moveGuide, removeGuide } =
+    useGuidesStore((s) => ({
+      guides: s.guides,
+      visible: s.visible,
+      locked: s.locked,
+      preview: s.preview,
+      moveGuide: s.moveGuide,
+      removeGuide: s.removeGuide,
+    }))
   if (!visible) return null
+  const visGuides = guides.filter((g) => g.visible)
 
   const toWorld: ScreenToWorld = (p, axis) => {
     if (!canvasRef?.current) return p
@@ -35,10 +40,15 @@ export const GuidesOverlay = memo(function GuidesOverlay({
   const activeKey = (g: Active) => `${g.axis}:${Math.round(g.at)}`
   const activeMap = new Set(active.map(activeKey))
 
-  const startDrag = (gId: string, axis: 'x'|'y') => (e: React.MouseEvent<SVGLineElement>) => {
-    if (locked) return
+  const startDrag = (
+    gId: string,
+    axis: 'x' | 'y',
+    guideLocked: boolean,
+  ) => (e: React.MouseEvent<SVGLineElement>) => {
+    if (locked || guideLocked) return
     e.preventDefault()
-    const onMove = (ev: MouseEvent) => moveGuide(gId, toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis))
+    const onMove = (ev: MouseEvent) =>
+      moveGuide(gId, toWorld(axis === 'x' ? ev.clientX : ev.clientY, axis))
     const onUp = () => {
       window.removeEventListener('mousemove', onMove)
       window.removeEventListener('mouseup', onUp)
@@ -47,8 +57,9 @@ export const GuidesOverlay = memo(function GuidesOverlay({
     window.addEventListener('mouseup', onUp)
   }
 
-  const onContext = (id: string) => (e: React.MouseEvent) => {
+  const onContext = (id: string, guideLocked: boolean) => (e: React.MouseEvent) => {
     e.preventDefault()
+    if (locked || guideLocked) return
     removeGuide(id)
   }
 
@@ -56,15 +67,33 @@ export const GuidesOverlay = memo(function GuidesOverlay({
     <div className="absolute inset-0">
       {/* ▼ ビジュアル（非インタラクティブ） */}
       <svg className="absolute inset-0 pointer-events-none" width={width} height={height}>
-        {guides.map((g) => {
+        {visGuides.map((g) => {
           const key = `${g.axis}:${Math.round(g.pos)}`
           const isActive = activeMap.has(key)
           const stroke = isActive ? 'rgba(32,148,243,1)' : 'rgba(32,148,243,.5)'
-          const dash = isActive ? '0' : '6,6'
+          const dash = g.locked ? '2,2' : isActive ? '0' : '6,6'
           return g.axis === 'x' ? (
-            <line key={key} x1={g.pos} y1={0} x2={g.pos} y2={height} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+            <line
+              key={key}
+              x1={g.pos}
+              y1={0}
+              x2={g.pos}
+              y2={height}
+              stroke={stroke}
+              strokeWidth={1}
+              strokeDasharray={dash}
+            />
           ) : (
-            <line key={key} x1={0} y1={g.pos} x2={width} y2={g.pos} stroke={stroke} strokeWidth={1} strokeDasharray={dash} />
+            <line
+              key={key}
+              x1={0}
+              y1={g.pos}
+              x2={width}
+              y2={g.pos}
+              stroke={stroke}
+              strokeWidth={1}
+              strokeDasharray={dash}
+            />
           )
         })}
         {preview && (
@@ -79,12 +108,14 @@ export const GuidesOverlay = memo(function GuidesOverlay({
       {/* ▼ インタラクティブ（太いヒットエリア） */}
       <div className="absolute inset-0 pointer-events-auto">
         <svg className="absolute inset-0" width={width} height={height}>
-          {guides.map((g) => {
+          {visGuides.map((g) => {
             // 透明の太い線をヒットエリアに（見た目は上のSVGが担う）
             const common = {
-              onMouseDown: startDrag(g.id, g.axis),
-              onContextMenu: onContext(g.id),
-              style: { cursor: g.axis === 'x' ? 'col-resize' as const : 'row-resize' as const },
+              onMouseDown: startDrag(g.id, g.axis, g.locked),
+              onContextMenu: onContext(g.id, g.locked),
+              style: {
+                cursor: g.axis === 'x' ? ('col-resize' as const) : ('row-resize' as const),
+              },
               stroke: 'rgba(0,0,0,0)', // 透明
               strokeWidth: 12,        // 太いヒット
             }

--- a/web/hooks/useSnapToGuides.ts
+++ b/web/hooks/useSnapToGuides.ts
@@ -19,15 +19,15 @@ export const useSnapToGuides = (
   mode: 'move' | 'resize',
   zoom: number
 ): SnapResult => {
-  const { guides, visible, snapPx } = useGuidesStore((s) => ({
-    guides: s.guides,
-    visible: s.visible,
+  const { guides, globalVisible, snapPx } = useGuidesStore((s) => ({
+    guides: s.guides.filter((g) => g.visible),
+    globalVisible: s.visible,
     snapPx: s.snapPx,
   }))
   const thresholdWorld = snapPx / Math.max(zoom, 0.01)
 
   return useMemo(() => {
-    if (!visible || guides.length === 0) {
+    if (!globalVisible || guides.length === 0) {
       return { rect: draftRect, snapped: false, active: [] }
     }
 
@@ -77,5 +77,5 @@ export const useSnapToGuides = (
     const active = [ax, ay].filter(Boolean) as {axis:'x'|'y'; at:number}[]
 
     return { rect, snapped: true, active }
-  }, [draftRect, visible, guides, thresholdWorld])
+  }, [draftRect, globalVisible, guides, thresholdWorld])
 }

--- a/web/lib/builder/snap.ts
+++ b/web/lib/builder/snap.ts
@@ -1,5 +1,6 @@
 import type { Elm } from '@/store/builderStore'
 import { useGridStore } from '@/store/gridStore'
+import { useGuidesStore } from '@/store/guidesStore'
 
 export type SnapPoints = {
   x: { left: number[]; center: number[]; right: number[] }
@@ -20,6 +21,20 @@ export function collectSnapPoints(elements: Elm[], exceptId?: string): SnapPoint
     points.y.middle.push(el.y + el.h / 2)
     points.y.bottom.push(el.y + el.h)
   })
+  const guideLines = useGuidesStore
+    .getState()
+    .guides.filter((g) => g.visible)
+  guideLines.forEach((g) => {
+    if (g.axis === 'x') {
+      points.x.left.push(g.pos)
+      points.x.center.push(g.pos)
+      points.x.right.push(g.pos)
+    } else {
+      points.y.top.push(g.pos)
+      points.y.middle.push(g.pos)
+      points.y.bottom.push(g.pos)
+    }
+  })
   return points
 }
 
@@ -33,7 +48,7 @@ export function snapRect(
   points: SnapPoints,
   opts: { threshold?: number; mode?: 'move' | 'resize' } = {},
 ): { rect: Rect; guides: GuideLine[] } {
-  const threshold = opts.threshold ?? SNAP_THRESHOLD
+  const threshold = opts.threshold ?? useGuidesStore.getState().snapPx ?? SNAP_THRESHOLD
   const mode = opts.mode ?? 'move'
   const { snap, size } = useGridStore.getState()
   if (!snap) return { rect, guides: [] }

--- a/web/store/guidesStore.ts
+++ b/web/store/guidesStore.ts
@@ -5,11 +5,15 @@ export type Guide = {
   id: string
   axis: 'x' | 'y'   // x=垂直ガイド, y=水平ガイド
   pos: number       // ワールド(px)座標。%やremは変換後にここへ格納
+  locked: boolean
+  visible: boolean
 }
 
 type GuidesState = {
   guides: Guide[]
+  /** 全体表示切替 */
   visible: boolean
+  /** 全体ロック */
   locked: boolean
   unit: Unit
   baseRemPx: number
@@ -17,10 +21,12 @@ type GuidesState = {
   smartEnabled: boolean
   smartSnapPx?: number
   preview: { axis: 'x'|'y'; pos: number } | null
-  addGuide: (g: Omit<Guide, 'id'> & { id?: string }) => string
+  addGuide: (g: Omit<Guide, 'id'|'locked'|'visible'> & { id?: string }) => string
   moveGuide: (id: string, pos: number) => void
   removeGuide: (id: string) => void
   clearGuides: () => void
+  toggleGuideLock: (id: string) => void
+  toggleGuideVisible: (id: string) => void
   setVisible: (v: boolean) => void
   setLocked: (v: boolean) => void
   setUnit: (u: Unit) => void
@@ -50,21 +56,42 @@ export const useGuidesStore = create<GuidesState>((set, get) => ({
 
   addGuide: (g) => {
     const id = g.id ?? uid()
-    set((s) => ({ guides: [...s.guides, { id, axis: g.axis, pos: g.pos }] }))
+    set((s) => ({
+      guides: [
+        ...s.guides,
+        { id, axis: g.axis, pos: g.pos, locked: false, visible: true },
+      ],
+    }))
     return id
   },
 
   moveGuide: (id, pos) => {
     if (get().locked) return
     set((s) => ({
-      guides: s.guides.map((gg) => (gg.id === id ? { ...gg, pos } : gg)),
+      guides: s.guides.map((gg) =>
+        gg.id === id ? (gg.locked ? gg : { ...gg, pos }) : gg,
+      ),
     }))
   },
 
   removeGuide: (id) =>
-    set((s) => ({ guides: s.guides.filter((g) => g.id !== id) })),
+    set((s) => ({ guides: s.guides.filter((g) => g.id !== id || g.locked) })),
 
   clearGuides: () => set({ guides: [] }),
+
+  toggleGuideLock: (id) =>
+    set((s) => ({
+      guides: s.guides.map((g) =>
+        g.id === id ? { ...g, locked: !g.locked } : g,
+      ),
+    })),
+
+  toggleGuideVisible: (id) =>
+    set((s) => ({
+      guides: s.guides.map((g) =>
+        g.id === id ? { ...g, visible: !g.visible } : g,
+      ),
+    })),
 
   setVisible: (v) => set({ visible: v }),
   setLocked: (v) => set({ locked: v }),


### PR DESCRIPTION
## Summary
- add per-guide lock and visibility states with snap distance setting
- enable context menu on rulers to toggle guide lock/visibility
- render guides in overlay and include them in snapping

## Testing
- `pnpm tsc -p tsconfig.json --noEmit` *(fails: components/CanvasFree.tsx JSX tag mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b30cfb818c832c94b8dba8b719e04e