### PR TITLE
feat(history): undo/redo for move/resize/props/presets

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -4,6 +4,7 @@ import { useDroppable, useDraggable } from '@dnd-kit/core'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
 import { useGridStore } from '@/store/gridStore'
+import { useHistoryStore } from '@/store/historyStore'
 import { CanvasOverlay } from './CanvasOverlay'
 import { HeaderView } from './header/HeaderView'
 import { FooterView } from './footer/FooterView'
@@ -81,6 +82,8 @@ function ResizeHandles({ elm }: { elm: Elm }) {
   const setDragDraft = useBuilderStore((s) => s.setDragDraft)
   const setGuides = useBuilderStore((s) => s.setGuides)
   const clearGuides = useBuilderStore((s) => s.clearGuides)
+  const startBatch = useHistoryStore((s) => s.start)
+  const commitBatch = useHistoryStore((s) => s.commit)
   const [resizing, setResizing] = React.useState(false)
   const startRef = React.useRef({
     x: 0,
@@ -108,6 +111,7 @@ function ResizeHandles({ elm }: { elm: Elm }) {
   const onPointerDown = (dir: HandleDir) => (e: React.PointerEvent) => {
     e.stopPropagation()
     e.preventDefault()
+    startBatch()
     startRef.current = {
       x: elm.x,
       y: elm.y,
@@ -192,6 +196,7 @@ function ResizeHandles({ elm }: { elm: Elm }) {
       document.body.style.cursor = ''
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
+      commitBatch()
     }
 
     window.addEventListener('pointermove', onMove)
@@ -238,6 +243,14 @@ function ElmView({ elm }: { elm: Elm }) {
     id: `elm_${elm.id}`,
     data: { from: 'canvas', id: elm.id, anchorX: elm.w / 2, anchorY: elm.h / 2 },
   })
+  const startBatch = useHistoryStore((s) => s.start)
+  const commitBatch = useHistoryStore((s) => s.commit)
+  const prevDragging = React.useRef(false)
+  React.useEffect(() => {
+    if (isDragging && !prevDragging.current) startBatch()
+    if (!isDragging && prevDragging.current) commitBatch()
+    prevDragging.current = isDragging
+  }, [isDragging, startBatch, commitBatch])
 
   const common = 'absolute rounded border text-[12px] select-none'
   const border = isSel ? 'border-amber-400' : 'border-zinc-700'
@@ -302,6 +315,8 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const toggleSelect = useBuilderStore((s) => s.toggleSelect)
   const nudge = useBuilderStore((s) => s.nudge)
   const align = useBuilderStore((s) => s.align)
+  const undo = useBuilderStore((s) => s.undo)
+  const redo = useBuilderStore((s) => s.redo)
   const { setNodeRef } = useDroppable({ id: 'CANVAS' })
   const gridSize = useGridStore((s) => s.size)
   const gridVisible = useGridStore((s) => s.visible)
@@ -319,6 +334,12 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
       ) {
         e.preventDefault()
       }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
+        e.preventDefault()
+        if (e.shiftKey) redo()
+        else undo()
+        return
+      }
       if (e.altKey && e.shiftKey) {
         if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') align('hSpace')
         if (e.key === 'ArrowUp' || e.key === 'ArrowDown') align('vSpace')
@@ -331,7 +352,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [nudge, align, gridSize])
+  }, [nudge, align, gridSize, undo, redo])
 
   React.useLayoutEffect(() => {
     const el = canvasRef.current

--- a/web/components/builder/Toolbar.tsx
+++ b/web/components/builder/Toolbar.tsx
@@ -2,6 +2,8 @@
 import React from 'react'
 import { useGridStore } from '@/store/gridStore'
 import { useGuidesStore } from '@/store/guidesStore'
+import { useBuilderStore } from '@/store/builderStore'
+import { useHistoryStore } from '@/store/historyStore'
 
 export function Toolbar({
   align,
@@ -20,8 +22,28 @@ export function Toolbar({
 }) {
   const { visible, snap, size, setVisible, setSnap, setSize } = useGridStore()
   const { snapPx, setSnapPx } = useGuidesStore((s) => ({ snapPx: s.snapPx, setSnapPx: s.setSnapPx }))
+  const undo = useBuilderStore((s) => s.undo)
+  const redo = useBuilderStore((s) => s.redo)
+  const { index, stack } = useHistoryStore((s) => ({ index: s.index, stack: s.stack }))
+  const canUndo = index >= 0
+  const canRedo = index < stack.length - 1
   return (
     <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-1 pointer-events-auto">
+      <button
+        onClick={undo}
+        disabled={!canUndo}
+        className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 disabled:opacity-50"
+      >
+        Undo
+      </button>
+      <button
+        onClick={redo}
+        disabled={!canRedo}
+        className="px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 disabled:opacity-50"
+      >
+        Redo
+      </button>
+      <div className="mx-1 w-px bg-zinc-600" />
       <button
         onClick={() => setVisible(!visible)}
         className={`px-1 py-0.5 text-xs bg-zinc-800 border border-zinc-600 rounded text-amber-200 ${

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -1,10 +1,11 @@
 'use client'
 import { create } from 'zustand'
-import { produce } from 'immer'
+import { produce, produceWithPatches } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
 import { registry, type RegistryKey } from '@/lib/registry'
 import { useGridStore } from '@/store/gridStore'
+import { useHistoryStore } from './historyStore'
 
 export type ElmType = RegistryKey | 'code'
 
@@ -87,6 +88,8 @@ type BuilderActions = {
   setElements: (els: Elm[]) => void
   serialize: () => string
   hydrate: (json: string) => void
+  undo: () => void
+  redo: () => void
 }
 
 function snapToGrid(n: number) {
@@ -102,11 +105,20 @@ function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
   return { ...size, text }
 }
 
-export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => ({
-  elements: [],
-  selectedId: null,
-  selectedIds: [],
-  ui: { guides: [] },
+export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => {
+  const apply = (recipe: (draft: BuilderState) => void) => {
+    set((state) => {
+      const [next, patches, inverse] = produceWithPatches(state, recipe)
+      useHistoryStore.getState().push(patches, inverse)
+      return next
+    })
+  }
+
+  return {
+    elements: [],
+    selectedId: null,
+    selectedIds: [],
+    ui: { guides: [] },
 
   addFromPalette(type, at, meta) {
     const id = `elm_${Date.now().toString(36)}`
@@ -114,73 +126,67 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     const snapState = useGridStore.getState()
     const x = snapState.snap ? snapToGrid(at?.x ?? 40) : at?.x ?? 40
     const y = snapState.snap ? snapToGrid(at?.y ?? 40) : at?.y ?? 40
-    set(
-      produce((draft: BuilderState) => {
-        if (type === 'code') {
-          const initProps: Record<string, unknown> = {}
-          meta?.props?.forEach((p) => {
-            const v = parseValue(p.defaultValue?.value)
-            if (v !== undefined) initProps[p.name] = v
-          })
-          draft.elements.push({
-            id,
-            type,
-            x,
-            y,
-            w,
-            h,
-            visible: true,
-            code: {
-              displayName: meta?.displayName ?? 'Component',
-              importPath: meta?.importPath ?? '',
-              exportName: meta?.exportName,
-              props: initProps,
-            },
-          })
-        } else {
-          draft.elements.push({
-            id,
-            type,
-            x,
-            y,
-            w,
-            h,
-            visible: true,
-            props: {
-              text,
-              bg: type === 'button' ? '#0ea5e9' : '#111827',
-              color: '#e5e7eb',
-            },
-          })
-        }
-        draft.selectedId = id
-        draft.selectedIds = [id]
-      }),
-    )
+    apply((draft: BuilderState) => {
+      if (type === 'code') {
+        const initProps: Record<string, unknown> = {}
+        meta?.props?.forEach((p) => {
+          const v = parseValue(p.defaultValue?.value)
+          if (v !== undefined) initProps[p.name] = v
+        })
+        draft.elements.push({
+          id,
+          type,
+          x,
+          y,
+          w,
+          h,
+          visible: true,
+          code: {
+            displayName: meta?.displayName ?? 'Component',
+            importPath: meta?.importPath ?? '',
+            exportName: meta?.exportName,
+            props: initProps,
+          },
+        })
+      } else {
+        draft.elements.push({
+          id,
+          type,
+          x,
+          y,
+          w,
+          h,
+          visible: true,
+          props: {
+            text,
+            bg: type === 'button' ? '#0ea5e9' : '#111827',
+            color: '#e5e7eb',
+          },
+        })
+      }
+      draft.selectedId = id
+      draft.selectedIds = [id]
+    })
   },
 
   move(id, to, snapGrid = true) {
-    set(
-      produce((draft: BuilderState) => {
-        const e = draft.elements.find((x) => x.id === id)
-        if (!e) return
-        const { snap } = useGridStore.getState()
-        e.x = snapGrid && snap ? snapToGrid(to.x) : to.x
-        e.y = snapGrid && snap ? snapToGrid(to.y) : to.y
-      }),
-    )
+    apply((draft: BuilderState) => {
+      const e = draft.elements.find((x) => x.id === id)
+      if (!e) return
+      const { snap } = useGridStore.getState()
+      e.x = snapGrid && snap ? snapToGrid(to.x) : to.x
+      e.y = snapGrid && snap ? snapToGrid(to.y) : to.y
+    })
   },
 
   resize(id, to, snapGrid = true) {
-    set(
-      produce((draft: BuilderState) => {
-        const e = draft.elements.find((x) => x.id === id)
-        if (!e) return
-        const { snap } = useGridStore.getState()
-        e.w = Math.max(16, snapGrid && snap ? snapToGrid(to.w) : to.w)
-        e.h = Math.max(16, snapGrid && snap ? snapToGrid(to.h) : to.h)
-      }),
-    )
+    apply((draft: BuilderState) => {
+      const e = draft.elements.find((x) => x.id === id)
+      if (!e) return
+      const { snap } = useGridStore.getState()
+      e.w = Math.max(16, snapGrid && snap ? snapToGrid(to.w) : to.w)
+      e.h = Math.max(16, snapGrid && snap ? snapToGrid(to.h) : to.h)
+    })
   },
 
   setDragDraft(d) {
@@ -254,140 +260,130 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
 
   align(kind) {
     const ids = get().selectedIds
-    const els = get()
-      .elements.filter((e) => ids.includes(e.id) && e.visible !== false)
+    const els = get().elements.filter((e) => ids.includes(e.id) && e.visible !== false)
     if (els.length < 2) return
     const x1 = Math.min(...els.map((e) => e.x))
     const y1 = Math.min(...els.map((e) => e.y))
     const x2 = Math.max(...els.map((e) => e.x + e.w))
     const y2 = Math.max(...els.map((e) => e.y + e.h))
-    set(
-      produce((draft: BuilderState) => {
-        const targets = draft.elements.filter((e) =>
-          ids.includes(e.id) && e.visible !== false,
-        )
-        switch (kind) {
-          case 'left':
-            targets.forEach((e) => {
-              e.x = x1
-            })
-            break
-          case 'centerX': {
-            const cx = (x1 + x2) / 2
-            targets.forEach((e) => {
-              e.x = Math.round(cx - e.w / 2)
-            })
-            break
-          }
-          case 'right':
-            targets.forEach((e) => {
-              e.x = x2 - e.w
-            })
-            break
-          case 'top':
-            targets.forEach((e) => {
-              e.y = y1
-            })
-            break
-          case 'centerY': {
-            const cy = (y1 + y2) / 2
-            targets.forEach((e) => {
-              e.y = Math.round(cy - e.h / 2)
-            })
-            break
-          }
-          case 'bottom':
-            targets.forEach((e) => {
-              e.y = y2 - e.h
-            })
-            break
-          case 'hSpace': {
-            const sorted = [...targets].sort((a, b) => a.x - b.x)
-            const min = sorted[0].x
-            const max = sorted[sorted.length - 1].x +
-              sorted[sorted.length - 1].w
-            const total = sorted.reduce((s, e) => s + e.w, 0)
-            const gap = sorted.length > 1 ? Math.round((max - min - total) / (sorted.length - 1)) : 0
-            let cur = min
-            sorted.forEach((e) => {
-              e.x = cur
-              cur += e.w + gap
-            })
-            break
-          }
-          case 'vSpace': {
-            const sorted = [...targets].sort((a, b) => a.y - b.y)
-            const min = sorted[0].y
-            const max = sorted[sorted.length - 1].y +
-              sorted[sorted.length - 1].h
-            const total = sorted.reduce((s, e) => s + e.h, 0)
-            const gap = sorted.length > 1 ? Math.round((max - min - total) / (sorted.length - 1)) : 0
-            let cur = min
-            sorted.forEach((e) => {
-              e.y = cur
-              cur += e.h + gap
-            })
-            break
-          }
+    apply((draft: BuilderState) => {
+      const targets = draft.elements.filter(
+        (e) => ids.includes(e.id) && e.visible !== false,
+      )
+      switch (kind) {
+        case 'left':
+          targets.forEach((e) => {
+            e.x = x1
+          })
+          break
+        case 'centerX': {
+          const cx = (x1 + x2) / 2
+          targets.forEach((e) => {
+            e.x = Math.round(cx - e.w / 2)
+          })
+          break
         }
-      }),
-    )
+        case 'right':
+          targets.forEach((e) => {
+            e.x = x2 - e.w
+          })
+          break
+        case 'top':
+          targets.forEach((e) => {
+            e.y = y1
+          })
+          break
+        case 'centerY': {
+          const cy = (y1 + y2) / 2
+          targets.forEach((e) => {
+            e.y = Math.round(cy - e.h / 2)
+          })
+          break
+        }
+        case 'bottom':
+          targets.forEach((e) => {
+            e.y = y2 - e.h
+          })
+          break
+        case 'hSpace': {
+          const sorted = [...targets].sort((a, b) => a.x - b.x)
+          const min = sorted[0].x
+          const max = sorted[sorted.length - 1].x + sorted[sorted.length - 1].w
+          const total = sorted.reduce((s, e) => s + e.w, 0)
+          const gap =
+            sorted.length > 1 ? Math.round((max - min - total) / (sorted.length - 1)) : 0
+          let cur = min
+          sorted.forEach((e) => {
+            e.x = cur
+            cur += e.w + gap
+          })
+          break
+        }
+        case 'vSpace': {
+          const sorted = [...targets].sort((a, b) => a.y - b.y)
+          const min = sorted[0].y
+          const max = sorted[sorted.length - 1].y + sorted[sorted.length - 1].h
+          const total = sorted.reduce((s, e) => s + e.h, 0)
+          const gap =
+            sorted.length > 1 ? Math.round((max - min - total) / (sorted.length - 1)) : 0
+          let cur = min
+          sorted.forEach((e) => {
+            e.y = cur
+            cur += e.h + gap
+          })
+          break
+        }
+      }
+    })
   },
 
   updateProps(id, patch) {
-    set(
-      produce((draft: BuilderState) => {
-        const e = draft.elements.find((x) => x.id === id)
-        if (!e) return
-        const { code, ...rest } = patch as any
-        if (Object.keys(rest).length) {
-          e.props = { ...(e.props ?? {}), ...rest }
+    apply((draft: BuilderState) => {
+      const e = draft.elements.find((x) => x.id === id)
+      if (!e) return
+      const { code, ...rest } = patch as any
+      if (Object.keys(rest).length) {
+        e.props = { ...(e.props ?? {}), ...rest }
+      }
+      if (code) {
+        e.code = {
+          ...(e.code ?? { displayName: '', importPath: '', props: {} }),
+          ...code,
+          props: {
+            ...(e.code?.props ?? {}),
+            ...(code.props ?? {}),
+          },
         }
-        if (code) {
-          e.code = {
-            ...(e.code ?? { displayName: '', importPath: '', props: {} }),
-            ...code,
-            props: {
-              ...(e.code?.props ?? {}),
-              ...(code.props ?? {}),
-            },
-          }
-        }
-      }),
-    )
+      }
+    })
   },
 
   deleteSelected() {
     const id = get().selectedId
     if (!id) return
-    set(
-      produce((draft: BuilderState) => {
-        draft.elements = draft.elements.filter((x) => x.id !== id)
-        draft.selectedId = null
-      }),
-    )
+    apply((draft: BuilderState) => {
+      draft.elements = draft.elements.filter((x) => x.id !== id)
+      draft.selectedId = null
+      draft.selectedIds = []
+    })
   },
 
   bringToFront(id) {
-    set(
-      produce((draft: BuilderState) => {
-        const i = draft.elements.findIndex((x) => x.id === id)
-        if (i < 0) return
-        const [e] = draft.elements.splice(i, 1)
-        draft.elements.push(e)
-      }),
-    )
+    apply((draft: BuilderState) => {
+      const i = draft.elements.findIndex((x) => x.id === id)
+      if (i < 0) return
+      const [e] = draft.elements.splice(i, 1)
+      draft.elements.push(e)
+    })
   },
 
   sendToBack(id) {
-    set(
-      produce((draft: BuilderState) => {
-        const i = draft.elements.findIndex((x) => x.id === id)
-        if (i < 0) return
-        const [e] = draft.elements.splice(i, 1)
-        draft.elements.unshift(e)
-      }),
-    )
+    apply((draft: BuilderState) => {
+      const i = draft.elements.findIndex((x) => x.id === id)
+      if (i < 0) return
+      const [e] = draft.elements.splice(i, 1)
+      draft.elements.unshift(e)
+    })
   },
 
   nudge(dx, dy) {
@@ -397,6 +393,14 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     if (!el) return
     const { snap } = useGridStore.getState()
     get().move(id, { x: el.x + dx, y: el.y + dy }, snap)
+  },
+
+  undo() {
+    set((state) => useHistoryStore.getState().undo(state))
+  },
+
+  redo() {
+    set((state) => useHistoryStore.getState().redo(state))
   },
 
   setElements(els) {
@@ -421,5 +425,5 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
       console.error('Failed to hydrate builder state', e)
     }
   },
-}))
+})
 

--- a/web/store/historyStore.ts
+++ b/web/store/historyStore.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import { Patch, applyPatches } from 'immer'
+
+interface Entry {
+  patches: Patch[]
+  inverse: Patch[]
+}
+
+interface HistoryState {
+  stack: Entry[]
+  index: number
+  limit: number
+  draft: Entry | null
+  push: (patches: Patch[], inverse: Patch[]) => void
+  start: () => void
+  commit: () => void
+  undo: <T>(state: T) => T
+  redo: <T>(state: T) => T
+  clear: () => void
+}
+
+export const useHistoryStore = create<HistoryState>((set, get) => ({
+  stack: [],
+  index: -1,
+  limit: 100,
+  draft: null,
+  push(patches, inverse) {
+    const draft = get().draft
+    if (draft) {
+      draft.patches.push(...patches)
+      draft.inverse = [...inverse, ...draft.inverse]
+      set({ draft })
+      return
+    }
+    let stack = get().stack.slice(0, get().index + 1)
+    stack.push({ patches, inverse })
+    if (stack.length > get().limit) {
+      stack = stack.slice(stack.length - get().limit)
+    }
+    set({ stack, index: stack.length - 1 })
+  },
+  start() {
+    set({ draft: { patches: [], inverse: [] } })
+  },
+  commit() {
+    const draft = get().draft
+    if (draft && draft.patches.length) {
+      let stack = get().stack.slice(0, get().index + 1)
+      stack.push(draft)
+      if (stack.length > get().limit) {
+        stack = stack.slice(stack.length - get().limit)
+      }
+      set({ stack, index: stack.length - 1, draft: null })
+    } else {
+      set({ draft: null })
+    }
+  },
+  undo(state) {
+    const { index, stack } = get()
+    if (index < 0) return state
+    const entry = stack[index]
+    set({ index: index - 1 })
+    return applyPatches(state, entry.inverse)
+  },
+  redo(state) {
+    const { index, stack } = get()
+    if (index + 1 >= stack.length) return state
+    const entry = stack[index + 1]
+    set({ index: index + 1 })
+    return applyPatches(state, entry.patches)
+  },
+  clear() {
+    set({ stack: [], index: -1, draft: null })
+  },
+}))


### PR DESCRIPTION
## Summary
- add history store with stack-based undo/redo
- track builder state mutations and expose undo/redo actions
- batch drag/resize updates and wire up shortcuts and toolbar buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31636fc8c832c8d19fab8574d071c