### PR TITLE
feat(actions): debug console and test mode with intercept, logging, filters and replay

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -21,6 +21,9 @@ import { DeviceFrame } from '@/components/hud/DeviceFrame'
 import { GridOverlay } from '@/components/hud/GridOverlay'
 import { BuilderHUD } from '@/components/hud/BuilderHUD'
 import { useAutosave } from '@/hooks/useAutosave'
+import ActionGate from '@/components/interaction/ActionGate'
+import ActionDevConsole from '@/components/interaction/ActionDevConsole'
+import { useActionDebugStore } from '@/store/actionDebugStore'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -33,6 +36,9 @@ export default function BuilderPage() {
   const clearGuides = useBuilderStore((s) => s.clearGuides)
   const setElements = useBuilderStore((s) => s.setElements)
   useAutosave()
+
+  const debug = true
+  const intercept = useActionDebugStore((s) => s.intercept)
 
   const currentPageId = usePageStore((s) => s.currentPageId)
   const getTree = usePageStore((s) => s.getTree)
@@ -168,42 +174,45 @@ export default function BuilderPage() {
   }, [elements, setTree])
 
   return (
-    <div className="flex h-[calc(100vh-40px)]">
-      <DndContext
-        sensors={sensors}
-        onDragStart={onDragStart}
-        onDragMove={onDragMove}
-        onDragEnd={onDragEnd}
-      >
-        <aside className="w-48 border-r border-zinc-800 bg-zinc-950/40 p-3">
-          <PagesPanel />
-        </aside>
-        <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-3">
-          <h2 className="text-sm font-semibold mb-2">パレット</h2>
-          <Palette />
-        </aside>
-        <LayersPanel />
-        <main className="flex-1 relative">
-          <DeviceFrame>
-            <div className="relative w-full h-full">
-              <Canvas canvasRef={canvasRef} />
-              <GridOverlay />
-            </div>
-          </DeviceFrame>
-          <BuilderHUD />
-        </main>
-        <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3 flex flex-col">
-          <h2 className="text-sm font-semibold mb-2">プロパティ</h2>
-          <Inspector />
-          <button
-            className="mt-auto px-2 py-1 text-xs rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
-            onClick={onExport}
-          >
-            Export Composer
-          </button>
-        </aside>
-      </DndContext>
-    </div>
+    <ActionGate enabled debug={debug} intercept={intercept}>
+      <div className="flex h-[calc(100vh-40px)]">
+        <DndContext
+          sensors={sensors}
+          onDragStart={onDragStart}
+          onDragMove={onDragMove}
+          onDragEnd={onDragEnd}
+        >
+          <aside className="w-48 border-r border-zinc-800 bg-zinc-950/40 p-3">
+            <PagesPanel />
+          </aside>
+          <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-3">
+            <h2 className="text-sm font-semibold mb-2">パレット</h2>
+            <Palette />
+          </aside>
+          <LayersPanel />
+          <main className="flex-1 relative">
+            <DeviceFrame>
+              <div className="relative w-full h-full">
+                <Canvas canvasRef={canvasRef} />
+                <GridOverlay />
+              </div>
+            </DeviceFrame>
+            <BuilderHUD />
+          </main>
+          <aside className="w-72 border-l border-zinc-800 bg-zinc-950/40 p-3 flex flex-col">
+            <h2 className="text-sm font-semibold mb-2">プロパティ</h2>
+            <Inspector />
+            <button
+              className="mt-auto px-2 py-1 text-xs rounded bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+              onClick={onExport}
+            >
+              Export Composer
+            </button>
+          </aside>
+        </DndContext>
+      </div>
+      <ActionDevConsole />
+    </ActionGate>
   )
 }
 

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -5,6 +5,7 @@ import { defaultEffect } from '@/types/interactions'
 import type { Effect, InteractionPreset, Trigger } from '@/types/interactions'
 import { buildPresetCss } from '@/lib/interactionCss'
 import { emitApply } from '@/lib/presetChannel'
+import { useEditorStore } from '@/store/editorStore'
 
 const ALL_TRIGGERS: Trigger[] = ['hover','active','focus','focusWithin','groupHover']
 const EFFECT_OPTIONS: Effect['kind'][] = ['bgColor','textColor','borderColor','shadow','scale','opacity','translate','rotate','outline','cursor']
