### PR TITLE
feat(transform): multi-select bbox move/resize with world-space snapping and batch history

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -15,7 +15,7 @@ import { useUnitStore } from '@/store/unitStore'
 import { intersects } from '@/lib/geom'
 import { useViewStore } from '@/store/viewStore'
 import { screenToWorld } from '@/lib/coord'
-import { SelectionBBox } from './SelectionBBox'
+import SelectionBBox from './SelectionBBox'
 import {
   runActionsForNode,
   type ActionRuntimeContext,
@@ -275,7 +275,10 @@ function ElmView({
   const select = useBuilderStore((s) => s.select)
   const addSelect = useBuilderStore((s) => s.addSelect)
   const toggleSelect = useBuilderStore((s) => s.toggleSelect)
-  const selectedId = useBuilderStore((s) => s.selectedId)
+  const { selectedId, selectedIds } = useBuilderStore((s) => ({
+    selectedId: s.selectedId,
+    selectedIds: s.selectedIds,
+  }))
   const isSel = selectedId === elm.id
   const dragDraft = useBuilderStore((s) => s.ui.dragDraft)
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -355,7 +358,7 @@ function ElmView({
         <div className="h-full flex items-center px-2">{mergedProps?.text ?? 'Text'}</div>
       )}
       {elm.type === 'code' && <CodePreview elm={{ ...elm, props: mergedProps }} />}
-      {isSel && !elm.locked && <ResizeHandles elm={elm} />}
+      {isSel && !elm.locked && selectedIds.length === 1 && <ResizeHandles elm={elm} />}
       {elm.children?.map((cid) => {
         const c = all.find((e) => e.id === cid)
         return c ? (
@@ -378,6 +381,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const els = useBuilderStore((s) => s.elements)
   const select = useBuilderStore((s) => s.select)
   const addSelect = useBuilderStore((s) => s.addSelect)
+  const selectedIds = useBuilderStore((s) => s.selectedIds)
   const toggleSelect = useBuilderStore((s) => s.toggleSelect)
   const nudge = useBuilderStore((s) => s.nudge)
   const align = useBuilderStore((s) => s.align)
@@ -584,8 +588,8 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
                 runtimeProps={runtimeProps}
               />
             ))}
-          <SelectionBBox />
         </div>
+        {selectedIds.length >= 2 && <SelectionBBox />}
         <CanvasOverlay marquee={marquee ?? undefined} />
         <Rulers
           width={1200}

--- a/web/components/builder/SelectionBBox.tsx
+++ b/web/components/builder/SelectionBBox.tsx
@@ -1,66 +1,165 @@
 'use client'
-import React from 'react'
-import { useBuilderStore } from '@/store/builderStore'
-import { snapRect, collectSnapPoints } from '@/lib/builder/snap'
+import * as React from 'react'
 import { useViewStore } from '@/store/viewStore'
-import { screenToWorld } from '@/lib/coord'
+import { useBuilderStore, type Elm } from '@/store/builderStore'
+import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
 
-export function SelectionBBox() {
-  const selectedIds = useBuilderStore((s) => s.selectedIds)
-  const elements = useBuilderStore((s) => s.elements)
-  const updateMany = useBuilderStore((s) => s.updateMany)
-  const clearGuides = useBuilderStore((s) => s.clearGuides)
-  const worldToScreen = useViewStore((s) => s.worldToScreen)
-  const zoom = useViewStore((s) => s.zoom)
-  if (selectedIds.length < 2) return null
-  const selected = elements.filter((el) => selectedIds.includes(el.id) && el.visible !== false)
-  const x1 = Math.min(...selected.map((e) => e.x))
-  const y1 = Math.min(...selected.map((e) => e.y))
-  const x2 = Math.max(...selected.map((e) => e.x + e.w))
-  const y2 = Math.max(...selected.map((e) => e.y + e.h))
-  const bbox = { x: x1, y: y1, w: x2 - x1, h: y2 - y1 }
+ type Handle = 'n'|'ne'|'e'|'se'|'s'|'sw'|'w'|'nw'
 
-  const onPointerDown = (e: React.PointerEvent) => {
-    e.stopPropagation()
-    e.preventDefault()
-    const root = (e.currentTarget as HTMLElement).closest('[data-canvas-root]') as HTMLElement
-    const rect = root.getBoundingClientRect()
-    const start = screenToWorld(e.clientX - rect.left, e.clientY - rect.top)
-    const startBox = { ...bbox }
-    const snapPoints = collectSnapPoints(elements, undefined)
-    const move = (ev: PointerEvent) => {
-      const p = screenToWorld(ev.clientX - rect.left, ev.clientY - rect.top)
-      const dx = p.x - start.x
-      const dy = p.y - start.y
-      const { rect: r } = snapRect(
-        { x: startBox.x + dx, y: startBox.y + dy, w: startBox.w, h: startBox.h },
-        snapPoints,
-        { mode: 'move' },
-      )
-      const patches = selected.map((el) => ({ id: el.id, patch: { x: el.x + r.x - bbox.x, y: el.y + r.y - bbox.y } }))
-      updateMany(patches)
-    }
-    const up = () => {
-      window.removeEventListener('pointermove', move)
-      window.removeEventListener('pointerup', up)
-      clearGuides()
-    }
-    window.addEventListener('pointermove', move)
-    window.addEventListener('pointerup', up)
-  }
+ const minW = 8, minH = 8
 
-  return (
-    <div
-      className="absolute border border-sky-400/80"
-      style={{
-        left: worldToScreen({ x: bbox.x, y: bbox.y }).x,
-        top: worldToScreen({ x: bbox.x, y: bbox.y }).y,
-        width: bbox.w * zoom,
-        height: bbox.h * zoom,
-      }}
-      onPointerDown={onPointerDown}
-    />
-  )
-}
+ function bboxOf(els: Elm[]) {
+   const xs = els.map(e=>e.x), ys = els.map(e=>e.y)
+   const xe = els.map(e=>e.x+e.w), ye = els.map(e=>e.y+e.h)
+   const x = Math.min(...xs), y = Math.min(...ys)
+   const w = Math.max(...xe) - x, h = Math.max(...ye) - y
+   return { x,y,w,h }
+ }
 
-export default SelectionBBox
+ export default function SelectionBBox() {
+   const els = useBuilderStore(s=>s.elements)
+   const selected = useBuilderStore(s => s.selectedIds)
+   const updateMany = useBuilderStore(s=>s.updateMany)
+   const beginBatch = useBuilderStore(s=>s.beginBatch)
+   const endBatch = useBuilderStore(s=>s.endBatch)
+   const { worldToScreen, screenToWorld } = useViewStore(s => ({ worldToScreen: s.worldToScreen, screenToWorld: s.screenToWorld, zoom: s.zoom, pan: s.pan }))
+
+   const activeEls = React.useMemo(()=> els.filter(e => selected.includes(e.id) && (e.visible ?? true) && !e.locked), [els, selected])
+   if (activeEls.length < 2) return null
+
+   const others = React.useMemo(()=> els.filter(e => !selected.includes(e.id) && (e.visible ?? true)), [els, selected])
+   const points = React.useMemo(()=> collectSnapPoints(others, null), [others])
+
+   const box = bboxOf(activeEls)
+   const s0 = worldToScreen({x:box.x, y:box.y})
+   const s1 = worldToScreen({x:box.x+box.w, y:box.y+box.h})
+   const style: React.CSSProperties = {
+     position:'absolute',
+     left: `${s0.x}px`, top: `${s0.y}px`,
+     width: `${s1.x - s0.x}px`, height:`${s1.y - s0.y}px`,
+     pointerEvents:'none',
+   }
+
+   const startRef = React.useRef<{
+     kind: 'move'|'resize'
+     handle?: Handle
+     startWorld: { x:number, y:number }
+     box0: { x:number, y:number, w:number, h:number }
+     els0: Elm[]
+     shift: boolean
+     alt: boolean
+   }|null>(null)
+
+   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+     e.stopPropagation()
+     e.preventDefault()
+     const target = (e.target as HTMLElement).dataset.handle as Handle | undefined
+     const root = (e.currentTarget as HTMLElement).closest('[data-canvas-root]') as HTMLElement
+     const rect = root.getBoundingClientRect()
+     const p = screenToWorld({ x: e.clientX - rect.left, y: e.clientY - rect.top })
+     startRef.current = {
+       kind: target ? 'resize' : 'move',
+       handle: target,
+       startWorld: p,
+       box0: box,
+       els0: activeEls.map(a=>({ ...a })),
+       shift: e.shiftKey,
+       alt: e.altKey || e.metaKey,
+     }
+     ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+     beginBatch()
+   }
+
+   const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+     const st = startRef.current; if (!st) return
+     const root = (e.currentTarget as HTMLElement).closest('[data-canvas-root]') as HTMLElement
+     const rect = root.getBoundingClientRect()
+     const p = screenToWorld({ x: e.clientX - rect.left, y: e.clientY - rect.top })
+     let dx = p.x - st.startWorld.x
+     let dy = p.y - st.startWorld.y
+
+     if (st.kind === 'move') {
+       const moved = { x: st.box0.x + dx, y: st.box0.y + dy, w: st.box0.w, h: st.box0.h }
+       const { rect: snapped } = snapRect(moved, points, { mode:'move' })
+       const sx = snapped.x - st.box0.x
+       const sy = snapped.y - st.box0.y
+       const patches = st.els0.map(el => ({ id: el.id, x: el.x + sx, y: el.y + sy }))
+       updateMany(patches, false)
+       return
+     }
+
+     let n = { ...st.box0 }
+     const fromCenter = st.alt
+     const uniform = st.shift
+     const H = st.handle!
+     if (H.includes('e')) n.w = Math.max(minW, st.box0.w + dx)
+     if (H.includes('s')) n.h = Math.max(minH, st.box0.h + dy)
+     if (H.includes('w')) { n.w = Math.max(minW, st.box0.w - dx); n.x = st.box0.x + (st.box0.w - n.w) }
+     if (H.includes('n')) { n.h = Math.max(minH, st.box0.h - dy); n.y = st.box0.y + (st.box0.h - n.h) }
+
+     if (uniform) {
+       const ar = st.box0.w / Math.max(1e-6, st.box0.h)
+       if (H==='e'||H==='w') n.h = n.w / ar
+       else if (H==='n'||H==='s') n.w = n.h * ar
+       else {
+         const dw = n.w - st.box0.w
+         const dh = n.h - st.box0.h
+         if (Math.abs(dw) > Math.abs(dh)) n.h = n.w / ar
+         else n.w = n.h * ar
+         if (H==='nw'||H==='sw') n.x = st.box0.x + (st.box0.w - n.w)
+         if (H==='nw'||H==='ne') n.y = st.box0.y + (st.box0.h - n.h)
+       }
+     }
+
+     if (fromCenter) {
+       n.x = st.box0.x + (st.box0.w - n.w)/2
+       n.y = st.box0.y + (st.box0.h - n.h)/2
+     }
+
+     const { rect: snapped } = snapRect(n, points, { mode:'resize' })
+     n = snapped
+
+     const sx = n.w / st.box0.w
+     const sy = n.h / st.box0.h
+
+     const patches = st.els0.map(el => {
+       const ox = el.x - st.box0.x
+       const oy = el.y - st.box0.y
+       const nx = n.x + ox * sx
+       const ny = n.y + oy * sy
+       const nw = Math.max(minW, el.w * sx)
+       const nh = Math.max(minH, el.h * sy)
+       return { id: el.id, x: Math.round(nx), y: Math.round(ny), w: Math.round(nw), h: Math.round(nh) }
+     })
+     updateMany(patches, false)
+   }
+
+   const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
+     if (!startRef.current) return
+     ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+     startRef.current = null
+     endBatch()
+   }
+
+   return (
+     <div className="absolute inset-0 pointer-events-none" onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}>
+       <div className="absolute border border-amber-300/80 rounded-sm" style={style}>
+         {(['nw','n','ne','e','se','s','sw','w'] as Handle[]).map(h => {
+           const base = 'absolute w-2 h-2 bg-amber-300 border border-black rounded-sm pointer-events-auto'
+           const pos: Record<Handle,string> = {
+             n:'top-0 left-1/2 -translate-x-1/2 -translate-y-1/2',
+             ne:'top-0 right-0 translate-x-1/2 -translate-y-1/2',
+             e:'top-1/2 right-0 translate-x-1/2 -translate-y-1/2',
+             se:'bottom-0 right-0 translate-x-1/2 translate-y-1/2',
+             s:'bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2',
+             sw:'bottom-0 left-0 -translate-x-1/2 translate-y-1/2',
+             w:'top-1/2 left-0 -translate-x-1/2 -translate-y-1/2',
+             nw:'top-0 left-0 -translate-x-1/2 -translate-y-1/2'
+           }
+           const cursor: Record<Handle,string> = { n:'ns-resize', ne:'nesw-resize', e:'ew-resize', se:'nwse-resize', s:'ns-resize', sw:'nesw-resize', w:'ew-resize', nw:'nwse-resize' }
+           return <div key={h} data-handle={h} className={`${base} ${pos[h]}`} style={{ cursor: cursor[h] }} />
+         })}
+       </div>
+     </div>
+   )
+ }

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -43,6 +43,8 @@ export type Elm = {
   }
 }
 
