### PR TITLE
feat(binding): light read-only data binding for text/attrs

### DIFF
--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -3,7 +3,8 @@ import { useEditorStore } from '@/store/editorStore';
 import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
-import { resolveBinding } from '@/lib/binding/resolve';
+import { resolveComponentBinding, resolveBinding } from '@/lib/binding/resolve';
+import { useBindingStore } from '@/store/bindingStore';
 import { DEVICE_PRESETS } from '@/lib/devicePresets';
 import AnnotationsOverlay from '@/components/editor/AnnotationsOverlay';
 import { useSearchParams } from 'next/navigation';
@@ -11,7 +12,9 @@ import '@/styles/preview.css';
 
 function renderNode(
   node: ComponentNode,
-  components: Record<string, any>
+  components: Record<string, any>,
+  sources: ReturnType<typeof useBindingStore.getState>['sources'],
+  bindings: ReturnType<typeof useBindingStore.getState>['bindings'],
 ): JSX.Element {
   if (node.type === 'Instance') {
     const inst = node as InstanceNode;
@@ -19,25 +22,27 @@ function renderNode(
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
       if (inst.propValues)
-        resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+        resolved = resolveComponentBinding(resolved, def.props, inst.propValues || {});
       if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
-      return renderNode(resolved, components);
+      return renderNode(resolved, components, sources, bindings);
     }
   }
+  const nodeBindings = bindings.filter((b) => b.nodeId === node.id);
+  const props = resolveBinding(node.props || {}, nodeBindings, sources);
   const style: React.CSSProperties = {
     position: 'absolute',
-    left: node.props?.x || 0,
-    top: node.props?.y || 0,
-    width: node.props?.w || 0,
-    height: node.props?.h || 0,
-    transform: `rotate(${node.props?.rotation || 0}deg)`,
+    left: props.x || 0,
+    top: props.y || 0,
+    width: props.w || 0,
+    height: props.h || 0,
+    transform: `rotate(${props.rotation || 0}deg)`,
   };
-  if (node.props?.visible === false) style.display = 'none';
+  if (props.visible === false) style.display = 'none';
   return (
-    <div key={node.id} style={style} className={node.props?.className}>
-      {node.props?.text}
-      {node.children?.map((c) => renderNode(c, components))}
+    <div key={node.id} style={style} className={props.className}>
+      {props.text}
+      {node.children?.map((c) => renderNode(c, components, sources, bindings))}
     </div>
   );
 }