@@ -14,6 +15,7 @@ export default function ActionDesignerPage() {
 
   const onNew = () => add({ name:'New Preset', triggers:['hover'], effects:[], transitionMs:120, easing:'cubic-bezier(.2,.8,.2,1)' })
   const sel = presets.find(p => p.id === selectedId)
+  const selectedNodeId = useEditorStore(s => s.selectedIds[0])
 
   const css = useMemo(() => sel ? buildPresetCss('preview-node', sel) : '', [sel])
 
@@ -115,6 +117,20 @@ export default function ActionDesignerPage() {
                   <div className="w-px h-5 bg-neutral-700 mx-1" />
 
                   <ProjectDefaultPicker currentId={sel.id} />
+                  <button
+                    className="ml-auto px-2 py-1 bg-indigo-700/80 rounded text-sm disabled:opacity-40"
+                    disabled={!selectedNodeId}
+                    onClick={() =>
+                      selectedNodeId &&
+                      window.dispatchEvent(
+                        new CustomEvent('actions:test', {
+                          detail: { nodeId: selectedNodeId, trigger: 'click' },
+                        }),
+                      )
+                    }
+                  >
+                    Test click on selection
+                  </button>
                 </div>
               )}
 

--- a/web/components/interaction/ActionDevConsole.tsx
+++ b/web/components/interaction/ActionDevConsole.tsx
@@ -1,0 +1,73 @@
+'use client'
+import * as React from 'react'
+import { useActionDebugStore } from '@/store/actionDebugStore'
+
+export default function ActionDevConsole() {
+  const { enabled, intercept, entries, filters, toggleEnabled, setIntercept, clear, setFilters } = useActionDebugStore()
+  React.useEffect(()=>{
+    const onKey = (e: KeyboardEvent) => {
+      const mod = (e.ctrlKey||e.metaKey) && e.shiftKey && e.key.toLowerCase()==='a'
+      if (mod) { e.preventDefault(); toggleEnabled() }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [toggleEnabled])
+
+  const filtered = entries.filter(e =>
+    (!filters.nodeId || e.nodeId===filters.nodeId) &&
+    (!filters.trigger || e.trigger===filters.trigger) &&
+    (!filters.kind || e.actions.some(a=>a.kind===filters.kind))
+  )
+
+  const replay = (row:any) => {
+    window.dispatchEvent(new CustomEvent('actions:test', { detail: { nodeId: row.nodeId, trigger: row.trigger } }))
+  }
+
+  if (!enabled) return null
+  return (
+    <div className="fixed right-3 bottom-3 z-[1000] w-[560px] h-[320px] bg-zinc-900/95 border border-zinc-700 rounded-lg shadow-xl backdrop-blur p-2 text-sm">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="font-medium">Actions Debug</div>
+        <label className="ml-2 flex items-center gap-1">
+          <input type="checkbox" checked={enabled} onChange={()=>toggleEnabled()} /> Enable
+        </label>
+        <label className="flex items-center gap-1">
+          <input type="checkbox" checked={intercept} onChange={e=>setIntercept(e.currentTarget.checked)} /> Intercept nav/url
+        </label>
+        <button className="ml-auto px-2 py-1 bg-zinc-800 rounded" onClick={clear}>Clear</button>
+      </div>
+      <div className="flex gap-2 mb-2">
+        <input className="bg-zinc-800 rounded px-2 py-1 flex-1" placeholder="Filter nodeId" value={filters.nodeId ?? ''} onChange={e=>setFilters({nodeId:e.currentTarget.value||undefined})}/>
+        <select className="bg-zinc-800 rounded px-2 py-1" value={filters.trigger ?? ''} onChange={e=>setFilters({trigger:(e.target.value||undefined) as any})}>
+          <option value="">trigger: any</option>
+          <option>click</option><option>doubleClick</option><option>mount</option><option>delay</option><option>inView</option>
+        </select>
+        <select className="bg-zinc-800 rounded px-2 py-1" value={filters.kind ?? ''} onChange={e=>setFilters({kind:(e.target.value||undefined) as any})}>
+          <option value="">kind: any</option>
+          <option>openUrl</option><option>navigate</option><option>emitEvent</option><option>setProp</option>
+        </select>
+      </div>
+      <div className="h-[240px] overflow-auto rounded border border-zinc-800">
+        <table className="w-full text-xs">
+          <thead className="bg-zinc-800/80 sticky top-0">
+            <tr><th className="text-left p-2 w-16">Δms</th><th className="text-left p-2">trigger</th><th className="text-left p-2">node</th><th className="text-left p-2">actions</th><th className="p-2 w-16"> </th></tr>
+          </thead>
+          <tbody>
+            {filtered.map(row=> (
+              <tr key={row.id} className="border-t border-zinc-800 hover:bg-zinc-800/40">
+                <td className="p-2">{Math.round((row.t1??row.t0)-row.t0)}</td>
+                <td className="p-2">{row.trigger}</td>
+                <td className="p-2">{row.nodeId}</td>
+                <td className="p-2">{row.actions.map(a=>a.kind).join(', ')}</td>
+                <td className="p-2">
+                  <button className="px-2 py-1 bg-zinc-800 rounded" onClick={()=>replay(row)}>Replay</button>
+                </td>
+              </tr>
+            ))}
+            {filtered.length===0 && <tr><td className="p-4 text-center text-zinc-500" colSpan={5}>No entries</td></tr>}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/web/components/interaction/ActionGate.tsx
+++ b/web/components/interaction/ActionGate.tsx
@@ -1,0 +1,16 @@
+'use client'
+import * as React from 'react'
+import { installActionRuntime } from '@/lib/actions/runner'
+
+export default function ActionGate({ enabled=true, debug=false, intercept=false, children }:{
+  enabled?: boolean; debug?: boolean; intercept?: boolean; children: React.ReactNode
+}) {
+  const ref = React.useRef<HTMLDivElement>(null)
+  React.useEffect(() => {
+    const el = ref.current
+    if (!el || !enabled) return
+    const dispose = installActionRuntime(el, { debug, intercept })
+    return () => dispose && dispose()
+  }, [enabled, debug, intercept])
+  return <div ref={ref}>{children}</div>
+}

--- a/web/components/preview/Player.tsx
+++ b/web/components/preview/Player.tsx
@@ -14,6 +14,9 @@ import {
   runActionsForNode,
   type ActionRuntimeContext,
 } from '@/lib/actions/runtime';
+import ActionGate from '@/components/interaction/ActionGate'
+import ActionDevConsole from '@/components/interaction/ActionDevConsole'
+import { useActionDebugStore } from '@/store/actionDebugStore'
 
 function setByPath(obj: any, path: string, value: any) {
   const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.');
@@ -179,6 +182,8 @@ function NodeRenderer({
 
 export default function Player() {
   const tree = useEditorStore((s) => s.tree);
+  const debug = true;
+  const intercept = useActionDebugStore((s) => s.intercept);
   const frames = tree;
   const [history, setHistory] = useState<string[]>(() => (frames[0] ? [frames[0].id] : []));
   const [overlay, setOverlay] = useState<string | null>(null);
@@ -318,7 +323,8 @@ export default function Player() {
 
   if (!current) return null;
   return (
-    <div className="relative w-full h-full" data-actions-enabled="true">
+    <ActionGate enabled debug={debug} intercept={intercept}>
+      <div className="relative w-full h-full" data-actions-enabled="true">
       <PresenterHUD
         title={(current as any).name ?? current.id}
         index={currentIndex}
@@ -360,7 +366,9 @@ export default function Player() {
           </div>
         </div>
       )}
-    </div>
+      </div>
+      <ActionDevConsole />
+    </ActionGate>
   );
 }
 

--- a/web/lib/actions/runner.ts
+++ b/web/lib/actions/runner.ts
@@ -1,0 +1,169 @@
+'use client'
+import { useActionDebugStore } from '@/store/actionDebugStore'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
+import { useEditorStore } from '@/store/editorStore'
+import type { ActionKind, BehaviorTrigger, ActionLogEntry } from '@/types/interactions'
+
+type Action = { kind: ActionKind; [key: string]: any }
+
+async function execAction(a: Action, currentEl: HTMLElement, intercept: boolean) {
+  switch (a.kind) {
+    case 'openUrl': {
+      if (intercept) return
+      const url = (a as any).url || (a as any).payload?.url
+      try {
+        if (typeof url === 'string') {
+          const u = new URL(url, window.location.href)
+          window.open(u.toString(), (a as any).target || '_blank')
+        }
+      } catch {
+        /* ignore */
+      }
+      return
+    }
+    case 'navigate': {
+      if (intercept) return
+      const frameId = (a as any).frameId || (a as any).target
+      if (typeof frameId === 'string') {
+        window.dispatchEvent(new CustomEvent('navigate', { detail: { frameId } }))
+      }
+      return
+    }
+    case 'emitEvent': {
+      const name = (a as any).name || (a as any).event || (a as any).payload?.name
+      if (name) {
+        window.dispatchEvent(new CustomEvent(name, { detail: (a as any).detail }))
+      }
+      return
+    }
+    case 'setProp': {
+      const path = (a as any).path || (a as any).payload?.path
+      const value = (a as any).value ?? (a as any).payload?.value
+      const nodeId = currentEl.getAttribute('data-node-id')
+      const setProp = (useEditorStore.getState() as any).setProp
+      if (nodeId && typeof setProp === 'function' && typeof path === 'string') {
+        setProp(nodeId, path, value)
+      }
+      return
+    }
+  }
+}
+
+function collectNodeMeta(nodeId: string) {
+  const { presets, projectDefaultPresetIds } = useInteractionRegistry.getState() as any
+  const node = (useEditorStore.getState() as any).tree.find((n: any) => n.id === nodeId)
+  const ownIds = Array.isArray(node?.props?.presetIds)
+    ? node.props.presetIds
+    : node?.props?.presetId
+    ? [node.props.presetId]
+    : []
+  const ids = ownIds.length ? ownIds : projectDefaultPresetIds ?? []
+  const chosen = (presets || []).filter((p: any) => ids.includes(p.id))
+  const actions = chosen.flatMap((p: any) => p.actions ?? [])
+  const when = chosen.flatMap((p: any) => p.when ?? [])
+  return { actions, when, presetIds: ids }
+}
+
+export function installActionRuntime(
+  root: HTMLElement,
+  opts?: { debug?: boolean; intercept?: boolean },
+) {
+  const debug = !!opts?.debug
+  const intercept = !!opts?.intercept
+  const log = (entry: ActionLogEntry) => {
+    if (debug) useActionDebugStore.getState().push(entry)
+  }
+
+  const runFor = async (trigger: BehaviorTrigger, target: HTMLElement) => {
+    const nodeId = target.getAttribute('data-node-id')!
+    const meta = collectNodeMeta(nodeId)
+    if (!meta.when?.includes(trigger)) return
+    const entry: ActionLogEntry = {
+      id: Math.random().toString(36).slice(2, 9),
+      t0: performance.now(),
+      nodeId,
+      trigger,
+      actions: (meta.actions ?? []).map((a: any) => ({
+        kind: (a as any).kind as ActionKind,
+        payload: a,
+      })),
+      presetIds: meta.presetIds,
+      status: 'ok',
+    }
+    try {
+      for (const a of meta.actions ?? []) {
+        const kind = (a as any).kind as ActionKind
+        if (intercept && (kind === 'openUrl' || kind === 'navigate')) {
+          entry.status = 'skipped'
+          continue
+        }
+        await execAction(a, target, intercept)
+      }
+    } catch (e: any) {
+      entry.status = 'error'
+      entry.error = e?.message ?? String(e)
+    } finally {
+      entry.t1 = performance.now()
+      log(entry)
+    }
+  }
+
+  const onClick = (ev: MouseEvent) => {
+    const target = (ev.target as HTMLElement)?.closest('[data-node-id]') as
+      | HTMLElement
+      | null
+    if (!target) return
+    ev.preventDefault()
+    runFor('click', target)
+  }
+  const onDbl = (ev: MouseEvent) => {
+    const target = (ev.target as HTMLElement)?.closest('[data-node-id]') as
+      | HTMLElement
+      | null
+    if (!target) return
+    ev.preventDefault()
+    runFor('doubleClick', target)
+  }
+  root.addEventListener('click', onClick)
+  root.addEventListener('dblclick', onDbl)
+
+  const timers = new Map<HTMLElement, any>()
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((en) => {
+      if (en.isIntersecting) runFor('inView', en.target as HTMLElement)
+    })
+  })
+
+  const setupNode = (el: HTMLElement) => {
+    const nodeId = el.getAttribute('data-node-id')
+    if (!nodeId) return
+    const meta = collectNodeMeta(nodeId)
+    if (meta.when?.includes('mount')) runFor('mount', el)
+    if (meta.when?.includes('delay')) {
+      const ms = parseInt(el.getAttribute('data-action-delay') || '0', 10)
+      const t = setTimeout(() => runFor('delay', el), ms)
+      timers.set(el, t)
+    }
+    if (meta.when?.includes('inView')) io.observe(el)
+  }
+
+  root.querySelectorAll<HTMLElement>('[data-node-id]').forEach(setupNode)
+
+  const onTest = (e: any) => {
+    const { nodeId, trigger } = e.detail || {}
+    if (!nodeId || !trigger) return
+    const el = root.querySelector(
+      `[data-node-id="${CSS.escape(nodeId)}"]`,
+    ) as HTMLElement | null
+    if (el) runFor(trigger as BehaviorTrigger, el)
+  }
+  window.addEventListener('actions:test', onTest)
+
+  return () => {
+    root.removeEventListener('click', onClick)
+    root.removeEventListener('dblclick', onDbl)
+    window.removeEventListener('actions:test', onTest)
+    timers.forEach((t) => clearTimeout(t))
+    io.disconnect()
+  }
+}

--- a/web/store/actionDebugStore.ts
+++ b/web/store/actionDebugStore.ts
@@ -1,0 +1,33 @@
+'use client'
+import { create } from 'zustand'
+import type { ActionLogEntry, BehaviorTrigger } from '@/types/interactions'
+
+type State = {
+  enabled: boolean
+  intercept: boolean
+  entries: ActionLogEntry[]
+  filters: {
+    nodeId?: string
+    trigger?: BehaviorTrigger
+    kind?: string
+  }
+  toggleEnabled(): void
+  setEnabled(v:boolean): void
+  setIntercept(v:boolean): void
+  clear(): void
+  push(e: ActionLogEntry): void
+  setFilters(f: Partial<State['filters']>): void
+}
+
+export const useActionDebugStore = create<State>((set,get)=>({
+  enabled:false,
+  intercept:false,
+  entries:[],
+  filters:{},
+  toggleEnabled(){ set(s=>({enabled:!s.enabled})) },
+  setEnabled(v){ set({enabled:v}) },
+  setIntercept(v){ set({intercept:v}) },
+  clear(){ set({entries:[]}) },
+  push(e){ set(s=>({ entries:[e, ...s.entries].slice(0,500) })) },
+  setFilters(f){ set(s=>({ filters:{...s.filters, ...f} })) }
+}))

--- a/web/types/interactions.ts
+++ b/web/types/interactions.ts
@@ -47,3 +47,23 @@ export const defaultEffect = (k: Effect['kind']): Effect => {
       return { kind: 'cursor', value: 'pointer' }
   }
 }
+
+export type ActionKind = 'openUrl' | 'navigate' | 'emitEvent' | 'setProp'
+export type BehaviorTrigger =
+  | 'click'
+  | 'doubleClick'
+  | 'mount'
+  | 'delay'
+  | 'inView'
+
+export type ActionLogEntry = {
+  id: string
+  t0: number
+  t1?: number
+  nodeId: string
+  trigger: BehaviorTrigger
+  actions: { kind: ActionKind; payload: any }[]
+  presetIds: string[]
+  status: 'ok' | 'error' | 'skipped'
+  error?: string
+}


### PR DESCRIPTION
## Summary
- add action debug store and console with filtering, replay, and intercept toggles
- implement action runtime runner with detailed logging and synthetic test trigger
- wire ActionGate across builder and preview; add test trigger button in dev actions page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33439b090832c8db198f4f9c9ca31