### PR TITLE
feat: canvas zoom/pan and multi-select transforms

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -13,6 +13,8 @@ import NodeWrapper from './NodeWrapper'
 import { Rulers } from './Rulers'
 import { useUnitStore } from '@/store/unitStore'
 import { intersects } from '@/lib/geom'
+import { useViewStore } from '@/store/viewStore'
+import { SelectionBBox } from './SelectionBBox'
 
 function bgGridStyle(s: number) {
   return {
@@ -330,6 +332,28 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const [marquee, setMarquee] = React.useState<
     { x: number; y: number; w: number; h: number } | null
   >(null)
+  const { zoom, pan, setZoom, setPan, screenToWorld } = useViewStore((s) => ({
+    zoom: s.zoom,
+    pan: s.pan,
+    setZoom: s.setZoom,
+    setPan: s.setPan,
+    screenToWorld: s.screenToWorld,
+  }))
+  const spacePressed = React.useRef(false)
+  React.useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.code === 'Space') spacePressed.current = true
+    }
+    const up = (e: KeyboardEvent) => {
+      if (e.code === 'Space') spacePressed.current = false
+    }
+    window.addEventListener('keydown', down)
+    window.addEventListener('keyup', up)
+    return () => {
+      window.removeEventListener('keydown', down)
+      window.removeEventListener('keyup', up)
+    }
+  }, [])
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -383,33 +407,56 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
           // @ts-ignore
           canvasRef.current = n
         }}