@@ -45,6 +50,8 @@ function renderNode(
 export default function PreviewPage() {
   const tree = useEditorStore((s) => s.tree);
   const components = useEditorStore((s) => s.components);
+  const sources = useBindingStore((s) => s.sources);
+  const bindings = useBindingStore((s) => s.bindings);
   const params = useSearchParams();
   const device = (params.get('device') as 'desktop' | 'tablet' | 'mobile') || 'desktop';
   const zoom = parseFloat(params.get('zoom') || '1');
@@ -78,7 +85,7 @@ export default function PreviewPage() {
     <div className="w-full h-full flex items-center justify-center bg-gray-100">
       <div style={style}>
         {safe}
-        {tree.map((n) => renderNode(n, components))}
+        {tree.map((n) => renderNode(n, components, sources, bindings))}
         {showComments && <AnnotationsOverlay />}
       </div>
     </div>

--- a/web/app/s/[id]/page.tsx
+++ b/web/app/s/[id]/page.tsx
@@ -5,35 +5,43 @@ import { deserialize } from '@/lib/deserialize';
 import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
-import { resolveBinding } from '@/lib/binding/resolve';
+import { resolveComponentBinding, resolveBinding } from '@/lib/binding/resolve';
+import { useBindingStore } from '@/store/bindingStore';
 import AnnotationsOverlay from '@/components/editor/AnnotationsOverlay';
 
-function renderNode(node: ComponentNode, components: Record<string, any>): JSX.Element {
+function renderNode(
+  node: ComponentNode,
+  components: Record<string, any>,
+  sources: ReturnType<typeof useBindingStore.getState>['sources'],
+  bindings: ReturnType<typeof useBindingStore.getState>['bindings'],
+): JSX.Element {
   if (node.type === 'Instance') {
     const inst = node as InstanceNode;
     const def = components[inst.componentId];
     if (def) {
       let resolved = resolveVariant(def, inst.variant);
       if (inst.propValues)
-        resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+        resolved = resolveComponentBinding(resolved, def.props, inst.propValues || {});
       if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
       resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
-      return renderNode(resolved, components);
+      return renderNode(resolved, components, sources, bindings);
     }
   }
+  const nodeBindings = bindings.filter((b) => b.nodeId === node.id);
+  const props = resolveBinding(node.props || {}, nodeBindings, sources);
   const style: React.CSSProperties = {
     position: 'absolute',
-    left: node.props?.x || 0,
-    top: node.props?.y || 0,
-    width: node.props?.w || 0,
-    height: node.props?.h || 0,
-    transform: `rotate(${node.props?.rotation || 0}deg)`
+    left: props.x || 0,
+    top: props.y || 0,
+    width: props.w || 0,
+    height: props.h || 0,
+    transform: `rotate(${props.rotation || 0}deg)`
   };
-  if (node.props?.visible === false) style.display = 'none';
+  if (props.visible === false) style.display = 'none';
   return (
-    <div key={node.id} style={style} className={node.props?.className}>
-      {node.props?.text}
-      {node.children?.map((c) => renderNode(c, components))}
+    <div key={node.id} style={style} className={props.className}>
+      {props.text}
+      {node.children?.map((c) => renderNode(c, components, sources, bindings))}
     </div>
   );
 }
@@ -47,10 +55,12 @@ export default function SharedPreview() {
   }, [params.id]);
   if (!data) return null;
   const state = deserialize(data);
+  const sources = useBindingStore((s) => s.sources);
+  const bindings = useBindingStore((s) => s.bindings);
   const showComments = search.get('comments') === '1';
   return (
     <div className="relative w-full h-full">
-      {state.tree.map((n) => renderNode(n, state.components))}
+      {state.tree.map((n) => renderNode(n, state.components, sources, bindings))}
       {showComments && <AnnotationsOverlay />}
     </div>
   );

--- a/web/components/blocks/Text.tsx
+++ b/web/components/blocks/Text.tsx
@@ -1,6 +1,6 @@
 import type { BuilderNodeMeta } from '@/types/builder'
 
-export function Text({ text, className }: { text: string; className?: string }) {
+export function Text({ text, className }: { text?: string; className?: string }) {
   return <div className={className}>{text}</div>
 }
 

--- a/web/components/builder/RightInspectorBindings.tsx
+++ b/web/components/builder/RightInspectorBindings.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useBindingStore } from '@/store/bindingStore'
+import { useState } from 'react'
+
+export default function RightInspectorBindings() {
+  const sources = useBindingStore((s) => s.sources)
+  const addSource = useBindingStore((s) => s.addSource)
+  const updateSource = useBindingStore((s) => s.updateSource)
+  const removeSource = useBindingStore((s) => s.removeSource)
+
+  const [kind, setKind] = useState<'const' | 'json' | 'expr'>('const')
+  const [value, setValue] = useState('')
+
+  const handleAdd = () => {
+    let val: any = value
+    if (kind === 'json') {
+      try { val = JSON.parse(value) } catch { /* ignore */ }
+    }
+    addSource(kind, val)
+    setValue('')
+  }
+
+  return (
+    <div className="p-2 space-y-2 text-xs">
+      <div className="flex space-x-2">
+        <select
+          className="bg-gray-700 text-white p-1"
+          value={kind}
+          onChange={(e) => setKind(e.target.value as any)}
+        >
+          <option value="const">const</option>
+          <option value="json">json</option>
+          <option value="expr">expr</option>
+        </select>
+        <input
+          className="flex-1 bg-gray-700 text-white p-1"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <button
+          className="bg-gray-600 px-2"
+          onClick={handleAdd}
+        >
+          add
+        </button>
+      </div>
+      {sources.map((s) => (
+        <div key={s.id} className="border border-gray-700 p-1 space-y-1">
+          <div className="flex space-x-2 items-center">
+            <span className="text-gray-400">{s.id}</span>
+            <select
+              className="bg-gray-700 text-white p-1 flex-1"
+              value={s.kind}
+              onChange={(e) => updateSource(s.id, { kind: e.target.value as any })}
+            >
+              <option value="const">const</option>
+              <option value="json">json</option>
+              <option value="expr">expr</option>
+            </select>
+            <button
+              className="text-red-400"
+              onClick={() => removeSource(s.id)}
+            >
+              x
+            </button>
+          </div>
+          <textarea
+            className="w-full bg-gray-700 text-white p-1"
+            rows={3}
+            value={typeof s.value === 'string' ? s.value : JSON.stringify(s.value, null, 2)}
+            onChange={(e) => {
+              let v: any = e.target.value
+              if (s.kind === 'json') {
+                try { v = JSON.parse(e.target.value) } catch { /* ignore */ }
+              }
+              updateSource(s.id, { value: v })
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -5,37 +5,43 @@ import { findNode } from '@/lib/tree';
 import type { ComponentNode, InstanceNode, PrototypeLink } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
 import { applyOverrides } from '@/lib/overrideMerge';
-import { resolveBinding } from '@/lib/binding/resolve';
+import { resolveComponentBinding, resolveBinding } from '@/lib/binding/resolve';
+import { useBindingStore } from '@/store/bindingStore';
 import { PresenterHUD } from '@/components/preview/PresenterHUD';
 import { buildPoseMap, diffPoses, easeStandard } from '@/lib/animate/smart';
 import PresetStyle from '@/components/interaction/PresetStyle';
 
 function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: PrototypeLink) => void }) {
   const components = useEditorStore((s) => s.components);
+  const sources = useBindingStore((s) => s.sources);
+  const bindingsForNode = useBindingStore((s) =>
+    s.bindings.filter((b) => b.nodeId === node.id),
+  );
   if (node.type === 'Instance') {
     const inst = node as InstanceNode;
     const def = components[inst.defId || inst.componentId];
     if (!def) return null;
     let resolved = resolveVariant(def, inst.variantProps);
     if (inst.propValues)
-      resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+      resolved = resolveComponentBinding(resolved, def.props, inst.propValues || {});
     if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
     resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
     return <NodeRenderer node={resolved} onLink={onLink} />;
   }
-  const layout = node.props?.layout || 'free';
+  const resolvedProps = resolveBinding(node.props || {}, bindingsForNode, sources);
+  const layout = resolvedProps.layout || 'free';
   const style: any = {};
   if (layout === 'auto') {
     style.display = 'flex';
-    style.flexDirection = node.props?.axis === 'horizontal' ? 'row' : 'column';
-    if (node.props?.gap !== undefined) style.gap = node.props.gap;
+    style.flexDirection = resolvedProps.axis === 'horizontal' ? 'row' : 'column';
+    if (resolvedProps.gap !== undefined) style.gap = resolvedProps.gap;
   } else {
     style.position = 'absolute';
-    style.left = node.props?.x || 0;
-    style.top = node.props?.y || 0;
+    style.left = resolvedProps.x || 0;
+    style.top = resolvedProps.y || 0;
   }
-  if (node.props?.w !== undefined) style.width = node.props.w;
-  if (node.props?.h !== undefined) style.height = node.props.h;
+  if (resolvedProps.w !== undefined) style.width = resolvedProps.w;
+  if (resolvedProps.h !== undefined) style.height = resolvedProps.h;
  
   const link = node.prototypeLink;
   const handleClick = (e: any) => {
@@ -62,7 +68,7 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         style={style}
         data-node-id={node.id}
         data-node-type={node.type}
-        data-node-name={(node as any).props?.name}
+        data-node-name={resolvedProps?.name}
         onClick={handleClick}
         onMouseEnter={handleHover}
         className={link ? 'cursor-pointer' : undefined}
@@ -70,10 +76,10 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         <div className="w-full h-full bg-gray-300" />
         <PresetStyle
           nodeId={node.id}
-          presetIds={node.props?.presetIds}
-          presetId={node.props?.presetId}
-          hoverEffects={node.props?.hoverEffects}
-          hoverTransitionMs={node.props?.hoverTransitionMs}
+          presetIds={resolvedProps?.presetIds}
+          presetId={resolvedProps?.presetId}
+          hoverEffects={resolvedProps?.hoverEffects}
+          hoverTransitionMs={resolvedProps?.hoverTransitionMs}
         />
       </div>
     );
@@ -84,18 +90,18 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         style={style}
         data-node-id={node.id}
         data-node-type={node.type}
-        data-node-name={(node as any).props?.name}
+        data-node-name={resolvedProps?.name}
         onClick={handleClick}
         onMouseEnter={handleHover}
         className={link ? 'cursor-pointer' : undefined}
       >
-        {node.props?.text}
+        {resolvedProps?.text}
         <PresetStyle
           nodeId={node.id}
-          presetIds={node.props?.presetIds}
-          presetId={node.props?.presetId}
-          hoverEffects={node.props?.hoverEffects}
-          hoverTransitionMs={node.props?.hoverTransitionMs}
+          presetIds={resolvedProps?.presetIds}
+          presetId={resolvedProps?.presetId}
+          hoverEffects={resolvedProps?.hoverEffects}
+          hoverTransitionMs={resolvedProps?.hoverTransitionMs}
         />
       </div>
     );
@@ -105,7 +111,7 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       style={style}
       data-node-id={node.id}
       data-node-type={node.type}
-      data-node-name={(node as any).props?.name}
+      data-node-name={resolvedProps?.name}
       onClick={handleClick}
       onMouseEnter={handleHover}
       className={link ? 'cursor-pointer' : undefined}
@@ -115,10 +121,10 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       ))}
       <PresetStyle
         nodeId={node.id}
-        presetIds={node.props?.presetIds}
-        presetId={node.props?.presetId}
-        hoverEffects={node.props?.hoverEffects}
-        hoverTransitionMs={node.props?.hoverTransitionMs}
+        presetIds={resolvedProps?.presetIds}
+        presetId={resolvedProps?.presetId}
+        hoverEffects={resolvedProps?.hoverEffects}
+        hoverTransitionMs={resolvedProps?.hoverTransitionMs}
       />
     </div>
   );

--- a/web/lib/binding/resolve.ts
+++ b/web/lib/binding/resolve.ts
@@ -1,7 +1,57 @@
 import type { ComponentNode, ComponentProp } from '@/types/editor'
 
-// Apply component prop values to the cloned node tree
+export type BindingSource = {
+  id: string
+  kind: 'const' | 'json' | 'expr'
+  value: any
+}
+
+export type Binding = {
+  nodeId: string
+  prop: string
+  sourceId: string
+  path?: string
+}
+
+// Resolve data bindings for a node's props
 export function resolveBinding(
+  nodeProps: Record<string, any>,
+  bindings: Binding[],
+  sources: BindingSource[],
+): Record<string, any> {
+  const result: Record<string, any> = { ...nodeProps }
+  const resolvedSources: Record<string, any> = {}
+
+  for (const s of sources) {
+    if (s.kind === 'const' || s.kind === 'json') {
+      resolvedSources[s.id] = s.value
+    }
+  }
+  for (const s of sources) {
+    if (s.kind === 'expr') {
+      let str = String(s.value)
+      str = str.replace(/\{\{([^}]+)\}\}/g, (_, p) => {
+        const v = getByPath(resolvedSources, p.trim())
+        return v == null ? '' : String(v)
+      })
+      resolvedSources[s.id] = str
+    }
+  }
+
+  for (const b of bindings) {
+    const srcVal = resolvedSources[b.sourceId]
+    if (srcVal === undefined) continue
+    let val = srcVal
+    if (b.path) {
+      val = getByPath(srcVal, b.path)
+    }
+    result[b.prop] = val
+  }
+  return result
+}
+
+// Apply component prop values to the cloned node tree (legacy)
+export function resolveComponentBinding(
   root: ComponentNode,
   props: ComponentProp[] | undefined,
   values: Record<string, any> = {},
@@ -15,6 +65,16 @@ export function resolveBinding(
     setByPath(clone, p.targetPath, val)
   }
   return clone
+}
+
+function getByPath(obj: any, path: string) {
+  const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.')
+  let cur = obj
+  for (const k of keys) {
+    if (cur == null) return undefined
+    cur = cur[k]
+  }
+  return cur
 }
 
 function setByPath(obj: any, path: string, value: any) {

--- a/web/lib/override/resolve.ts
+++ b/web/lib/override/resolve.ts
@@ -1,6 +1,6 @@
 import type { ComponentNode, EditorState, InstanceNode, OverrideMap } from '@/types/editor'
 import { deepCloneNodeTree, findNode } from '@/lib/tree'
-import { resolveBinding } from '@/lib/binding/resolve'
+import { resolveComponentBinding } from '@/lib/binding/resolve'
 
 export function resolveOverrides(root: ComponentNode, overrides: OverrideMap = {}): ComponentNode {
   const clone = deepCloneNodeTree(root)
@@ -40,7 +40,7 @@ export function resolveInstance(state: EditorState, inst: InstanceNode): Compone
   if (!baseRoot) return null
   let root = deepCloneNodeTree(baseRoot)
   if (def.props)
-    root = resolveBinding(root, def.props, inst.propValues || {})
+    root = resolveComponentBinding(root, def.props, inst.propValues || {})
   if (inst.overrides) root = resolveOverrides(root, inst.overrides)
   ;(root as any).props = { ...(root as any).props, ...(inst as any).props }
   ;(root as any).opacity = (inst as any).opacity ?? (root as any).opacity

--- a/web/store/bindingStore.ts
+++ b/web/store/bindingStore.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand'
+import { nanoid } from 'nanoid'
+
+export type BindingSource = {
+  id: string
+  kind: 'const' | 'json' | 'expr'
+  value: any
+}
+
+export type Binding = {
+  nodeId: string
+  prop: string
+  sourceId: string
+  path?: string
+}
+
+interface BindingState {
+  sources: BindingSource[]
+  bindings: Binding[]
+}
+
+interface BindingActions {
+  addSource: (kind: BindingSource['kind'], value: any) => string
+  updateSource: (
+    id: string,
+    patch: Partial<Omit<BindingSource, 'id'>>,
+  ) => void
+  removeSource: (id: string) => void
+  addBinding: (b: Binding) => void
+  removeBinding: (nodeId: string, prop: string) => void
+}
+
+export const useBindingStore = create<BindingState & BindingActions>((set) => ({
+  sources: [],
+  bindings: [],
+
+  addSource(kind, value) {
+    const id = nanoid()
+    set((s) => ({ sources: [...s.sources, { id, kind, value }] }))
+    return id
+  },
+
+  updateSource(id, patch) {
+    set((s) => ({
+      sources: s.sources.map((src) =>
+        src.id === id ? { ...src, ...patch } : src,
+      ),
+    }))
+  },
+
+  removeSource(id) {
+    set((s) => ({
+      sources: s.sources.filter((src) => src.id !== id),
+      bindings: s.bindings.filter((b) => b.sourceId !== id),
+    }))
+  },
+
+  addBinding(b) {
+    set((s) => ({ bindings: [...s.bindings, b] }))
+  },
+
+  removeBinding(nodeId, prop) {
+    set((s) => ({
+      bindings: s.bindings.filter(
+        (b) => b.nodeId !== nodeId || b.prop !== prop,
+      ),
+    }))
+  },
+}))
+

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -34,7 +34,7 @@ import { idbStorage } from "@/lib/idb";
 import { initPersist, schedulePersist } from "@/lib/persist";
 import { push, undo as undoStack, redo as redoStack } from "./undoRedo";
 import { resolveVariantRoot } from "@/lib/variant/resolve";
-import { resolveBinding } from "@/lib/binding/resolve";
+import { resolveComponentBinding } from "@/lib/binding/resolve";
 import { mapNodesForSwap } from "@/lib/override/compat";
 import { resolveOverrides } from "@/lib/override/resolve";
 import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
@@ -737,7 +737,7 @@ export const useEditorStore = create<
     if (!def) return;
     let resolved = resolveVariant(def, inst.variant);
     if (inst.propValues) {
-      resolved = resolveBinding(resolved, def.props, inst.propValues || {});
+      resolved = resolveComponentBinding(resolved, def.props, inst.propValues || {});
     }
     if (inst.overrides) {
       resolved = resolveOverrides(resolved, inst.overrides);


### PR DESCRIPTION
## Summary
- introduce binding store for managing constant, JSON and expression data sources
- add simple inspector panel to create and edit data sources
- resolve node props from data bindings and render bound text in preview/player

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b319a3e558832c9b47a8121c585474