### PR TITLE
feat(select): marquee selection with shift-add/remove

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -11,6 +11,7 @@ import { SidebarView } from '@/components/app/SidebarView'
 import NodeWrapper from './NodeWrapper'
 import { Rulers } from './Rulers'
 import { useUnitStore } from '@/store/unitStore'
+import { intersects } from '@/lib/geom'
 
 function bgGridStyle(s: number) {
   return {
@@ -228,6 +229,8 @@ function ResizeHandles({ elm }: { elm: Elm }) {
 
 function ElmView({ elm }: { elm: Elm }) {
   const select = useBuilderStore((s) => s.select)
+  const addSelect = useBuilderStore((s) => s.addSelect)
+  const toggleSelect = useBuilderStore((s) => s.toggleSelect)
   const selectedId = useBuilderStore((s) => s.selectedId)
   const isSel = selectedId === elm.id
   const dragDraft = useBuilderStore((s) => s.ui.dragDraft)
@@ -259,7 +262,11 @@ function ElmView({ elm }: { elm: Elm }) {
       ref={setNodeRef}
       {...listeners}
       {...attributes}
-      onMouseDown={() => select(elm.id)}
+      onMouseDown={(e) => {
+        if (e.shiftKey) addSelect(elm.id)
+        else if (e.altKey || e.ctrlKey) toggleSelect(elm.id)
+        else select(elm.id)
+      }}
       className={`${common} ${border} ${shadow} cursor-move ${isDragging ? 'opacity-60' : ''}`}
       id={elm.id}
       type={elm.type}
@@ -291,12 +298,17 @@ function ElmView({ elm }: { elm: Elm }) {
 export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElement> }) {
   const els = useBuilderStore((s) => s.elements)
   const select = useBuilderStore((s) => s.select)
+  const addSelect = useBuilderStore((s) => s.addSelect)
+  const toggleSelect = useBuilderStore((s) => s.toggleSelect)
   const nudge = useBuilderStore((s) => s.nudge)
   const align = useBuilderStore((s) => s.align)
   const { setNodeRef } = useDroppable({ id: 'CANVAS' })
   const gridSize = useGridStore((s) => s.size)
   const gridVisible = useGridStore((s) => s.visible)
   const setPercentBase = useUnitStore((s) => s.setPercentBase)
+  const [marquee, setMarquee] = React.useState<
+    { x: number; y: number; w: number; h: number } | null
+  >(null)
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -344,8 +356,58 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
           // @ts-ignore
           canvasRef.current = n
         }}
-        onMouseDown={(e) => {
-          if (e.target === e.currentTarget) select(null)
+        onPointerDown={(e) => {
+          if (e.button !== 0) return
+          if (e.target !== e.currentTarget) return
+          const rect = e.currentTarget.getBoundingClientRect()
+          const startX = e.clientX - rect.left
+          const startY = e.clientY - rect.top
+          let box = { x: startX, y: startY, w: 0, h: 0 }
+          setMarquee(box)
+          const onMove = (ev: PointerEvent) => {
+            const x = ev.clientX - rect.left
+            const y = ev.clientY - rect.top
+            const mx = Math.min(x, startX)
+            const my = Math.min(y, startY)
+            const mw = Math.abs(x - startX)
+            const mh = Math.abs(y - startY)
+            box = { x: mx, y: my, w: mw, h: mh }
+            setMarquee(box)
+          }
+          const onUp = (ev: PointerEvent) => {
+            window.removeEventListener('pointermove', onMove)
+            window.removeEventListener('pointerup', onUp)
+            const x = ev.clientX - rect.left
+            const y = ev.clientY - rect.top
+            const mx = Math.min(x, startX)
+            const my = Math.min(y, startY)
+            const mw = Math.abs(x - startX)
+            const mh = Math.abs(y - startY)
+            const final = { x: mx, y: my, w: mw, h: mh }
+            setMarquee(null)
+            if (mw < 2 && mh < 2) {
+              if (!ev.shiftKey && !ev.altKey && !ev.ctrlKey) select(null)
+              return
+            }
+            const ids = useBuilderStore
+              .getState()
+              .elements.filter(
+                (el) =>
+                  el.visible !== false &&
+                  intersects(final, {
+                    x: el.x,
+                    y: el.y,
+                    w: el.w,
+                    h: el.h,
+                  }),
+              )
+              .map((el) => el.id)
+            if (ev.shiftKey) addSelect(ids)
+            else if (ev.altKey || ev.ctrlKey) toggleSelect(ids)
+            else select(ids)
+          }
+          window.addEventListener('pointermove', onMove)
+          window.addEventListener('pointerup', onUp)
         }}
         className="relative w-[1200px] h-[720px] border border-zinc-800 rounded-lg overflow-hidden"
         style={gridVisible ? bgGridStyle(gridSize) : undefined}
@@ -355,7 +417,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         {els.map((e) => (
           <ElmView key={e.id} elm={e} />
         ))}
-        <CanvasOverlay />
+        <CanvasOverlay marquee={marquee ?? undefined} />
         <Rulers width={1200} height={720} canvasRef={canvasRef} />
         <div className="absolute left-2 bottom-2 text-[11px] text-zinc-400 bg-black/40 px-2 py-1 rounded border border-zinc-800">
           drag to move • drop from Palette • arrows to nudge • click empty = unselect

--- a/web/components/builder/CanvasOverlay.tsx
+++ b/web/components/builder/CanvasOverlay.tsx
@@ -4,7 +4,11 @@ import { useBuilderStore } from '@/store/builderStore'
 import { useGuidesStore } from '@/store/guidesStore'
 import { Toolbar } from './Toolbar'
 
-export function CanvasOverlay() {
+export function CanvasOverlay({
+  marquee,
+}: {
+  marquee?: { x: number; y: number; w: number; h: number }
+}) {
   const snapGuides = useBuilderStore((s) => s.ui.guides)
   const selectedIds = useBuilderStore((s) => s.selectedIds)
   const align = useBuilderStore((s) => s.align)
@@ -12,6 +16,17 @@ export function CanvasOverlay() {
   const guides = useGuidesStore((s) => s.guides.filter((g) => g.visible))
   return (
     <div className="absolute inset-0 pointer-events-none z-50">
+      {marquee && (
+        <div
+          className="absolute border border-amber-400/70 bg-amber-400/10"
+          style={{
+            left: marquee.x,
+            top: marquee.y,
+            width: marquee.w,
+            height: marquee.h,
+          }}
+        />
+      )}
       {guides.map((g) =>
         g.axis === 'x' ? (
           <div

--- a/web/lib/geom.ts
+++ b/web/lib/geom.ts
@@ -1,0 +1,10 @@
+export type Rect = { x: number; y: number; w: number; h: number }
+
+export function intersects(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y
+  )
+}

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -62,6 +62,9 @@ type BuilderActions = {
   setGuides: (lines: Array<{ axis: 'x' | 'y'; pos: number }>) => void
   clearGuides: () => void
   select: (id: string | string[] | null) => void
+  addSelect: (id: string | string[]) => void
+  removeSelect: (id: string | string[]) => void
+  toggleSelect: (id: string | string[]) => void
   align: (
     kind:
       | 'left'
@@ -210,6 +213,43 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     } else {
       set({ selectedId: id, selectedIds: id ? [id] : [] })
     }
+  },
+
+  addSelect(id) {
+    const ids = Array.isArray(id) ? id : [id]
+    set(
+      produce((draft: BuilderState) => {
+        ids.forEach((i) => {
+          if (!draft.selectedIds.includes(i)) draft.selectedIds.push(i)
+        })
+        draft.selectedId = draft.selectedIds[draft.selectedIds.length - 1] ?? null
+      }),
+    )
+  },
+
+  removeSelect(id) {
+    const ids = Array.isArray(id) ? id : [id]
+    set(
+      produce((draft: BuilderState) => {
+        draft.selectedIds = draft.selectedIds.filter((i) => !ids.includes(i))
+        draft.selectedId =
+          draft.selectedIds[draft.selectedIds.length - 1] ?? null
+      }),
+    )
+  },
+
+  toggleSelect(id) {
+    const ids = Array.isArray(id) ? id : [id]
+    set(
+      produce((draft: BuilderState) => {
+        ids.forEach((i) => {
+          const idx = draft.selectedIds.indexOf(i)
+          if (idx >= 0) draft.selectedIds.splice(idx, 1)
+          else draft.selectedIds.push(i)
+        })
+        draft.selectedId = draft.selectedIds[draft.selectedIds.length - 1] ?? null
+      }),
+    )
   },
 
   align(kind) {


### PR DESCRIPTION
## Summary
- add rectangle intersection utility
- extend builder store with add/remove/toggle selection helpers
- implement marquee selection with Shift-add and Alt/Ctrl toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b312256d10832c8207746ef367b5db