+        onWheel={(e) => {
+          if (!e.ctrlKey && !e.metaKey) return
+          e.preventDefault()
+          const rect = e.currentTarget.getBoundingClientRect()
+          const cursor = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+          const world = screenToWorld(cursor)
+          let z = zoom * (1 - e.deltaY * 0.001)
+          z = Math.max(0.25, Math.min(4, z))
+          const newPan = { x: cursor.x - world.x * z, y: cursor.y - world.y * z }
+          setZoom(z)
+          setPan(newPan)
+        }}
         onPointerDown={(e) => {
           if (e.button !== 0) return
+          if (spacePressed.current) {
+            const start = { x: e.clientX, y: e.clientY }
+            const startPan = { ...pan }
+            const move = (ev: PointerEvent) => {
+              setPan({ x: startPan.x + ev.clientX - start.x, y: startPan.y + ev.clientY - start.y })
+            }
+            const up = () => {
+              window.removeEventListener('pointermove', move)
+              window.removeEventListener('pointerup', up)
+            }
+            window.addEventListener('pointermove', move)
+            window.addEventListener('pointerup', up)
+            return
+          }
           if (e.target !== e.currentTarget) return
           const rect = e.currentTarget.getBoundingClientRect()
-          const startX = e.clientX - rect.left
-          const startY = e.clientY - rect.top
-          let box = { x: startX, y: startY, w: 0, h: 0 }
+          const start = screenToWorld({ x: e.clientX - rect.left, y: e.clientY - rect.top })
+          let box = { x: start.x, y: start.y, w: 0, h: 0 }
           setMarquee(box)
           const onMove = (ev: PointerEvent) => {
-            const x = ev.clientX - rect.left
-            const y = ev.clientY - rect.top
-            const mx = Math.min(x, startX)
-            const my = Math.min(y, startY)
-            const mw = Math.abs(x - startX)
-            const mh = Math.abs(y - startY)
+            const p = screenToWorld({ x: ev.clientX - rect.left, y: ev.clientY - rect.top })
+            const mx = Math.min(p.x, start.x)
+            const my = Math.min(p.y, start.y)
+            const mw = Math.abs(p.x - start.x)
+            const mh = Math.abs(p.y - start.y)
             box = { x: mx, y: my, w: mw, h: mh }
             setMarquee(box)
           }
           const onUp = (ev: PointerEvent) => {
             window.removeEventListener('pointermove', onMove)
             window.removeEventListener('pointerup', onUp)
-            const x = ev.clientX - rect.left
-            const y = ev.clientY - rect.top
-            const mx = Math.min(x, startX)
-            const my = Math.min(y, startY)
-            const mw = Math.abs(x - startX)
-            const mh = Math.abs(y - startY)
+            const p = screenToWorld({ x: ev.clientX - rect.left, y: ev.clientY - rect.top })
+            const mx = Math.min(p.x, start.x)
+            const my = Math.min(p.y, start.y)
+            const mw = Math.abs(p.x - start.x)
+            const mh = Math.abs(p.y - start.y)
             const final = { x: mx, y: my, w: mw, h: mh }
             setMarquee(null)
             if (mw < 2 && mh < 2) {
@@ -439,15 +486,29 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         className="relative w-[1200px] h-[720px] border border-zinc-800 rounded-lg overflow-hidden"
         style={gridVisible ? bgGridStyle(gridSize) : undefined}
       >
-        {/* page base pseudo preview */}
-        <div className="absolute inset-0 pointer-events-none" />
-        {els
-          .filter((e) => !e.parentId)
-          .map((e) => (
-            <ElmView key={e.id} elm={e} all={els} />
-          ))}
+        <div
+          className="absolute inset-0"
+          style={{ transform: `translate(${pan.x}px,${pan.y}px) scale(${zoom})`, transformOrigin: '0 0' }}
+        >
+          {/* page base pseudo preview */}
+          <div className="absolute inset-0 pointer-events-none" />
+          {els
+            .filter((e) => !e.parentId)
+            .map((e) => (
+              <ElmView key={e.id} elm={e} all={els} />
+            ))}
+          <SelectionBBox />
+        </div>
         <CanvasOverlay marquee={marquee ?? undefined} />
-        <Rulers width={1200} height={720} canvasRef={canvasRef} />
+        <Rulers
+          width={1200}
+          height={720}
+          canvasRef={canvasRef}
+          screenToWorld={(p, axis) => {
+            const pt = screenToWorld(axis === 'x' ? { x: p, y: 0 } : { x: 0, y: p })
+            return axis === 'x' ? pt.x : pt.y
+          }}
+        />
         <div className="absolute left-2 bottom-2 text-[11px] text-zinc-400 bg-black/40 px-2 py-1 rounded border border-zinc-800">
           drag to move • drop from Palette • arrows to nudge • click empty = unselect
         </div>

--- a/web/components/builder/CanvasOverlay.tsx
+++ b/web/components/builder/CanvasOverlay.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useBuilderStore } from '@/store/builderStore'
 import { useGuidesStore } from '@/store/guidesStore'
 import { Toolbar } from './Toolbar'
+import { useViewStore } from '@/store/viewStore'
 
 export function CanvasOverlay({
   marquee,
@@ -14,16 +15,18 @@ export function CanvasOverlay({
   const align = useBuilderStore((s) => s.align)
   const showAlign = selectedIds.length > 1
   const guides = useGuidesStore((s) => s.guides.filter((g) => g.visible))
+  const worldToScreen = useViewStore((s) => s.worldToScreen)
+  const zoom = useViewStore((s) => s.zoom)
   return (
     <div className="absolute inset-0 pointer-events-none z-50">
       {marquee && (
         <div
           className="absolute border border-amber-400/70 bg-amber-400/10"
           style={{
-            left: marquee.x,
-            top: marquee.y,
-            width: marquee.w,
-            height: marquee.h,
+            left: worldToScreen({ x: marquee.x, y: marquee.y }).x,
+            top: worldToScreen({ x: marquee.x, y: marquee.y }).y,
+            width: marquee.w * zoom,
+            height: marquee.h * zoom,
           }}
         />
       )}
@@ -32,13 +35,13 @@ export function CanvasOverlay({
           <div
             key={g.id}
             className={`absolute top-0 bottom-0 border-l ${g.locked ? 'border-red-400 border-dashed' : 'border-amber-400/70'}`}
-            style={{ left: g.pos }}
+            style={{ left: worldToScreen({ x: g.pos, y: 0 }).x }}
           />
         ) : (
           <div
             key={g.id}
             className={`absolute left-0 right-0 border-t ${g.locked ? 'border-red-400 border-dashed' : 'border-amber-400/70'}`}
-            style={{ top: g.pos }}
+            style={{ top: worldToScreen({ x: 0, y: g.pos }).y }}
           />
         ),
       )}
@@ -47,13 +50,13 @@ export function CanvasOverlay({
           <div
             key={`snap-${i}`}
             className="absolute top-0 bottom-0 border-l border-sky-400/70"
-            style={{ left: g.pos }}
+            style={{ left: worldToScreen({ x: g.pos, y: 0 }).x }}
           />
         ) : (
           <div
             key={`snap-${i}`}
             className="absolute left-0 right-0 border-t border-sky-400/70"
-            style={{ top: g.pos }}
+            style={{ top: worldToScreen({ x: 0, y: g.pos }).y }}
           />
         ),
       )}

--- a/web/components/builder/Rulers.tsx
+++ b/web/components/builder/Rulers.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { useGuidesStore } from '@/store/guidesStore'
 import { useUnitStore } from '@/store/unitStore'
+import { useViewStore } from '@/store/viewStore'
 
 export type ScreenToWorld = (p: number, axis: 'x'|'y') => number
 
@@ -95,8 +96,9 @@ export function Rulers({
     return () => window.removeEventListener('click', close)
   }, [])
 
-  const ticksX = getTicks(width, unit, remBase)
-  const ticksY = getTicks(height, unit, remBase)
+  const zoom = useViewStore((s) => s.zoom)
+  const ticksX = React.useMemo(() => getTicks(width * zoom, unit, remBase).map((t) => ({ ...t, px: t.px / zoom })), [width, zoom, unit, remBase])
+  const ticksY = React.useMemo(() => getTicks(height * zoom, unit, remBase).map((t) => ({ ...t, px: t.px / zoom })), [height, zoom, unit, remBase])
 
   return (
     <div className="absolute top-0 left-0 select-none">

--- a/web/components/builder/SelectionBBox.tsx
+++ b/web/components/builder/SelectionBBox.tsx
@@ -1,0 +1,64 @@
+'use client'
+import React from 'react'
+import { useBuilderStore } from '@/store/builderStore'
+import { snapRect, collectSnapPoints } from '@/lib/builder/snap'
+import { useViewStore } from '@/store/viewStore'
+
+export function SelectionBBox() {
+  const selectedIds = useBuilderStore((s) => s.selectedIds)
+  const elements = useBuilderStore((s) => s.elements)
+    const updateMany = useBuilderStore((s) => s.updateMany)
+    const clearGuides = useBuilderStore((s) => s.clearGuides)
+  const screenToWorld = useViewStore((s) => s.screenToWorld)
+  const worldToScreen = useViewStore((s) => s.worldToScreen)
+  const zoom = useViewStore((s) => s.zoom)
+  if (selectedIds.length < 2) return null
+  const selected = elements.filter((el) => selectedIds.includes(el.id) && el.visible !== false)
+  const x1 = Math.min(...selected.map((e) => e.x))
+  const y1 = Math.min(...selected.map((e) => e.y))
+  const x2 = Math.max(...selected.map((e) => e.x + e.w))
+  const y2 = Math.max(...selected.map((e) => e.y + e.h))
+  const bbox = { x: x1, y: y1, w: x2 - x1, h: y2 - y1 }
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    const start = screenToWorld({ x: e.clientX, y: e.clientY })
+    const startBox = { ...bbox }
+    const snapPoints = collectSnapPoints(elements, undefined)
+    const move = (ev: PointerEvent) => {
+      const p = screenToWorld({ x: ev.clientX, y: ev.clientY })
+      const dx = p.x - start.x
+      const dy = p.y - start.y
+      const { rect } = snapRect(
+        { x: startBox.x + dx, y: startBox.y + dy, w: startBox.w, h: startBox.h },
+        snapPoints,
+        { mode: 'move' },
+      )
+      const patches = selected.map((el) => ({ id: el.id, patch: { x: el.x + rect.x - bbox.x, y: el.y + rect.y - bbox.y } }))
+      updateMany(patches)
+    }
+    const up = () => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', up)
+        clearGuides()
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', up)
+  }
+
+  return (
+    <div
+      className="absolute border border-sky-400/80"
+      style={{
+        left: worldToScreen({ x: bbox.x, y: bbox.y }).x,
+        top: worldToScreen({ x: bbox.x, y: bbox.y }).y,
+        width: bbox.w * zoom,
+        height: bbox.h * zoom,
+      }}
+      onPointerDown={onPointerDown}
+    />
+  )
+}
+
+export default SelectionBBox

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -98,6 +98,7 @@ type BuilderActions = {
   hydrate: (json: string) => void
   undo: () => void
   redo: () => void
+  updateMany: (patches: Array<{ id: string; patch: Partial<Elm> }>) => void
 }
 
 function snapToGrid(n: number) {
@@ -514,6 +515,15 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
 
   redo() {
     set((state) => useHistoryStore.getState().redo(state))
+  },
+
+  updateMany(patches) {
+    apply((draft: BuilderState) => {
+      patches.forEach(({ id, patch }) => {
+        const el = draft.elements.find((e) => e.id === id)
+        if (el) Object.assign(el, patch)
+      })
+    })
   },
 
   setElements(els) {

--- a/web/store/viewStore.ts
+++ b/web/store/viewStore.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand'
+
+export type Point = { x: number; y: number }
+export type Size = { width: number; height: number }
+export type BBox = { x: number; y: number; w: number; h: number }
+
+const ZOOM_MIN = 0.25
+const ZOOM_MAX = 4
+
+interface ViewState {
+  zoom: number
+  pan: Point
+}
+
+interface ViewActions {
+  setZoom: (z: number) => void
+  setPan: (p: Point) => void
+  fitToBounds: (canvas: Size, bbox: BBox) => void
+  worldToScreen: (p: Point) => Point
+  screenToWorld: (p: Point) => Point
+}
+
+export const useViewStore = create<ViewState & ViewActions>((set, get) => ({
+  zoom: 1,
+  pan: { x: 0, y: 0 },
+  setZoom(z) {
+    const clamped = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z))
+    set({ zoom: clamped })
+  },
+  setPan(p) {
+    set({ pan: p })
+  },
+  fitToBounds(canvas, bbox) {
+    if (bbox.w === 0 || bbox.h === 0) {
+      set({ zoom: 1, pan: { x: 0, y: 0 } })
+      return
+    }
+    const zx = canvas.width / bbox.w
+    const zy = canvas.height / bbox.h
+    const z = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.min(zx, zy)))
+    const x = (canvas.width - bbox.w * z) / 2 - bbox.x * z
+    const y = (canvas.height - bbox.h * z) / 2 - bbox.y * z
+    set({ zoom: z, pan: { x, y } })
+  },
+  worldToScreen(p) {
+    const { zoom, pan } = get()
+    return { x: p.x * zoom + pan.x, y: p.y * zoom + pan.y }
+  },
+  screenToWorld(p) {
+    const { zoom, pan } = get()
+    return { x: (p.x - pan.x) / zoom, y: (p.y - pan.y) / zoom }
+  },
+}))
+
+export { ZOOM_MIN, ZOOM_MAX }
+


### PR DESCRIPTION
## Summary
- add view store for pan/zoom with world<->screen helpers
- support cursor-centered zoom, space-drag panning, and transform layer on canvas
- introduce selection bounding box with group move support

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31e9003f0832c9ccf2f68ce4a27c3