+export type ElmPatch = { id: string; x?: number; y?: number; w?: number; h?: number; props?: any }
+
 type BuilderState = {
   elements: Elm[]
   selectedId: string | null
@@ -51,6 +53,7 @@ type BuilderState = {
     dragDraft?: { id: string; rect: { x: number; y: number; w: number; h: number } }
     guides: Array<{ axis: 'x' | 'y'; pos: number }>
   }
+  historyBatchDepth: number
 }
 
 type BuilderActions = {
@@ -101,7 +104,9 @@ type BuilderActions = {
   hydrate: (json: string) => void
   undo: () => void
   redo: () => void
-  updateMany: (patches: Array<{ id: string; patch: Partial<Elm> }>) => void
+  beginBatch: () => void
+  endBatch: () => void
+  updateMany: (patches: ElmPatch[], recordHistory?: boolean) => void
 }
 
 function snapToGrid(n: number) {
@@ -131,6 +136,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     selectedId: null,
     selectedIds: [],
     ui: { guides: [] },
+    historyBatchDepth: 0,
 
   addFromPalette(type, at, meta) {
     const id = `elm_${Date.now().toString(36)}`
@@ -602,12 +608,41 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     set((state) => useHistoryStore.getState().redo(state))
   },
 
-  updateMany(patches) {
-    apply((draft: BuilderState) => {
-      patches.forEach(({ id, patch }) => {
-        const el = draft.elements.find((e) => e.id === id)
-        if (el) Object.assign(el, patch)
+  beginBatch() {
+    const history = useHistoryStore.getState()
+    set((s) => {
+      const depth = s.historyBatchDepth + 1
+      if (depth === 1) history.start()
+      return { historyBatchDepth: depth }
+    })
+  },
+
+  endBatch() {
+    const history = useHistoryStore.getState()
+    set((s) => {
+      const depth = Math.max(0, s.historyBatchDepth - 1)
+      if (s.historyBatchDepth > 0 && depth === 0) history.commit()
+      return { historyBatchDepth: depth }
+    })
+  },
+
+  updateMany(patches, recordHistory = true) {
+    set((state) => {
+      const [next, patchList, inverse] = produceWithPatches(state, (draft: BuilderState) => {
+        patches.forEach((p) => {
+          const el = draft.elements.find((e) => e.id === p.id)
+          if (!el) return
+          if ('x' in p) el.x = p.x!
+          if ('y' in p) el.y = p.y!
+          if ('w' in p) el.w = p.w!
+          if ('h' in p) el.h = p.h!
+          if (p.props) el.props = { ...(el.props || {}), ...(p.props || {}) }
+        })
       })
+      if (recordHistory || state.historyBatchDepth > 0) {
+        useHistoryStore.getState().push(patchList, inverse)
+      }
+      return next
     })
   },
 


### PR DESCRIPTION
## Summary
- add ElmPatch-based batch update API with begin/end batching and history coalescing
- enable multi-select bounding box move & resize with world-space snapping
- guard single-node resize handles and show shared bbox only for multi-selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b32de64f6c832cbb79a20880238689