### PR TITLE
feat(actions): runtime v1 (click/hover/mount with built-in executors)

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -15,6 +15,21 @@ import { useUnitStore } from '@/store/unitStore'
 import { intersects } from '@/lib/geom'
 import { useViewStore } from '@/store/viewStore'
 import { SelectionBBox } from './SelectionBBox'
+import {
+  runActionsForNode,
+  type ActionRuntimeContext,
+} from '@/lib/actions/runtime'
+
+function setByPath(obj: any, path: string, value: any) {
+  const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.')
+  let cur = obj
+  for (let i = 0; i < keys.length - 1; i++) {
+    const k = keys[i]
+    if (typeof cur[k] !== 'object' || cur[k] === null) cur[k] = {}
+    cur = cur[k]
+  }
+  cur[keys[keys.length - 1]] = value
+}
 
 function bgGridStyle(s: number) {
   return {
@@ -234,7 +249,19 @@ function ResizeHandles({ elm }: { elm: Elm }) {
   )
 }
 
-function ElmView({ elm, all, offset = { x: 0, y: 0 } }: { elm: Elm; all: Elm[]; offset?: { x: number; y: number } }) {
+function ElmView({
+  elm,
+  all,
+  offset = { x: 0, y: 0 },
+  ctx,
+  runtimeProps,
+}: {
+  elm: Elm
+  all: Elm[]
+  offset?: { x: number; y: number }
+  ctx: ActionRuntimeContext
+  runtimeProps: Record<string, any>
+}) {
   if (elm.visible === false) return null
   const select = useBuilderStore((s) => s.select)
   const addSelect = useBuilderStore((s) => s.addSelect)
@@ -247,6 +274,10 @@ function ElmView({ elm, all, offset = { x: 0, y: 0 } }: { elm: Elm; all: Elm[]; 
     data: { from: 'canvas', id: elm.id, anchorX: elm.w / 2, anchorY: elm.h / 2 },
     disabled: elm.locked,
   })
+  React.useEffect(() => {
+    runActionsForNode(elm.id, 'mount', ctx)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elm.id])
   const startBatch = useHistoryStore((s) => s.start)
   const commitBatch = useHistoryStore((s) => s.commit)
   const prevDragging = React.useRef(false)
@@ -261,13 +292,16 @@ function ElmView({ elm, all, offset = { x: 0, y: 0 } }: { elm: Elm; all: Elm[]; 
   const shadow = isSel ? 'shadow-[0_0_0_1px_rgba(251,191,36,0.6)]' : ''
 
   const preview = dragDraft && dragDraft.id === elm.id ? dragDraft.rect : null
+  const mergedProps = runtimeProps[elm.id]
+    ? { ...(elm.props || {}), ...runtimeProps[elm.id] }
+    : elm.props || {}
   const baseStyle: React.CSSProperties = {
     left: (preview ? preview.x : elm.x) - offset.x,
     top: (preview ? preview.y : elm.y) - offset.y,
     width: preview ? preview.w : elm.w,
     height: preview ? preview.h : elm.h,
-    background: elm.props?.bg,
-    color: elm.props?.color ?? '#e5e7eb',
+    background: mergedProps?.bg,
+    color: mergedProps?.color ?? '#e5e7eb',
     transform: preview
       ? `translate3d(${preview.x - elm.x}px, ${preview.y - elm.y}px, 0)`
       : undefined,
@@ -279,6 +313,8 @@ function ElmView({ elm, all, offset = { x: 0, y: 0 } }: { elm: Elm; all: Elm[]; 
       ref={setNodeRef}
       {...(!elm.locked ? listeners : {})}
       {...attributes}
+      onClick={() => runActionsForNode(elm.id, 'click', ctx)}
+      onMouseEnter={() => runActionsForNode(elm.id, 'hover', ctx)}
       onMouseDown={(e) => {
         if (e.shiftKey) addSelect(elm.id)
         else if (e.altKey || e.ctrlKey) toggleSelect(elm.id)
@@ -290,10 +326,10 @@ function ElmView({ elm, all, offset = { x: 0, y: 0 } }: { elm: Elm; all: Elm[]; 
       name={elm.props?.name}
       style={baseStyle}
       presetProps={{
-        presetIds: elm.props?.presetIds,
-        presetId: elm.props?.presetId,
-        hoverEffects: elm.props?.hoverEffects,
-        hoverTransitionMs: elm.props?.hoverTransitionMs,
+        presetIds: mergedProps?.presetIds,
+        presetId: mergedProps?.presetId,
+        hoverEffects: mergedProps?.hoverEffects,
+        hoverTransitionMs: mergedProps?.hoverTransitionMs,
       }}
     >
       {elm.type === 'header' && <HeaderView elm={elm} />}
@@ -302,14 +338,29 @@ function ElmView({ elm, all, offset = { x: 0, y: 0 } }: { elm: Elm; all: Elm[]; 
       {elm.type === 'hud' && <div className="h-full flex items-center justify-center px-3">HUD</div>}
       {elm.type === 'container' && <div className="h-full px-3 py-2">Container</div>}
       {elm.type === 'button' && (
-        <div className="h-full flex items-center justify-center font-medium">{elm.props?.text ?? 'Button'}</div>
+        <div className="h-full flex items-center justify-center font-medium">
+          {mergedProps?.text ?? 'Button'}
+        </div>
       )}
-      {elm.type === 'text' && <div className="h-full flex items-center px-2">{elm.props?.text ?? 'Text'}</div>}
-      {elm.type === 'code' && <CodePreview elm={elm} />}
+      {elm.type === 'text' && (
+        <div className="h-full flex items-center px-2">{mergedProps?.text ?? 'Text'}</div>
+      )}
+      {elm.type === 'code' && <CodePreview elm={{ ...elm, props: mergedProps }} />}
       {isSel && !elm.locked && <ResizeHandles elm={elm} />}
       {elm.children?.map((cid) => {
         const c = all.find((e) => e.id === cid)
-        return c ? <ElmView key={cid} elm={c} all={all} offset={{ x: elm.x, y: elm.y }} /> : null
+        return c
+          ? (
+              <ElmView
+                key={cid}
+                elm={c}
+                all={all}
+                offset={{ x: elm.x, y: elm.y }}
+                ctx={ctx}
+                runtimeProps={runtimeProps}
+              />
+            )
+          : null
       })}
     </NodeWrapper>
   )
@@ -340,6 +391,20 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
     screenToWorld: s.screenToWorld,
   }))
   const spacePressed = React.useRef(false)
+  const [runtimeProps, setRuntimeProps] = React.useState<Record<string, any>>({})
+  const ctx = React.useMemo<ActionRuntimeContext>(
+    () => ({
+      getNode: (id) =>
+        useBuilderStore.getState().elements.find((e) => e.id === id),
+      setProp: (id, path, value) =>
+        setRuntimeProps((prev) => {
+          const next = { ...(prev[id] || {}) }
+          setByPath(next, path, value)
+          return { ...prev, [id]: next }
+        }),
+    }),
+    [],
+  )
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.code === 'Space') spacePressed.current = true
@@ -495,7 +560,13 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
           {els
             .filter((e) => !e.parentId)
             .map((e) => (
-              <ElmView key={e.id} elm={e} all={els} />
+              <ElmView
+                key={e.id}
+                elm={e}
+                all={els}
+                ctx={ctx}
+                runtimeProps={runtimeProps}
+              />
             ))}
           <SelectionBBox />
         </div>

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -10,8 +10,33 @@ import { useBindingStore } from '@/store/bindingStore';
 import { PresenterHUD } from '@/components/preview/PresenterHUD';
 import { buildPoseMap, diffPoses, easeStandard } from '@/lib/animate/smart';
 import PresetStyle from '@/components/interaction/PresetStyle';
+import {
+  runActionsForNode,
+  type ActionRuntimeContext,
+} from '@/lib/actions/runtime';
 
-function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: PrototypeLink) => void }) {
+function setByPath(obj: any, path: string, value: any) {
+  const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.');
+  let cur = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const k = keys[i];
+    if (typeof cur[k] !== 'object' || cur[k] === null) cur[k] = {};
+    cur = cur[k];
+  }
+  cur[keys[keys.length - 1]] = value;
+}
+
+function NodeRenderer({
+  node,
+  onLink,
+  ctx,
+  runtimeProps,
+}: {
+  node: ComponentNode;
+  onLink: (l: PrototypeLink) => void;
+  ctx: ActionRuntimeContext;
+  runtimeProps: Record<string, any>;
+}) {
   const components = useEditorStore((s) => s.components);
   const sources = useBindingStore((s) => s.sources);
   const bindingsForNode = useBindingStore((s) =>
@@ -26,37 +51,53 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       resolved = resolveComponentBinding(resolved, def.props, inst.propValues || {});
     if (inst.overrides) resolved = applyOverrides(resolved, inst.overrides);
     resolved.props = { ...(resolved.props || {}), ...(inst.props || {}) };
-    return <NodeRenderer node={resolved} onLink={onLink} />;
+    return (
+      <NodeRenderer
+        node={resolved}
+        onLink={onLink}
+        ctx={ctx}
+        runtimeProps={runtimeProps}
+      />
+    );
   }
   const resolvedProps = resolveBinding(node.props || {}, bindingsForNode, sources);
-  const layout = resolvedProps.layout || 'free';
+  const merged = runtimeProps[node.id]
+    ? { ...resolvedProps, ...runtimeProps[node.id] }
+    : resolvedProps;
+  const layout = merged.layout || 'free';
   const style: any = {};
   if (layout === 'auto') {
     style.display = 'flex';
-    style.flexDirection = resolvedProps.axis === 'horizontal' ? 'row' : 'column';
-    if (resolvedProps.gap !== undefined) style.gap = resolvedProps.gap;
+    style.flexDirection = merged.axis === 'horizontal' ? 'row' : 'column';
+    if (merged.gap !== undefined) style.gap = merged.gap;
   } else {
     style.position = 'absolute';
-    style.left = resolvedProps.x || 0;
-    style.top = resolvedProps.y || 0;
+    style.left = merged.x || 0;
+    style.top = merged.y || 0;
   }
-  if (resolvedProps.w !== undefined) style.width = resolvedProps.w;
-  if (resolvedProps.h !== undefined) style.height = resolvedProps.h;
- 
+  if (merged.w !== undefined) style.width = merged.w;
+  if (merged.h !== undefined) style.height = merged.h;
+
   const link = node.prototypeLink;
   const handleClick = (e: any) => {
+    runActionsForNode(node.id, 'click', ctx);
     if (!link) return;
     e.stopPropagation();
     const trig = link.trigger?.type || 'click';
     if (trig === 'click') onLink(link);
   };
   const handleHover = (e: any) => {
+    runActionsForNode(node.id, 'hover', ctx);
     if (!link) return;
     if (link.trigger?.type === 'hover') {
       e.stopPropagation();
       onLink(link);
     }
   };
+  useEffect(() => {
+    runActionsForNode(node.id, 'mount', ctx);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node.id]);
   useEffect(() => {
     if (!link || link.trigger?.type !== 'delay') return;
     const id = setTimeout(() => onLink(link), link.trigger.ms ?? 300);
@@ -68,7 +109,7 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         style={style}
         data-node-id={node.id}
         data-node-type={node.type}
-        data-node-name={resolvedProps?.name}
+        data-node-name={merged?.name}
         onClick={handleClick}
         onMouseEnter={handleHover}
         className={link ? 'cursor-pointer' : undefined}
@@ -76,10 +117,10 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         <div className="w-full h-full bg-gray-300" />
         <PresetStyle
           nodeId={node.id}
-          presetIds={resolvedProps?.presetIds}
-          presetId={resolvedProps?.presetId}
-          hoverEffects={resolvedProps?.hoverEffects}
-          hoverTransitionMs={resolvedProps?.hoverTransitionMs}
+          presetIds={merged?.presetIds}
+          presetId={merged?.presetId}
+          hoverEffects={merged?.hoverEffects}
+          hoverTransitionMs={merged?.hoverTransitionMs}
         />
       </div>
     );
@@ -90,18 +131,18 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
         style={style}
         data-node-id={node.id}
         data-node-type={node.type}
-        data-node-name={resolvedProps?.name}
+        data-node-name={merged?.name}
         onClick={handleClick}
         onMouseEnter={handleHover}
         className={link ? 'cursor-pointer' : undefined}
       >
-        {resolvedProps?.text}
+        {merged?.text}
         <PresetStyle
           nodeId={node.id}
-          presetIds={resolvedProps?.presetIds}
-          presetId={resolvedProps?.presetId}
-          hoverEffects={resolvedProps?.hoverEffects}
-          hoverTransitionMs={resolvedProps?.hoverTransitionMs}
+          presetIds={merged?.presetIds}
+          presetId={merged?.presetId}
+          hoverEffects={merged?.hoverEffects}
+          hoverTransitionMs={merged?.hoverTransitionMs}
         />
       </div>
     );
@@ -111,20 +152,26 @@ function NodeRenderer({ node, onLink }: { node: ComponentNode; onLink: (l: Proto
       style={style}
       data-node-id={node.id}
       data-node-type={node.type}
-      data-node-name={resolvedProps?.name}
+      data-node-name={merged?.name}
       onClick={handleClick}
       onMouseEnter={handleHover}
       className={link ? 'cursor-pointer' : undefined}
     >
       {node.children?.map((c) => (
-        <NodeRenderer key={c.id} node={c} onLink={onLink} />
+        <NodeRenderer
+          key={c.id}
+          node={c}
+          onLink={onLink}
+          ctx={ctx}
+          runtimeProps={runtimeProps}
+        />
       ))}
       <PresetStyle
         nodeId={node.id}
-        presetIds={resolvedProps?.presetIds}
-        presetId={resolvedProps?.presetId}
-        hoverEffects={resolvedProps?.hoverEffects}
-        hoverTransitionMs={resolvedProps?.hoverTransitionMs}
+        presetIds={merged?.presetIds}
+        presetId={merged?.presetId}
+        hoverEffects={merged?.hoverEffects}
+        hoverTransitionMs={merged?.hoverTransitionMs}
       />
     </div>
   );
@@ -229,6 +276,29 @@ export default function Player() {
     setTr({ fromId, toId, kind, t0: performance.now(), dur: 200 });
   }
 
+  const [runtimeProps, setRuntimeProps] = useState<Record<string, any>>({});
+  const navigateTo = (frameId: string) => {
+    if (!frameId) return;
+    setHistory((h) => {
+      const fromId = h[h.length - 1];
+      startTransition(fromId, frameId, 'dissolve');
+      return [...h, frameId];
+    });
+  };
+  const ctx = useMemo<ActionRuntimeContext>(
+    () => ({
+      getNode: (id) => findNode(tree, id) as ComponentNode | undefined,
+      setProp: (id, path, value) =>
+        setRuntimeProps((prev) => {
+          const next = { ...(prev[id] || {}) };
+          setByPath(next, path, value);
+          return { ...prev, [id]: next };
+        }),
+      navigate: navigateTo,
+    }),
+    [tree],
+  );
+
   const progress = useTransitionProgress(tr);
 
   useEffect(() => {
@@ -259,11 +329,21 @@ export default function Player() {
       />
       {tr && tr.kind === 'dissolve' && (
         <div className="absolute inset-0 pointer-events-none" style={{ opacity: 1 - progress }}>
-          <NodeRenderer node={findNode(tree, tr.fromId)!} onLink={handleLink} />
+          <NodeRenderer
+            node={findNode(tree, tr.fromId)!}
+            onLink={handleLink}
+            ctx={ctx}
+            runtimeProps={runtimeProps}
+          />
         </div>
       )}
       <div className="absolute inset-0" style={{ opacity: tr?.kind === 'dissolve' ? progress : 1 }}>
-        <NodeRenderer node={current} onLink={handleLink} />
+        <NodeRenderer
+          node={current}
+          onLink={handleLink}
+          ctx={ctx}
+          runtimeProps={runtimeProps}
+        />
       </div>
       {overlay && (
         <div
@@ -271,7 +351,12 @@ export default function Player() {
           onClick={() => setOverlay(null)}
         >
           <div onClick={(e) => e.stopPropagation()}>
-            <NodeRenderer node={findNode(tree, overlay)!} onLink={handleLink} />
+            <NodeRenderer
+              node={findNode(tree, overlay)!}
+              onLink={handleLink}
+              ctx={ctx}
+              runtimeProps={runtimeProps}
+            />
           </div>
         </div>
       )}

--- a/web/components/props/ActionsEditor.tsx
+++ b/web/components/props/ActionsEditor.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import * as React from 'react'
+import { useEditorStore } from '@/store/editorStore'
+
+type NodeAction = {
+  trigger: 'click' | 'hover' | 'mount'
+  type: 'openUrl' | 'emitEvent' | 'setProp' | 'navigate'
+  payload?: any
+}
+
+export default function ActionsEditor({ nodeId }: { nodeId: string }) {
+  const updateNode = useEditorStore((s) => s.updateNode)
+  const node = useEditorStore((s) => s.tree.find((n) => n.id === nodeId)) as any
+  const actions: NodeAction[] = (node?.props?.actions as NodeAction[]) || []
+
+  const setActions = (next: NodeAction[]) => {
+    updateNode(nodeId, { props: { ...(node?.props || {}), actions: next } })
+  }
+
+  const addAction = () => {
+    setActions([
+      ...actions,
+      { trigger: 'click', type: 'openUrl', payload: {} },
+    ])
+  }
+
+  const updateAction = (idx: number, next: NodeAction) => {
+    const arr = [...actions]
+    arr[idx] = next
+    setActions(arr)
+  }
+
+  const removeAction = (idx: number) => {
+    const arr = [...actions]
+    arr.splice(idx, 1)
+    setActions(arr)
+  }
+
+  return (
+    <div className="space-y-2">
+      {actions.map((a, i) => (
+        <div
+          key={i}
+          className="flex flex-col gap-1 border border-neutral-700 rounded p-2"
+        >
+          <div className="flex gap-2 items-center">
+            <select
+              value={a.trigger}
+              onChange={(e) =>
+                updateAction(i, { ...a, trigger: e.target.value as any })
+              }
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
+            >
+              <option value="click">click</option>
+              <option value="hover">hover</option>
+              <option value="mount">mount</option>
+            </select>
+            <select
+              value={a.type}
+              onChange={(e) => updateAction(i, { ...a, type: e.target.value as any })}
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
+            >
+              <option value="openUrl">openUrl</option>
+              <option value="navigate">navigate</option>
+              <option value="emitEvent">emitEvent</option>
+              <option value="setProp">setProp</option>
+            </select>
+            <button
+              type="button"
+              className="ml-auto px-2 py-1 bg-neutral-800 rounded text-xs"
+              onClick={() => removeAction(i)}
+            >
+              Del
+            </button>
+          </div>
+          <textarea
+            className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs font-mono"
+            value={JSON.stringify(a.payload ?? {}, null, 2)}
+            onChange={(e) => {
+              try {
+                updateAction(i, {
+                  ...a,
+                  payload: JSON.parse(e.target.value || '{}'),
+                })
+              } catch {
+                /* ignore */
+              }
+            }}
+            rows={3}
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        className="px-2 py-1 bg-neutral-800 rounded text-xs"
+        onClick={addAction}
+      >
+        Add action
+      </button>
+    </div>
+  )
+}
+

--- a/web/lib/actions/runtime.ts
+++ b/web/lib/actions/runtime.ts
@@ -1,0 +1,69 @@
+import type { ComponentNode } from '@/types/editor'
+
+export type NodeAction = {
+  trigger: 'click' | 'hover' | 'mount'
+  type: 'openUrl' | 'emitEvent' | 'setProp' | 'navigate'
+  payload?: any
+}
+
+export interface ActionRuntimeContext {
+  getNode: (id: string) => ComponentNode | undefined
+  setProp?: (id: string, path: string, value: any) => void
+  navigate?: (frameId: string) => void
+}
+
+type Executor = (
+  payload: any,
+  nodeId: string,
+  ctx: ActionRuntimeContext,
+) => void
+
+const executors: Record<string, Executor> = {
+  openUrl: (payload) => {
+    const url = payload?.url
+    if (typeof url !== 'string') return
+    try {
+      const u = new URL(url, window.location.href)
+      if (u.protocol === 'http:' || u.protocol === 'https:')
+        window.open(u.toString(), payload?.target || '_blank')
+    } catch {
+      /* ignore */
+    }
+  },
+  navigate: (payload, _id, ctx) => {
+    const frameId = payload?.frameId || payload?.id || payload?.target
+    if (typeof frameId === 'string') ctx.navigate?.(frameId)
+  },
+  emitEvent: (payload) => {
+    const name = payload?.name
+    if (!name) return
+    window.dispatchEvent(
+      new CustomEvent(name, { detail: payload?.detail }) as Event,
+    )
+  },
+  setProp: (payload, id, ctx) => {
+    if (!ctx.setProp) return
+    const path = payload?.path
+    if (typeof path !== 'string') return
+    ctx.setProp(id, path, payload?.value)
+  },
+}
+
+export function runActionsForNode(
+  nodeId: string,
+  trigger: 'click' | 'hover' | 'mount',
+  ctx: ActionRuntimeContext,
+) {
+  const node = ctx.getNode(nodeId)
+  const actions = (node?.props as any)?.actions as NodeAction[] | undefined
+  if (!actions?.length) return
+  actions.forEach((a) => {
+    if (a.trigger !== trigger) return
+    const { trigger: _t, type, payload, ...rest } = a as any
+    const pl = payload ?? rest
+    const exec = executors[type]
+    if (exec) exec(pl, nodeId, ctx)
+  })
+}
+
+export { executors }


### PR DESCRIPTION
## Summary
- implement generic action runtime with openUrl, emitEvent, setProp and navigate executors
- wire runtime into Player and Builder Canvas for click/hover/mount triggers with local prop overrides
- add simple ActionsEditor to manage node action definitions

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32097e610832ca96137cc5a12c27d