### PR TITLE
feat(layers): outline panel with visibility/lock/rename

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -182,10 +182,7 @@ export default function BuilderPage() {
           <h2 className="text-sm font-semibold mb-2">パレット</h2>
           <Palette />
         </aside>
-        <aside className="w-56 border-r border-zinc-800 bg-zinc-950/40 p-3">
-          <h2 className="text-sm font-semibold mb-2">Layers</h2>
-          <LayersPanel />
-        </aside>
+        <LayersPanel />
         <main className="flex-1 relative">
           <DeviceFrame>
             <div className="relative w-full h-full">

--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -32,7 +32,7 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
       ref={ref}
       data-node-id={node.id}
       data-node-type={node.type}
-      data-node-name={node.props?.name}
+      data-node-name={node.name || node.props?.name}
       style={{ position: 'absolute', ...style }}
       onMouseDown={(e) => {
         e.stopPropagation()

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -332,7 +332,7 @@ function ElmView({
       className={`${common} ${border} ${shadow} ${elm.locked ? 'cursor-default' : 'cursor-move'} ${isDragging ? 'opacity-60' : ''}`}
       id={elm.id}
       type={elm.type}
-      name={elm.props?.name}
+      name={elm.name}
       style={baseStyle}
       presetProps={{
         presetIds: mergedProps?.presetIds,
@@ -358,18 +358,16 @@ function ElmView({
       {isSel && !elm.locked && <ResizeHandles elm={elm} />}
       {elm.children?.map((cid) => {
         const c = all.find((e) => e.id === cid)
-        return c
-          ? (
-              <ElmView
-                key={cid}
-                elm={c}
-                all={all}
-                offset={{ x: elm.x, y: elm.y }}
-                ctx={ctx}
-                runtimeProps={runtimeProps}
-              />
-            )
-          : null
+        return c ? (
+          <ElmView
+            key={cid}
+            elm={c}
+            all={all}
+            offset={{ x: elm.x, y: elm.y }}
+            ctx={ctx}
+            runtimeProps={runtimeProps}
+          />
+        ) : null
       })}
     </NodeWrapper>
   )

--- a/web/components/builder/LayersPanel.tsx
+++ b/web/components/builder/LayersPanel.tsx
@@ -1,116 +1,205 @@
 'use client'
-import React from 'react'
-import {
-  DndContext,
-  DragEndEvent,
-} from '@dnd-kit/core'
+import * as React from 'react'
+import { useBuilderStore } from '@/store/builderStore'
+import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import {
   SortableContext,
   useSortable,
-  verticalListSortingStrategy,
   arrayMove,
+  verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useBuilderStore } from '@/store/builderStore'
 
-function LayerItem({ id }: { id: string }) {
+function Row({ id, depth = 0 }: { id: string; depth?: number }) {
   const el = useBuilderStore((s) => s.elements.find((e) => e.id === id))
-  const selected = useBuilderStore((s) => s.selectedIds.includes(id))
   const select = useBuilderStore((s) => s.select)
   const setVisible = useBuilderStore((s) => s.setVisible)
   const setLocked = useBuilderStore((s) => s.setLocked)
-  const updateProps = useBuilderStore((s) => s.updateProps)
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
+  const rename = useBuilderStore((s) => s.rename)
+  const selectedIds = useBuilderStore((s) => s.selectedIds)
+  const childIds = useBuilderStore(
+    (s) => s.elements.filter((e) => e.parentId === id).map((e) => e.id),
+  )
+  const isSelected = selectedIds.includes(id)
+  const [editing, setEditing] = React.useState(false)
+  const [expanded, setExpanded] = React.useState(true)
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id, data: { parentId: el?.parentId ?? null } })
+
   if (!el) return null
+  const isGroup = el.type === 'group'
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
   }
-  const [name, setName] = React.useState(el.props?.name || '')
-  React.useEffect(() => {
-    setName(el.props?.name || '')
-  }, [el.props?.name])
-  const commitName = () => updateProps(el.id, { name })
+
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-      onClick={() => select(id)}
-      className={`flex items-center gap-1 px-1 text-xs border-b border-zinc-800 ${selected ? 'bg-zinc-800' : ''}`}
-    >
-      <button onClick={() => setVisible(el.id, el.visible === false)} className="w-4 text-zinc-400">
-        {el.visible === false ? '🙈' : '👁'}
-      </button>
-      <button onClick={() => setLocked(el.id, !(el.locked))} className="w-4 text-zinc-400">
-        {el.locked ? '🔒' : '🔓'}
-      </button>
-      <input
-        className="flex-1 bg-transparent outline-none"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        onBlur={commitName}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            commitName()
-            ;(e.target as HTMLInputElement).blur()
-          }
-        }}
-      />
+    <div>
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={`flex items-center gap-2 h-7 px-2 text-sm ${
+          isSelected ? 'bg-zinc-700' : 'hover:bg-zinc-800'
+        }`}
+        onClick={() => select(id)}
+      >
+        <span
+          {...attributes}
+          {...listeners}
+          className="cursor-grab opacity-70"
+          style={{ marginLeft: depth * 8 }}
+        >
+          ≡
+        </span>
+        {isGroup && childIds.length > 0 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              setExpanded((v) => !v)
+            }}
+            className="w-4"
+          >
+            {expanded ? '▾' : '▸'}
+          </button>
+        )}
+        {!isGroup && <span className="w-4" />}
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            setVisible(id, !(el.visible ?? true))
+          }}
+          title="Toggle visible"
+        >
+          {el.visible === false ? '🚫' : '👁'}
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            setLocked(id, !(el.locked ?? false))
+          }}
+          title="Toggle lock"
+        >
+          {el.locked ? '🔒' : '🔓'}
+        </button>
+        {editing ? (
+          <input
+            className="flex-1 bg-zinc-900 border border-zinc-700 rounded px-1"
+            autoFocus
+            defaultValue={el.name || el.type}
+            onBlur={(e) => {
+              rename(id, e.currentTarget.value)
+              setEditing(false)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                rename(id, (e.target as HTMLInputElement).value)
+                setEditing(false)
+              }
+              if (e.key === 'Escape') setEditing(false)
+            }}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <div
+            className="flex-1 truncate"
+            onDoubleClick={(e) => {
+              e.stopPropagation()
+              setEditing(true)
+            }}
+          >
+            {el.name || el.type}
+            {isGroup ? ' (group)' : ''}
+          </div>
+        )}
+      </div>
+      {isGroup && expanded && childIds.length > 0 && (
+        <div className="pl-4">
+          <SortableContext items={childIds} strategy={verticalListSortingStrategy}>
+            {childIds.map((cid) => (
+              <Row key={cid} id={cid} depth={depth + 1} />
+            ))}
+          </SortableContext>
+        </div>
+      )}
     </div>
   )
 }
 
 export default function LayersPanel() {
-  const els = useBuilderStore((s) => s.elements)
-  const ids = React.useMemo(() => [...els].map((e) => e.id).reverse(), [els])
-  const reorder = useBuilderStore((s) => s.reorder)
+  const elements = useBuilderStore((s) => s.elements)
+  const rootIds = elements.filter((e) => !e.parentId).map((e) => e.id)
+  const reorderWithinParent = useBuilderStore((s) => s.reorderWithinParent)
   const selectedIds = useBuilderStore((s) => s.selectedIds)
-  const groupSel = useBuilderStore((s) => s.group)
-  const ungroupSel = useBuilderStore((s) => s.ungroup)
-  const handleDragEnd = (e: DragEndEvent) => {
+  const group = useBuilderStore((s) => s.group)
+  const ungroup = useBuilderStore((s) => s.ungroup)
+
+  const canGroup = React.useMemo(() => {
+    if (selectedIds.length < 2) return false
+    const first = elements.find((e) => e.id === selectedIds[0])
+    const parent = first?.parentId ?? null
+    return selectedIds.every(
+      (sid) => (elements.find((e) => e.id === sid)?.parentId ?? null) === parent,
+    )
+  }, [selectedIds, elements])
+
+  const canUngroup =
+    selectedIds.length === 1 &&
+    elements.find((e) => e.id === selectedIds[0])?.type === 'group'
+
+  const onDragEnd = (e: DragEndEvent) => {
     const { active, over } = e
-    if (over && active.id !== over.id) {
-      const oldIndex = ids.indexOf(active.id as string)
-      const newIndex = ids.indexOf(over.id as string)
-      const newOrder = arrayMove(ids, oldIndex, newIndex).reverse()
-      reorder(newOrder)
-    }
+    if (!over || active.id === over.id) return
+    const activeParent = (active.data.current as any)?.parentId ?? null
+    const overParent = (over.data.current as any)?.parentId ?? null
+    if (activeParent !== overParent) return
+    const siblings = elements
+      .filter((el) => (el.parentId ?? null) === activeParent)
+      .map((el) => el.id)
+    const oldIndex = siblings.indexOf(active.id as string)
+    const newIndex = siblings.indexOf(over.id as string)
+    const newOrder = arrayMove(siblings, oldIndex, newIndex)
+    reorderWithinParent(activeParent, newOrder)
   }
-  const canUngroup = React.useMemo(() => {
-    if (selectedIds.length !== 1) return false
-    const el = els.find((e) => e.id === selectedIds[0])
-    return Boolean(el?.children && el.children.length)
-  }, [selectedIds, els])
+
   return (
-    <div>
-      <div className="flex gap-1 mb-1 text-xs">
-        <button
-          className="px-1 border border-zinc-700 rounded disabled:opacity-40"
-          disabled={selectedIds.length < 2}
-          onClick={() => groupSel(selectedIds)}
-        >
-          Group
-        </button>
-        <button
-          className="px-1 border border-zinc-700 rounded disabled:opacity-40"
-          disabled={!canUngroup}
-          onClick={() => ungroupSel(selectedIds[0])}
-        >
-          Ungroup
-        </button>
+    <aside
+      className="w-64 border-r border-zinc-800 bg-zinc-950/40 h-full flex flex-col"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if ((e.key === 'Delete' || e.key === 'Backspace') && canUngroup) {
+          ungroup(selectedIds[0])
+        }
+      }}
+    >
+      <div className="px-2 py-2 border-b border-zinc-800 flex items-center gap-2">
+        <div className="font-medium text-sm">Layers</div>
+        <div className="ml-auto flex gap-2">
+          <button
+            className="px-2 py-1 bg-zinc-800 rounded disabled:opacity-50"
+            disabled={!canGroup}
+            onClick={() => group(selectedIds, { name: 'Group' })}
+          >
+            Group
+          </button>
+          <button
+            className="px-2 py-1 bg-zinc-800 rounded disabled:opacity-50"
+            disabled={!canUngroup}
+            onClick={() => ungroup(selectedIds[0])}
+          >
+            Ungroup
+          </button>
+        </div>
       </div>
-      <DndContext onDragEnd={handleDragEnd}>
-        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-          <div className="text-xs border border-zinc-800">
-            {ids.map((id) => (
-              <LayerItem key={id} id={id} />
+      <div className="flex-1 overflow-auto">
+        <DndContext onDragEnd={onDragEnd}>
+          <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
+            {rootIds.map((id) => (
+              <Row key={id} id={id} />
             ))}
-          </div>
-        </SortableContext>
-      </DndContext>
-    </div>
+          </SortableContext>
+        </DndContext>
+      </div>
+    </aside>
   )
 }
 

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -20,6 +20,7 @@ export type Elm = {
   locked?: boolean
   parentId?: string | null
   children?: string[]
+  name?: string
   props?: {
     text?: string
     color?: string
@@ -85,9 +86,11 @@ type BuilderActions = {
     patch: Partial<Elm['props']> & { code?: Partial<Elm['code']> },
   ) => void
   reorder: (idsInOrder: string[]) => void
+  reorderWithinParent: (parentId: string | null, orderedIds: string[]) => void
   setVisible: (id: string, v: boolean) => void
   setLocked: (id: string, v: boolean) => void
-  group: (ids: string[]) => void
+  rename: (id: string, name: string) => void
+  group: (ids: string[], opts?: { name?: string }) => string
   ungroup: (id: string) => void
   deleteSelected: () => void
   bringToFront: (id: string) => void
@@ -152,6 +155,8 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
           visible: true,
           locked: false,
           parentId: null,
+          name: meta?.displayName ?? 'Component',
+          children: [],
           code: {
             displayName: meta?.displayName ?? 'Component',
             importPath: meta?.importPath ?? '',
@@ -170,6 +175,8 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
           visible: true,
           locked: false,
           parentId: null,
+          name: type.charAt(0).toUpperCase() + type.slice(1),
+          children: [],
           props: {
             text,
             bg: type === 'button' ? '#0ea5e9' : '#111827',
@@ -415,6 +422,30 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     })
   },
 
+  reorderWithinParent(parentId, orderedIds) {
+    apply((draft: BuilderState) => {
+      const siblings = draft.elements.filter(
+        (e) => (e.parentId ?? null) === (parentId ?? null),
+      )
+      const idSet = new Set(orderedIds)
+      const others = siblings.filter((e) => !idSet.has(e.id)).map((e) => e.id)
+      const newOrder = [...orderedIds, ...others]
+      draft.elements = [
+        ...draft.elements.filter((e) => (e.parentId ?? null) !== (parentId ?? null)),
+        ...newOrder
+          .map((id) => draft.elements.find((e) => e.id === id)!)
+          .filter(Boolean),
+      ]
+      if (parentId) {
+        const parent = draft.elements.find((e) => e.id === parentId)
+        if (parent) {
+          const rest = (parent.children || []).filter((id) => !idSet.has(id))
+          parent.children = [...orderedIds, ...rest]
+        }
+      }
+    })
+  },
+
   setVisible(id, v) {
     apply((draft: BuilderState) => {
       const e = draft.elements.find((x) => x.id === id)
@@ -429,44 +460,98 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     })
   },
 
-  group(ids) {
+  rename(id, name) {
     apply((draft: BuilderState) => {
-      const children = draft.elements.filter((e) => ids.includes(e.id))
-      if (children.length < 2) return
-      const x1 = Math.min(...children.map((e) => e.x))
-      const y1 = Math.min(...children.map((e) => e.y))
-      const x2 = Math.max(...children.map((e) => e.x + e.w))
-      const y2 = Math.max(...children.map((e) => e.y + e.h))
+      const e = draft.elements.find((x) => x.id === id)
+      if (e) e.name = name
+    })
+  },
+
+  group(ids, opts) {
+    let result = ''
+    apply((draft: BuilderState) => {
+      const siblings = draft.elements.filter((e) => ids.includes(e.id))
+      if (siblings.length < 2) return
+      const parentId = siblings[0]?.parentId ?? null
+      if (!siblings.every((e) => (e.parentId ?? null) === parentId)) return
+      const x1 = Math.min(...siblings.map((e) => e.x))
+      const y1 = Math.min(...siblings.map((e) => e.y))
+      const x2 = Math.max(...siblings.map((e) => e.x + e.w))
+      const y2 = Math.max(...siblings.map((e) => e.y + e.h))
       const id = `grp_${Date.now().toString(36)}`
-      draft.elements.push({
+      const groupElm: Elm = {
         id,
-        type: 'group' as ElmType,
+        type: 'group',
         x: x1,
         y: y1,
         w: x2 - x1,
         h: y2 - y1,
+        parentId,
+        children: ids.slice(),
         visible: true,
         locked: false,
-        parentId: null,
-        children: ids.slice(),
-      })
-      children.forEach((c) => (c.parentId = id))
+        name: opts?.name ?? 'Group',
+      }
+      const next = draft.elements.map((el) =>
+        ids.includes(el.id) ? { ...el, parentId: id } : el,
+      )
+      if (parentId) {
+        const parent = next.find((e) => e.id === parentId)
+        if (parent) {
+          const cur = parent.children ?? []
+          const firstIndex = Math.min(
+            ...ids.map((cid) => cur.indexOf(cid)).filter((i) => i >= 0),
+          )
+          parent.children = cur.filter((cid) => !ids.includes(cid))
+          parent.children.splice(firstIndex, 0, id)
+        }
+      }
+      const order = next
+        .filter((e) => (e.parentId ?? null) === parentId)
+        .map((e) => e.id)
+      const firstIndex = Math.min(
+        ...ids.map((cid) => order.indexOf(cid)).filter((i) => i >= 0),
+      )
+      order.splice(firstIndex, 0, id)
+      draft.elements = [
+        ...next.filter((e) => (e.parentId ?? null) !== parentId),
+        ...order
+          .map((eid) => (eid === id ? groupElm : next.find((e) => e.id === eid)!))
+          .filter(Boolean),
+      ]
       draft.selectedId = id
       draft.selectedIds = [id]
+      result = id
     })
+    return result
   },
 
   ungroup(id) {
     apply((draft: BuilderState) => {
-      const gIdx = draft.elements.findIndex((e) => e.id === id)
-      if (gIdx < 0) return
-      const g = draft.elements[gIdx]
-      if (!g.children) return
-      g.children.forEach((cid) => {
-        const c = draft.elements.find((e) => e.id === cid)
-        if (c) c.parentId = g.parentId ?? null
-      })
-      draft.elements.splice(gIdx, 1)
+      const g = draft.elements.find((e) => e.id === id && e.type === 'group')
+      if (!g) return
+      const parentId = g.parentId ?? null
+      const kids = draft.elements.filter((e) => e.parentId === g.id)
+      kids.forEach((k) => (k.parentId = parentId))
+      const order = draft.elements
+        .filter((e) => (e.parentId ?? null) === parentId && e.id !== id)
+        .map((e) => e.id)
+      const idx = draft.elements
+        .filter((e) => (e.parentId ?? null) === parentId)
+        .map((e) => e.id)
+        .indexOf(id)
+      order.splice(idx, 0, ...kids.map((k) => k.id))
+      if (parentId) {
+        const parent = draft.elements.find((e) => e.id === parentId)
+        if (parent) parent.children = order.slice()
+      }
+      const others = draft.elements.filter(
+        (e) => (e.parentId ?? null) !== parentId && e.id !== id,
+      )
+      draft.elements = [
+        ...others,
+        ...order.map((eid) => draft.elements.find((e) => e.id === eid)!),
+      ]
       draft.selectedId = null
       draft.selectedIds = []
     })
@@ -547,7 +632,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     } catch (e) {
       console.error('Failed to hydrate builder state', e)
     }
-  },
-  });
+  }
+}});
 
 


### PR DESCRIPTION
## Summary
- add hierarchical element model with visibility, locking, naming, and grouping helpers
- introduce drag-reorderable Layers panel with visibility/lock toggles and rename UI
- respect element visibility/lock on canvas and hook up Layers panel in builder page

## Testing
- `pnpm --filter ui-builder-web build` *(fails: Can't resolve 'source-map-support')*


------
https://chatgpt.com/codex/tasks/task_e_68b32a9e5d0c832cbad4514ad653a5a1