### PR TITLE
feat(units): px/%/rem switching for rulers & inspector

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -10,6 +10,7 @@ import { FooterView } from './footer/FooterView'
 import { SidebarView } from '@/components/app/SidebarView'
 import NodeWrapper from './NodeWrapper'
 import { Rulers } from './Rulers'
+import { useUnitStore } from '@/store/unitStore'
 
 function bgGridStyle(s: number) {
   return {
@@ -295,6 +296,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const { setNodeRef } = useDroppable({ id: 'CANVAS' })
   const gridSize = useGridStore((s) => s.size)
   const gridVisible = useGridStore((s) => s.visible)
+  const setPercentBase = useUnitStore((s) => s.setPercentBase)
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -318,6 +320,19 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [nudge, align, gridSize])
+
+  React.useLayoutEffect(() => {
+    const el = canvasRef.current
+    if (!el) return
+    const update = () =>
+      setPercentBase({ width: el.clientWidth, height: el.clientHeight })
+    update()
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(update)
+      ro.observe(el)
+      return () => ro.disconnect()
+    }
+  }, [canvasRef, setPercentBase])
 
   return (
     <div className="h-full w-full flex items-center justify-center bg-black">

--- a/web/components/builder/Rulers.tsx
+++ b/web/components/builder/Rulers.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 import { useGuidesStore } from '@/store/guidesStore'
+import { useUnitStore } from '@/store/unitStore'
 
 export type ScreenToWorld = (p: number, axis: 'x'|'y') => number
 
@@ -16,9 +17,6 @@ export function Rulers({
   screenToWorld?: ScreenToWorld
 }) {
   const {
-    unit,
-    setUnit,
-    baseRemPx,
     addGuide,
     locked,
     setPreview,
@@ -26,15 +24,19 @@ export function Rulers({
     toggleGuideLock,
     toggleGuideVisible,
   } = useGuidesStore((s) => ({
-    unit: s.unit,
-    setUnit: s.setUnit,
-    baseRemPx: s.baseRemPx,
     addGuide: s.addGuide,
     locked: s.locked,
     setPreview: s.setPreview,
     guides: s.guides,
     toggleGuideLock: s.toggleGuideLock,
     toggleGuideVisible: s.toggleGuideVisible,
+  }))
+
+  const { unit, setUnit, remBase, setRemBase } = useUnitStore((s) => ({
+    unit: s.unit,
+    setUnit: s.setUnit,
+    remBase: s.remBase,
+    setRemBase: s.setRemBase,
   }))
 
   const [menu, setMenu] = React.useState<{ id: string; x: number; y: number } | null>(null)
@@ -93,8 +95,8 @@ export function Rulers({
     return () => window.removeEventListener('click', close)
   }, [])
 
-  const ticksX = getTicks(width, unit, baseRemPx)
-  const ticksY = getTicks(height, unit, baseRemPx)
+  const ticksX = getTicks(width, unit, remBase)
+  const ticksY = getTicks(height, unit, remBase)
 
   return (
     <div className="absolute top-0 left-0 select-none">
@@ -112,9 +114,18 @@ export function Rulers({
           title="unit"
         >
           <option value="px">px</option>
-          <option value="%">%</option>
+          <option value="percent">%</option>
           <option value="rem">rem</option>
         </select>
+        {unit === 'rem' && (
+          <input
+            type="number"
+            className="absolute left-12 top-1 w-10 h-4 text-[10px] bg-neutral-800 rounded px-1"
+            value={remBase}
+            onChange={(e) => setRemBase(Number(e.target.value))}
+            title="rem base px"
+          />
+        )}
         <svg className="absolute left-0 top-0" width={width} height={24}>
           {ticksX.map((t) => (
             <g key={t.px}>
@@ -177,7 +188,7 @@ export function Rulers({
   )
 }
 
-function getTicks(lenPx: number, unit: 'px'|'%'|'rem', baseRemPx: number) {
+function getTicks(lenPx: number, unit: 'px'|'percent'|'rem', baseRemPx: number) {
   const ticks: { px: number; long: boolean; label?: string|number }[] = []
 
   if (unit === 'px') {
@@ -186,7 +197,7 @@ function getTicks(lenPx: number, unit: 'px'|'%'|'rem', baseRemPx: number) {
       const isLong = Math.round(x * 5) % step === 0
       ticks.push({ px: x, long: isLong, label: isLong ? Math.round(x) : undefined })
     }
-  } else if (unit === '%') {
+  } else if (unit === 'percent') {
     for (let p = 0; p <= 100; p += 1) {
       const x = (p / 100) * lenPx
       const isLong = p % 10 === 0

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -2,6 +2,8 @@
 import { useEditorStore } from '@/store/editorStore';
 import { useState } from 'react';
 import ActionPresetField from '@/components/props/ActionPresetField';
+import { useUnitStore } from '@/store/unitStore';
+import { worldToUnit, unitToWorld } from '@/lib/units';
 
 export default function RightInspector() {
   const selected = useEditorStore((s) => s.selectedIds[0]);
@@ -12,6 +14,11 @@ export default function RightInspector() {
   const update = useEditorStore((s) => s.updateNode);
   const setLayout = useEditorStore((s) => s.setLayoutProps);
   const setVariant = useEditorStore((s) => s.setInstanceVariant);
+  const { unit, remBase, percentBase } = useUnitStore((s) => ({
+    unit: s.unit,
+    remBase: s.remBase,
+    percentBase: s.percentBase,
+  }));
   const [form, setForm] = useState({
     x: node?.props?.x || 0,
     y: node?.props?.y || 0,
@@ -23,7 +30,12 @@ export default function RightInspector() {
   if (!selected) return <div className="bg-gray-800" />;
 
   const handleChange = (key: keyof typeof form, value: number) => {
-    const next = { ...form, [key]: value };
+    let pxValue = value;
+    if (key !== 'rotation') {
+      const base = key === 'x' || key === 'w' ? percentBase.width : percentBase.height;
+      pxValue = unitToWorld(value, unit, base, remBase);
+    }
+    const next = { ...form, [key]: pxValue };
     setForm(next);
     // 既存 props を保持して上書き
     update(selected, { props: { ...(node?.props || {}), ...next } });
@@ -33,19 +45,28 @@ export default function RightInspector() {
     ? components[(node as any).componentId]
     : null;
 
+  const unitLabel = unit === 'percent' ? '%' : unit
+
   return (
     <div className="bg-gray-800 p-2 space-y-2 overflow-y-auto">
-      {(['x', 'y', 'w', 'h', 'rotation'] as const).map((k) => (
-        <label key={k} className="block text-xs">
-          {k.toUpperCase()}:
-          <input
-            type="number"
-            className="w-full bg-gray-700 ml-1 p-1 text-white"
-            value={form[k]}
-            onChange={(e) => handleChange(k, Number(e.target.value))}
-          />
-        </label>
-      ))}
+      {(['x', 'y', 'w', 'h', 'rotation'] as const).map((k) => {
+        const base = k === 'x' || k === 'w' ? percentBase.width : percentBase.height
+        const value =
+          k === 'rotation'
+            ? form[k]
+            : worldToUnit(form[k], unit, base, remBase)
+        return (
+          <label key={k} className="block text-xs">
+            {k.toUpperCase()} {k !== 'rotation' ? `(${unitLabel})` : ''}:
+            <input
+              type="number"
+              className="w-full bg-gray-700 ml-1 p-1 text-white"
+              value={value}
+              onChange={(e) => handleChange(k, Number(e.target.value))}
+            />
+          </label>
+        )
+      })}
       {comp && comp.axes && (
         <div className="mt-2 space-y-1">
           <h3 className="text-xs font-bold">Variants</h3>

--- a/web/lib/units.ts
+++ b/web/lib/units.ts
@@ -1,33 +1,33 @@
-export type Unit = 'px' | '%' | 'rem'
+export type Unit = 'px' | 'percent' | 'rem'
 
-export const toWorldPx = (
+export const unitToWorld = (
   value: number,
   unit: Unit,
-  canvasSizePx: number,   // xなら幅、yなら高さで呼ぶ
-  baseRemPx = 16
+  canvasSizePx: number, // xなら幅、yなら高さで呼ぶ
+  remBase = 16
 ) => {
   switch (unit) {
     case 'px':
       return value
-    case '%':
+    case 'percent':
       return (value / 100) * canvasSizePx
     case 'rem':
-      return value * baseRemPx
+      return value * remBase
   }
 }
 
-export const fromWorldPx = (
+export const worldToUnit = (
   px: number,
   unit: Unit,
   canvasSizePx: number,
-  baseRemPx = 16
+  remBase = 16
 ) => {
   switch (unit) {
     case 'px':
       return px
-    case '%':
+    case 'percent':
       return (px / canvasSizePx) * 100
     case 'rem':
-      return px / baseRemPx
+      return px / remBase
   }
 }

--- a/web/store/unitStore.ts
+++ b/web/store/unitStore.ts
@@ -1,0 +1,23 @@
+'use client'
+import { create } from 'zustand'
+
+export type Unit = 'px' | 'percent' | 'rem'
+
+interface UnitState {
+  unit: Unit
+  remBase: number
+  percentBase: { width: number; height: number }
+  setUnit: (u: Unit) => void
+  setRemBase: (n: number) => void
+  setPercentBase: (size: { width: number; height: number }) => void
+}
+
+export const useUnitStore = create<UnitState>((set) => ({
+  unit: 'px',
+  remBase: 16,
+  percentBase: { width: 1, height: 1 },
+  setUnit: (u) => set({ unit: u }),
+  setRemBase: (n) => set({ remBase: n }),
+  setPercentBase: (size) => set({ percentBase: size }),
+}))
+


### PR DESCRIPTION
## Summary
- add unit store to manage px/percent/rem and rem base
- convert inspector fields using world/unit transforms
- hook canvas and rulers to unit store with rem base input

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30f27c608832c8a26f54e2a347ff2