### PR TITLE
feat(props): schema-driven property panel (auto form) with registry metas

### DIFF
--- a/web/components/blocks/Button.tsx
+++ b/web/components/blocks/Button.tsx
@@ -1,17 +1,34 @@
-import type { BuilderNodeMeta } from '@/types/builder'
+'use client'
+import * as React from 'react'
 
-export function Button({ text, className, onClick }: { text: string; className?: string; onClick?: () => void }) {
-  return (
-    <button className={className} onClick={onClick}>
-      {text}
-    </button>
-  )
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  text?: string
+  variant?: 'solid' | 'ghost'
+  color?: string
+  href?: string
 }
 
-export const ButtonMeta: BuilderNodeMeta = {
-  displayName: 'Button',
-  defaultSize: { w: 120, h: 40 },
-  resizable: false,
-  snap: 'grid',
-  events: ['click'],
+export default function Button({
+  text = 'Button',
+  variant = 'solid',
+  color = '#2563eb',
+  href,
+  children,
+  style,
+  ...props
+}: ButtonProps) {
+  const styles =
+    variant === 'ghost'
+      ? { background: 'transparent', border: `1px solid ${color}`, color }
+      : { background: color, color: '#fff', border: 'none' }
+  const Tag: any = href ? 'a' : 'button'
+  return (
+    <Tag
+      {...props}
+      href={href}
+      style={{ ...(style || {}), ...styles }}
+    >
+      {children ?? text}
+    </Tag>
+  )
 }

--- a/web/components/blocks/Container.tsx
+++ b/web/components/blocks/Container.tsx
@@ -1,14 +1,18 @@
-import { PropsWithChildren } from 'react'
-import type { BuilderNodeMeta } from '@/types/builder'
+'use client'
+import * as React from 'react'
 
-export function Container({ className, children }: PropsWithChildren<{ className?: string }>) {
-  return <div className={className}>{children}</div>
-}
-
-export const ContainerMeta: BuilderNodeMeta = {
-  displayName: 'Container',
-  defaultSize: { w: 320, h: 200 },
-  resizable: true,
-  snap: 'grid',
-  allowChildren: true,
+export default function Container({ children, style, bg, radius = 8, border = true, ...props }: any) {
+  return (
+    <div
+      {...props}
+      style={{
+        ...(style || {}),
+        background: bg,
+        borderRadius: radius,
+        border: border ? '1px solid #374151' : 'none',
+      }}
+    >
+      {children}
+    </div>
+  )
 }

--- a/web/components/blocks/Text.tsx
+++ b/web/components/blocks/Text.tsx
@@ -1,12 +1,16 @@
-import type { BuilderNodeMeta } from '@/types/builder'
+'use client'
+import * as React from 'react'
 
-export function Text({ text, className }: { text?: string; className?: string }) {
-  return <div className={className}>{text}</div>
+interface TextProps extends React.HTMLAttributes<HTMLElement> {
+  text?: string
+  color?: string
+  size?: number
 }
 
-export const TextMeta: BuilderNodeMeta = {
-  displayName: 'Text',
-  defaultSize: { w: 200, h: 24 },
-  resizable: false,
-  snap: 'grid',
+export default function Text({ text, children, color, size = 14, style, ...props }: TextProps) {
+  return (
+    <span {...props} style={{ ...(style || {}), color, fontSize: size }}>
+      {children ?? text}
+    </span>
+  )
 }

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEditorStore } from '@/store/editorStore';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import ActionPresetField from '@/components/props/ActionPresetField';
 import { useUnitStore } from '@/store/unitStore';
 import { worldToUnit, unitToWorld } from '@/lib/units';
@@ -29,6 +29,36 @@ export default function RightInspector() {
     rotation: node?.props?.rotation || 0,
   });
 
+  const meta = node ? (registry as any)[(node as any).type]?.meta : null;
+  const [formProps, setFormProps] = useState(() => {
+    if (meta?.propertySchema?.kind === 'object') {
+      const keys = Object.keys(meta.propertySchema.properties);
+      const out: any = {};
+      for (const k of keys) out[k] = (node?.props || {})[k];
+      return out;
+    }
+    return {};
+  });
+  useEffect(() => {
+    if (meta?.propertySchema?.kind === 'object') {
+      const keys = Object.keys(meta.propertySchema.properties);
+      const out: any = {};
+      for (const k of keys) out[k] = (node?.props || {})[k];
+      setFormProps(out);
+    } else {
+      setFormProps({});
+    }
+  }, [node?.id, meta?.propertySchema]);
+
+  const debounced = useRef<number | undefined>(undefined);
+  const apply = (next: any) => {
+    setFormProps(next);
+    window.clearTimeout(debounced.current);
+    debounced.current = window.setTimeout(() => {
+      update(selected, { props: { ...(node?.props || {}), ...next } });
+    }, 150);
+  };
+
   if (!selected) return <div className="bg-gray-800" />;
 
   const handleChange = (key: keyof typeof form, value: number) => {
@@ -46,10 +76,8 @@ export default function RightInspector() {
   const comp = node && (node as any).type === 'Instance'
     ? components[(node as any).componentId]
     : null;
-  const entry = node ? (registry as any)[(node as any).type] : null;
-  const propSchema = entry?.meta?.propertySchema;
 
-  const unitLabel = unit === 'percent' ? '%' : unit
+  const unitLabel = unit === 'percent' ? '%' : unit;
 
   return (
     <div className="bg-gray-800 p-2 space-y-2 overflow-y-auto">
@@ -71,6 +99,16 @@ export default function RightInspector() {
           </label>
         )
       })}
+      {meta?.propertySchema && (
+        <div className="mt-3">
+          <div className="mb-1 text-xs text-neutral-300">Properties</div>
+          <AutoPropsForm
+            value={formProps}
+            schema={meta.propertySchema}
+            onChange={apply}
+          />
+        </div>
+      )}
       {comp && comp.axes && (
         <div className="mt-2 space-y-1">
           <h3 className="text-xs font-bold">Variants</h3>
@@ -203,16 +241,6 @@ export default function RightInspector() {
           </label>
         </div>
       </div>
-      {propSchema && (
-        <AutoPropsForm
-          nodeId={node.id}
-          schema={propSchema}
-          value={node.props}
-          onChange={(patch) =>
-            update(node.id, { props: { ...(node?.props || {}), ...patch } })
-          }
-        />
-      )}
       {node && (
         <ActionPresetField
           nodeId={node.id}

--- a/web/components/props/AutoPropsForm.tsx
+++ b/web/components/props/AutoPropsForm.tsx
@@ -1,153 +1,149 @@
 'use client'
-import React from 'react'
+import * as React from 'react'
+import type { UISchema, UIPrimitive } from '@/types/schema'
 
-export type FieldSchema = {
-  type: 'string' | 'number' | 'boolean' | 'enum' | 'color'
-  options?: any[]
-}
-
-export type NormalizedSchema = Record<string, FieldSchema>
-
-function parseSchema(schema: any): NormalizedSchema {
-  // zod
-  if (schema && schema._def && (schema._def.shape || schema._def.shapeFn)) {
-    const shape = typeof schema._def.shape === 'function' ? schema._def.shape() : schema._def.shape || schema._def.shapeFn?.()
-    const out: NormalizedSchema = {}
-    for (const key in shape) {
-      const f = shape[key]
-      const tn = f?._def?.typeName
-      if (tn === 'ZodString') out[key] = { type: 'string' }
-      else if (tn === 'ZodNumber') out[key] = { type: 'number' }
-      else if (tn === 'ZodBoolean') out[key] = { type: 'boolean' }
-      else if (tn === 'ZodEnum') out[key] = { type: 'enum', options: f?._def?.values }
-      else out[key] = { type: 'string' }
-    }
-    return out
-  }
-  // JSON schema
-  if (schema && schema.properties) {
-    const out: NormalizedSchema = {}
-    for (const key in schema.properties) {
-      const p: any = schema.properties[key]
-      if (p.type === 'string') {
-        if (p.enum) out[key] = { type: 'enum', options: p.enum }
-        else if (p.format === 'color') out[key] = { type: 'color' }
-        else out[key] = { type: 'string' }
-      } else if (p.type === 'number' || p.type === 'integer') {
-        out[key] = { type: 'number' }
-      } else if (p.type === 'boolean') {
-        out[key] = { type: 'boolean' }
-      }
-    }
-    return out
-  }
-  return {}
-}
-
-export interface AutoPropsFormProps {
-  nodeId: string
-  schema: any
+type Props = {
   value: any
+  schema: UISchema
   onChange: (patch: any) => void
 }
 
-export default function AutoPropsForm({ nodeId, schema, value, onChange }: AutoPropsFormProps) {
-  const fields = React.useMemo(() => parseSchema(schema), [schema])
-  const [form, setForm] = React.useState(() => ({ ...(value || {}) }))
+/** Merge helper (deep merge for plain objects) */
+function merge(a: any, b: any) {
+  if (Array.isArray(a) || Array.isArray(b) || typeof a !== 'object' || typeof b !== 'object' || !a || !b) return b
+  const out: any = { ...a }
+  for (const k of Object.keys(b)) out[k] = merge(a[k], b[k])
+  return out
+}
 
-  React.useEffect(() => {
-    setForm({ ...(value || {}) })
-  }, [value])
-
-  const debounced = React.useRef<any>()
-  const emitChange = React.useCallback((patch: any) => {
-    if (debounced.current) clearTimeout(debounced.current)
-    debounced.current = setTimeout(() => {
-      onChange(patch)
-    }, 150)
-  }, [onChange])
-
-  const handleField = (key: string, v: any) => {
-    const next = { ...form, [key]: v }
-    setForm(next)
-    emitChange({ [key]: v })
-  }
-
-  return (
-    <div className="space-y-2">
-      {Object.entries(fields).map(([key, fs]) => {
-        const val = form?.[key]
-        if (fs.type === 'boolean') {
-          return (
-            <label key={key} className="flex items-center gap-2 text-xs">
-              <input
-                type="checkbox"
-                checked={Boolean(val)}
-                onChange={(e) => handleField(key, e.target.checked)}
-              />
-              {key}
-            </label>
-          )
-        }
-        if (fs.type === 'number') {
-          return (
-            <label key={key} className="block text-xs">
-              {key}
-              <input
-                type="number"
-                className="w-full bg-gray-700 ml-1 p-1 text-white"
-                value={val ?? ''}
-                onChange={(e) => handleField(key, Number(e.target.value))}
-              />
-            </label>
-          )
-        }
-        if (fs.type === 'enum') {
-          return (
-            <label key={key} className="block text-xs">
-              {key}
-              <select
-                className="w-full bg-gray-700 ml-1 p-1 text-white"
-                value={val ?? ''}
-                onChange={(e) => handleField(key, e.target.value)}
-              >
-                <option value="" />
-                {fs.options?.map((o) => (
-                  <option key={String(o)} value={String(o)}>
-                    {String(o)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )
-        }
-        if (fs.type === 'color') {
-          return (
-            <label key={key} className="block text-xs">
-              {key}
-              <input
-                type="color"
-                className="w-full bg-gray-700 ml-1 p-1 text-white"
-                value={val ?? '#000000'}
-                onChange={(e) => handleField(key, e.target.value)}
-              />
-            </label>
-          )
-        }
-        // string fallback
+export default function AutoPropsForm({ value, schema, onChange }: Props) {
+  const renderField = (key: string, prim: UIPrimitive, current: any) => {
+    const title = prim.title ?? key
+    if (prim.kind === 'string') {
+      if (prim.format === 'color') {
         return (
-          <label key={key} className="block text-xs">
-            {key}
+          <label key={key} className="block text-xs mb-1">
+            {title}
             <input
-              type="text"
-              className="w-full bg-gray-700 ml-1 p-1 text-white"
-              value={val ?? ''}
-              onChange={(e) => handleField(key, e.target.value)}
+              type="color"
+              className="w-full bg-gray-700 ml-1 p-1"
+              value={current ?? prim.default ?? '#000000'}
+              onChange={(e) => onChange(merge(value, { [key]: e.target.value }))}
             />
           </label>
         )
-      })}
-    </div>
-  )
-}
+      }
+      return (
+        <label key={key} className="block text-xs mb-1">
+          {title}
+          {prim.multiline ? (
+            <textarea
+              className="w-full bg-gray-700 ml-1 p-1"
+              placeholder={prim.placeholder}
+              value={current ?? prim.default ?? ''}
+              onChange={(e) => onChange(merge(value, { [key]: e.target.value }))}
+            />
+          ) : (
+            <input
+              type={prim.format === 'url' ? 'url' : 'text'}
+              className="w-full bg-gray-700 ml-1 p-1"
+              placeholder={prim.placeholder}
+              value={current ?? prim.default ?? ''}
+              onChange={(e) => onChange(merge(value, { [key]: e.target.value }))}
+            />
+          )}
+        </label>
+      )
+    }
+    if (prim.kind === 'number') {
+      return (
+        <label key={key} className="block text-xs mb-1">
+          {title}
+          <input
+            type="number"
+            className="w-full bg-gray-700 ml-1 p-1"
+            value={current ?? prim.default ?? 0}
+            min={prim.min}
+            max={prim.max}
+            step={prim.step ?? 1}
+            onChange={(e) => onChange(merge(value, { [key]: Number(e.target.value) }))}
+          />
+        </label>
+      )
+    }
+    if (prim.kind === 'boolean') {
+      return (
+        <label key={key} className="flex items-center text-xs mb-1 gap-2">
+          <input
+            type="checkbox"
+            checked={!!(current ?? prim.default ?? false)}
+            onChange={(e) => onChange(merge(value, { [key]: e.target.checked }))}
+          />
+          {title}
+        </label>
+      )
+    }
+    if (prim.kind === 'enum') {
+      return (
+        <label key={key} className="block text-xs mb-1">
+          {title}
+          <select
+            className="w-full bg-gray-700 ml-1 p-1"
+            value={current ?? prim.default ?? prim.options[0]?.value ?? ''}
+            onChange={(e) => onChange(merge(value, { [key]: e.target.value }))}
+          >
+            {prim.options.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </label>
+      )
+    }
+    if (prim.kind === 'object') {
+      const obj = current ?? {}
+      return (
+        <fieldset key={key} className="border border-gray-700 rounded p-2 mb-2">
+          <legend className="text-[11px] opacity-80">{title}</legend>
+          {Object.entries(prim.properties).map(([subKey, subSchema]) =>
+            renderField(`${key}.${subKey}`, subSchema as UIPrimitive, obj[subKey])
+          )}
+        </fieldset>
+      )
+    }
+    return null
+  }
 
+  // flatten path 'a.b' => nested patch
+  const setByPath = React.useCallback((path: string, v: any) => {
+    const segs = path.split('.')
+    let patch: any = {}
+    let cur = patch
+    segs.forEach((s, i) => {
+      if (i === segs.length - 1) cur[s] = v
+      else { cur[s] = {}; cur = cur[s] }
+    })
+    onChange(merge(value, patch))
+  }, [onChange, value])
+
+  // small wrapper to adapt renderField to nested set
+  const onChangeWrapper = (path: string) => (patch: any) => {
+    // patch has only leaf updated; compute delta value at path
+    const leaf = path.includes('.') ? path.split('.').pop()! : path
+    const val = (patch as any)[leaf]
+    setByPath(path, val)
+  }
+
+  // Note: for simplicity we call renderField with top-level keys; nested object keys are handled via path.
+  if (schema.kind === 'object') {
+    const obj = value ?? {}
+    return (
+      <div className="space-y-1">
+        {Object.entries(schema.properties).map(([key, s]) =>
+          renderField(key, s as UIPrimitive, obj[key])
+        )}
+      </div>
+    )
+  }
+  // Fallback (single primitive)
+  return <div>{renderField('value', schema as UIPrimitive, value)}</div>
+}

--- a/web/lib/registry.tsx
+++ b/web/lib/registry.tsx
@@ -1,15 +1,71 @@
-import { Button, ButtonMeta } from '@/components/blocks/Button'
-import { Container, ContainerMeta } from '@/components/blocks/Container'
-import { Text, TextMeta } from '@/components/blocks/Text'
+import type { BuilderNodeMeta } from '@/types/builder'
+import Button from '@/components/blocks/Button'
+import Container from '@/components/blocks/Container'
+import Text from '@/components/blocks/Text'
 import { Header, HeaderMeta } from '@/components/blocks/Header'
 import { Footer, FooterMeta } from '@/components/blocks/Footer'
 import { Sidebar, SidebarMeta } from '@/components/blocks/Sidebar'
 import { Hud, HudMeta } from '@/components/blocks/Hud'
 
+const ButtonMeta: BuilderNodeMeta = {
+  displayName: 'Button',
+  defaultSize: { w: 120, h: 40 },
+  resizable: false,
+  snap: 'grid',
+  events: ['click'],
+  propertySchema: {
+    kind: 'object',
+    title: 'Button',
+    properties: {
+      text:   { kind: 'string', title: 'Text', default: 'Button' },
+      variant:{ kind: 'enum',   title: 'Variant', options: [
+        { label:'Solid', value:'solid' },
+        { label:'Ghost', value:'ghost' },
+      ], default: 'solid' },
+      href:   { kind: 'string', title: 'URL', format:'url', placeholder:'https://...' },
+      color:  { kind: 'string', title: 'Color', format:'color', default:'#2563eb' },
+      disabled:{ kind: 'boolean', title: 'Disabled', default:false },
+    }
+  }
+}
+
+const TextMeta: BuilderNodeMeta = {
+  displayName: 'Text',
+  defaultSize: { w: 160, h: 24 },
+  resizable: true,
+  snap: 'grid',
+  propertySchema: {
+    kind: 'object',
+    title: 'Text',
+    properties: {
+      text: { kind: 'string', title:'Content', default:'Text', multiline:false },
+      color:{ kind: 'string', title:'Color', format:'color', default:'#e5e7eb' },
+      size: { kind: 'number', title:'Font Size', default:14, min:8, max:64, step:1 }
+    }
+  }
+}
+
+const ContainerMeta: BuilderNodeMeta = {
+  displayName: 'Container',
+  defaultSize: { w: 300, h: 200 },
+  resizable: true,
+  snap: 'grid',
+  allowChildren: true,
+  propertySchema: {
+    kind:'object',
+    title:'Container',
+    properties:{
+      bg:    { kind:'string', title:'Background', format:'color', default:'#111827' },
+      radius:{ kind:'number', title:'Radius', default:8, min:0, max:48, step:1 },
+      border:{ kind:'boolean', title:'Border', default:true },
+    }
+  }
+}
+
 export const registry = {
-  button: { Comp: Button, meta: ButtonMeta },
-  container: { Comp: Container, meta: ContainerMeta },
-  text: { Comp: Text, meta: TextMeta },
+  button:   { Comp: Button,   meta: ButtonMeta },
+  container:{ Comp: Container,meta: ContainerMeta },
+  text:     { Comp: Text,     meta: TextMeta },
   header: { Comp: Header, meta: HeaderMeta },
   footer: { Comp: Footer, meta: FooterMeta },
   sidebar: { Comp: Sidebar, meta: SidebarMeta },

--- a/web/types/builder.ts
+++ b/web/types/builder.ts
@@ -1,7 +1,3 @@
-import type { ZodTypeAny } from 'zod'
-
-export type JSONSchema = { [key: string]: any }
-
 export type BuilderNodeMeta = {
   displayName: string
   icon?: string
@@ -10,6 +6,6 @@ export type BuilderNodeMeta = {
   snap?: 'grid' | 'guides' | 'none'
   allowChildren?: boolean
   slots?: string[]
-  propertySchema?: ZodTypeAny | JSONSchema
+  propertySchema?: import('./schema').UISchema
   events?: string[]
 }

--- a/web/types/schema.ts
+++ b/web/types/schema.ts
@@ -1,0 +1,8 @@
+export type UIPrimitive =
+  | { kind: 'string'; title?: string; default?: string; multiline?: boolean; placeholder?: string; format?: 'color'|'text'|'url' }
+  | { kind: 'number'; title?: string; default?: number; min?: number; max?: number; step?: number }
+  | { kind: 'boolean'; title?: string; default?: boolean }
+  | { kind: 'enum'; title?: string; options: { label: string; value: string }[]; default?: string }
+  | { kind: 'object'; title?: string; properties: Record<string, UIPrimitive> }
+
+export type UISchema = UIPrimitive


### PR DESCRIPTION
## Summary
- add UISchema type and extend BuilderNodeMeta with propertySchema
- render schema-defined inputs via new `AutoPropsForm`
- hook property panel into RightInspector with debounce merge
- supply example property schemas for Button, Text, and Container
- apply color/size/variant props in block components

## Testing
- `pnpm run build` *(fails: Expected ';', got ')' in builderStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b323ae6414832cad06a77910ccb870