### PR TITLE
feat(actions): add conditions, templating, and throttle/debounce

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -2,13 +2,21 @@
 import React, { useMemo } from 'react'
 import { useInteractionRegistry } from '@/store/interactionRegistry'
 import { defaultEffect } from '@/types/interactions'
-import type { Effect, InteractionPreset, Trigger } from '@/types/interactions'
+import type {
+  Effect,
+  InteractionPreset,
+  Trigger,
+  Action,
+  BehaviorTrigger,
+} from '@/types/interactions'
 import { buildPresetCss } from '@/lib/interactionCss'
 import { emitApply } from '@/lib/presetChannel'
 import { useEditorStore } from '@/store/editorStore'
 
 const ALL_TRIGGERS: Trigger[] = ['hover','active','focus','focusWithin','groupHover']
 const EFFECT_OPTIONS: Effect['kind'][] = ['bgColor','textColor','borderColor','shadow','scale','opacity','translate','rotate','outline','cursor']
+const BEHAVIOR_TRIGGERS: BehaviorTrigger[] = ['click','doubleClick','mount','delay','inView']
+const ACTION_KINDS: Action['kind'][] = ['openUrl','navigate','emitEvent','setProp']
 
 export default function ActionDesignerPage() {
   const { presets, selectedId, add, update, remove, duplicate, select, import: importPresets, export: exportPresets } = useInteractionRegistry()
@@ -172,6 +180,13 @@ export default function ActionDesignerPage() {
               {/* Effects */}
               <div className="mt-3 text-xs text-neutral-300">Effects</div>
               <EffectEditor preset={sel} onChange={(fx)=>update(sel.id, { effects: fx })} />
+
+              {/* Behavior Actions */}
+              <div className="mt-6 text-xs text-neutral-300">Actions</div>
+              <ActionList actions={sel.actions || []} onChange={(acts)=>update(sel.id, { actions: acts })} />
+
+              <div className="mt-3 text-xs text-neutral-300">When</div>
+              <WhenEditor when={sel.when || []} onChange={(w)=>update(sel.id, { when: w })} />
             </>
           )}
         </div>
@@ -187,6 +202,175 @@ export default function ActionDesignerPage() {
           {css && <style dangerouslySetInnerHTML={{ __html: css }} />}
         </div>
       </div>
+    </div>
+  )
+}
+
+function ActionList({ actions, onChange }: { actions: Action[]; onChange: (a: Action[]) => void }) {
+  const add = () => onChange([...(actions || []), { kind: 'openUrl', url: '' } as Action])
+  const patch = (i: number, next: Partial<Action>) => {
+    const arr = actions.slice()
+    arr[i] = { ...arr[i], ...next }
+    onChange(arr)
+  }
+  const remove = (i: number) => {
+    const arr = actions.slice()
+    arr.splice(i, 1)
+    onChange(arr)
+  }
+  return (
+    <div className="space-y-2 mt-2">
+      {actions.map((a, i) => (
+        <div key={i} className="border border-neutral-700 rounded p-2 flex flex-col gap-1">
+          <div className="flex gap-2 items-center">
+            <select
+              value={a.kind}
+              onChange={(e) => patch(i, { kind: e.target.value as Action['kind'] })}
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
+            >
+              {ACTION_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {k}
+                </option>
+              ))}
+            </select>
+            <button
+              className="ml-auto px-2 py-1 bg-neutral-800 rounded text-xs"
+              onClick={() => remove(i)}
+            >
+              Del
+            </button>
+          </div>
+
+          {a.kind === 'openUrl' && (
+            <input
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+              placeholder="url"
+              value={a.url || ''}
+              onChange={(e) => patch(i, { url: e.target.value })}
+            />
+          )}
+          {a.kind === 'navigate' && (
+            <input
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+              placeholder="to"
+              value={a.to || ''}
+              onChange={(e) => patch(i, { to: e.target.value })}
+            />
+          )}
+          {a.kind === 'emitEvent' && (
+            <>
+              <input
+                className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+                placeholder="name"
+                value={a.name || ''}
+                onChange={(e) => patch(i, { name: e.target.value })}
+              />
+              <textarea
+                className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs font-mono"
+                placeholder="payload"
+                rows={2}
+                value={typeof a.payload === 'string' ? a.payload : JSON.stringify(a.payload ?? '', null, 2)}
+                onChange={(e) => patch(i, { payload: e.target.value })}
+              />
+            </>
+          )}
+          {a.kind === 'setProp' && (
+            <>
+              <input
+                className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+                placeholder="prop"
+                value={a.prop || ''}
+                onChange={(e) => patch(i, { prop: e.target.value })}
+              />
+              <input
+                className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+                placeholder="value"
+                value={typeof a.value === 'string' ? a.value : JSON.stringify(a.value ?? '')}
+                onChange={(e) => patch(i, { value: e.target.value })}
+              />
+            </>
+          )}
+
+          <textarea
+            className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs font-mono"
+            placeholder="If (JSON logic)"
+            rows={2}
+            value={a.if ? JSON.stringify(a.if, null, 2) : ''}
+            onChange={(e) => {
+              try {
+                patch(i, { if: e.target.value ? JSON.parse(e.target.value) : undefined })
+              } catch {}
+            }}
+          />
+          <div className="flex gap-2">
+            <input
+              type="number"
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+              placeholder="Throttle (ms)"
+              value={a.throttleMs ?? ''}
+              onChange={(e) =>
+                patch(i, {
+                  throttleMs: e.target.value ? parseInt(e.target.value, 10) : undefined,
+                })
+              }
+            />
+            <input
+              type="number"
+              className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-xs"
+              placeholder="Debounce (ms)"
+              value={a.debounceMs ?? ''}
+              onChange={(e) =>
+                patch(i, {
+                  debounceMs: e.target.value ? parseInt(e.target.value, 10) : undefined,
+                })
+              }
+            />
+          </div>
+        </div>
+      ))}
+      <button
+        className="px-2 py-1 bg-neutral-800 rounded text-xs"
+        type="button"
+        onClick={add}
+      >
+        Add action
+      </button>
+    </div>
+  )
+}
+
+function WhenEditor({
+  when,
+  onChange,
+}: {
+  when: BehaviorTrigger[]
+  onChange: (w: BehaviorTrigger[]) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-2 mt-1">
+      {BEHAVIOR_TRIGGERS.map((t) => {
+        const on = when.includes(t)
+        return (
+          <label
+            key={t}
+            className={`px-2 py-[6px] rounded border ${
+              on ? 'border-sky-500 bg-sky-500/10' : 'border-neutral-700'
+            }`}
+          >
+            <input
+              type="checkbox"
+              className="mr-1"
+              checked={on}
+              onChange={() => {
+                const next = on ? when.filter((x) => x !== t) : [...when, t]
+                onChange(next)
+              }}
+            />
+            {t}
+          </label>
+        )
+      })}
     </div>
   )
 }

--- a/web/lib/actions/logic.ts
+++ b/web/lib/actions/logic.ts
@@ -1,0 +1,63 @@
+'use client'
+export type AnyObj = Record<string, any>
+
+export function getVar(obj: AnyObj, path: string): any {
+  if (!path) return undefined
+  return path.split('.').reduce((acc, k) => (acc == null ? undefined : acc[k]), obj)
+}
+
+export function evaluate(expr: any, ctx: AnyObj): any {
+  if (expr == null || typeof expr === 'number' || typeof expr === 'string' || typeof expr === 'boolean') return expr
+  if (Array.isArray(expr)) return expr.map((x) => evaluate(x, ctx))
+  const op = Object.keys(expr)[0] as string
+  const val = (expr as any)[op]
+
+  switch (op) {
+    case 'var':
+      return getVar(ctx, String(val))
+    case '==':
+      return evaluate(val[0], ctx) == evaluate(val[1], ctx)
+    case '===':
+      return evaluate(val[0], ctx) === evaluate(val[1], ctx)
+    case '!=':
+      return evaluate(val[0], ctx) != evaluate(val[1], ctx)
+    case '!==':
+      return evaluate(val[0], ctx) !== evaluate(val[1], ctx)
+    case '<':
+      return evaluate(val[0], ctx) < evaluate(val[1], ctx)
+    case '<=':
+      return evaluate(val[0], ctx) <= evaluate(val[1], ctx)
+    case '>':
+      return evaluate(val[0], ctx) > evaluate(val[1], ctx)
+    case '>=':
+      return evaluate(val[0], ctx) >= evaluate(val[1], ctx)
+    case 'and':
+      return (val as any[]).every((v) => !!evaluate(v, ctx))
+    case 'or':
+      return (val as any[]).some((v) => !!evaluate(v, ctx))
+    case '!':
+      return !evaluate(val[0], ctx)
+    case '+':
+      return (val as any[]).reduce((a, b) => Number(evaluate(a, ctx)) + Number(evaluate(b, ctx)))
+    case '-':
+      return (val as any[]).reduce((a, b) => Number(evaluate(a, ctx)) - Number(evaluate(b, ctx)))
+    case '*':
+      return (val as any[]).reduce((a, b) => Number(evaluate(a, ctx)) * Number(evaluate(b, ctx)))
+    case '/': {
+      const xs = (val as any[]).map((v) => Number(evaluate(v, ctx)))
+      return xs.slice(1).reduce((a, b) => a / b, xs[0] || 0)
+    }
+    case '%':
+      return Number(evaluate(val[0], ctx)) % Number(evaluate(val[1], ctx))
+    default:
+      return undefined
+  }
+}
+
+export function template(input: any, ctx: AnyObj): any {
+  if (typeof input !== 'string') return input
+  return input.replace(/\{\{\s*([a-zA-Z0-9_.$[\]-]+)\s*\}\}/g, (_, p) => {
+    const v = getVar(ctx, p)
+    return v == null ? '' : String(v)
+  })
+}

--- a/web/lib/actions/runner.ts
+++ b/web/lib/actions/runner.ts
@@ -2,49 +2,78 @@
 import { useActionDebugStore } from '@/store/actionDebugStore'
 import { useInteractionRegistry } from '@/store/interactionRegistry'
 import { useEditorStore } from '@/store/editorStore'
-import type { ActionKind, BehaviorTrigger, ActionLogEntry } from '@/types/interactions'
+import type {
+  ActionKind,
+  BehaviorTrigger,
+  ActionLogEntry,
+  Action,
+  Target,
+} from '@/types/interactions'
+import { evaluate, template } from './logic'
 
-type Action = { kind: ActionKind; [key: string]: any }
+const throttleMap = new Map<string, number>()
+const debounceMap = new Map<string, number>()
 
-async function execAction(a: Action, currentEl: HTMLElement, intercept: boolean) {
+function keyFor(nodeId: string, idx: number, kind: string) {
+  return `${nodeId}:${idx}:${kind}`
+}
+
+function resolveTargets(selector: Target | undefined, el: HTMLElement): HTMLElement[] {
+  if (!selector) return [el]
+  if (selector.type === 'nodeId') {
+    const t = document.querySelector(
+      `[data-node-id="${CSS.escape(selector.value)}"]`,
+    ) as HTMLElement | null
+    return t ? [t] : []
+  }
+  if (selector.type === 'query') {
+    return Array.from(document.querySelectorAll<HTMLElement>(selector.value))
+  }
+  return [el]
+}
+
+function setNodePropById(id: string, prop: string, value: any) {
+  const setProp = (useEditorStore.getState() as any).setProp
+  if (typeof setProp === 'function') setProp(id, prop, value)
+}
+
+async function execOne(a: Action, el: HTMLElement, ctx: any) {
   switch (a.kind) {
     case 'openUrl': {
-      if (intercept) return
-      const url = (a as any).url || (a as any).payload?.url
-      try {
-        if (typeof url === 'string') {
-          const u = new URL(url, window.location.href)
-          window.open(u.toString(), (a as any).target || '_blank')
-        }
-      } catch {
-        /* ignore */
-      }
-      return
+      const url = template(a.url, ctx)
+      const t = a.target ?? '_self'
+      if ((window as any).__ACTIONS_INTERCEPT__) break
+      if (t === '_blank') window.open(url, '_blank', 'noopener,noreferrer')
+      else window.location.href = url
+      break
     }
     case 'navigate': {
-      if (intercept) return
-      const frameId = (a as any).frameId || (a as any).target
-      if (typeof frameId === 'string') {
-        window.dispatchEvent(new CustomEvent('navigate', { detail: { frameId } }))
+      const to = template(a.to, ctx)
+      if ((window as any).__ACTIONS_INTERCEPT__) break
+      try {
+        const r = (await import('next/navigation'))
+        r.useRouter?.().push?.(to)
+      } catch {
+        try {
+          ;(await import('next/router')).default.push?.(to)
+        } catch {}
       }
-      return
+      break
     }
     case 'emitEvent': {
-      const name = (a as any).name || (a as any).event || (a as any).payload?.name
-      if (name) {
-        window.dispatchEvent(new CustomEvent(name, { detail: (a as any).detail }))
-      }
-      return
+      const payload = typeof a.payload === 'string' ? template(a.payload, ctx) : a.payload
+      window.dispatchEvent(new CustomEvent(a.name, { detail: payload }))
+      break
     }
     case 'setProp': {
-      const path = (a as any).path || (a as any).payload?.path
-      const value = (a as any).value ?? (a as any).payload?.value
-      const nodeId = currentEl.getAttribute('data-node-id')
-      const setProp = (useEditorStore.getState() as any).setProp
-      if (nodeId && typeof setProp === 'function' && typeof path === 'string') {
-        setProp(nodeId, path, value)
-      }
-      return
+      const value = typeof a.value === 'string' ? template(a.value, ctx) : a.value
+      const els = resolveTargets(a.selector, el)
+      els.forEach((elm) => {
+        const id = elm.getAttribute('data-node-id')
+        if (!id) return
+        setNodePropById(id, a.prop, value)
+      })
+      break
     }
   }
 }
@@ -64,12 +93,58 @@ function collectNodeMeta(nodeId: string) {
   return { actions, when, presetIds: ids }
 }
 
+async function runActionsFor(
+  nodeId: string,
+  targetEl: HTMLElement,
+  trigger: BehaviorTrigger,
+) {
+  const { actions } = collectNodeMeta(nodeId)
+  if (!actions?.length) return
+  const st = useEditorStore.getState() as any
+  const node = st.tree.find((n: any) => n.id === nodeId)
+  const ctx = {
+    node,
+    props: node?.props || {},
+    dataset: Object.fromEntries(
+      Array.from(targetEl.attributes).map((a) => [a.name, a.value]),
+    ),
+    now: Date.now(),
+    env: { pathname: location.pathname },
+  }
+
+  for (let i = 0; i < actions.length; i++) {
+    const a = actions[i] as any
+    if (a.if !== undefined && !evaluate(a.if, ctx)) continue
+    const k = keyFor(nodeId, i, a.kind)
+    const now = performance.now()
+    const tms = a.throttleMs as number | undefined
+    const dms = a.debounceMs as number | undefined
+    if (tms && throttleMap.has(k)) {
+      const last = throttleMap.get(k)!
+      if (now - last < tms) continue
+    }
+    if (dms) {
+      const prev = debounceMap.get(k)
+      if (prev) clearTimeout(prev as unknown as number)
+      const id = window.setTimeout(() => {
+        throttleMap.set(k, performance.now())
+        execOne(a, targetEl, ctx)
+      }, dms)
+      debounceMap.set(k, id as unknown as number)
+      continue
+    }
+    throttleMap.set(k, now)
+    await execOne(a, targetEl, ctx)
+  }
+}
+
 export function installActionRuntime(
   root: HTMLElement,
   opts?: { debug?: boolean; intercept?: boolean },
 ) {
   const debug = !!opts?.debug
   const intercept = !!opts?.intercept
+  ;(window as any).__ACTIONS_INTERCEPT__ = intercept
   const log = (entry: ActionLogEntry) => {
     if (debug) useActionDebugStore.getState().push(entry)
   }
@@ -91,14 +166,7 @@ export function installActionRuntime(
       status: 'ok',
     }
     try {
-      for (const a of meta.actions ?? []) {
-        const kind = (a as any).kind as ActionKind
-        if (intercept && (kind === 'openUrl' || kind === 'navigate')) {
-          entry.status = 'skipped'
-          continue
-        }
-        await execAction(a, target, intercept)
-      }
+      await runActionsFor(nodeId, target, trigger)
     } catch (e: any) {
       entry.status = 'error'
       entry.error = e?.message ?? String(e)

--- a/web/types/interactions.ts
+++ b/web/types/interactions.ts
@@ -21,6 +21,8 @@ export type InteractionPreset = {
   easing?: string
   tags?: string[]
   updatedAt: number
+  actions?: Action[]
+  when?: BehaviorTrigger[]
 }
 
 export const defaultEffect = (k: Effect['kind']): Effect => {
@@ -67,3 +69,31 @@ export type ActionLogEntry = {
   status: 'ok' | 'error' | 'skipped'
   error?: string
 }
+
+export type Json =
+  | null | boolean | number | string
+  | Json[] | { [k: string]: Json }
+
+export type Logic =
+  | { '==': [Json, Json] } | { '===': [Json, Json] }
+  | { '!=': [Json, Json] } | { '!==': [Json, Json] }
+  | { '<': [Json, Json] }  | { '<=': [Json, Json] }
+  | { '>': [Json, Json] }  | { '>=': [Json, Json] }
+  | { 'and': Logic[] } | { 'or': Logic[] } | { '!': [Logic] }
+  | { '+': Json[] } | { '-': Json[] } | { '*': Json[] } | { '/': Json[] } | { '%': [Json, Json] }
+  | { 'var': string }
+  | Json
+
+export type ActionBase = {
+  if?: Logic
+  throttleMs?: number
+  debounceMs?: number
+}
+
+export type Action =
+  | (ActionBase & { kind:'openUrl';  url:string; target?:'_blank'|'_self' })
+  | (ActionBase & { kind:'navigate'; to:string })
+  | (ActionBase & { kind:'emitEvent'; name:string; payload?:Json })
+  | (ActionBase & { kind:'setProp';   selector?:Target; prop:string; value:Json | string })
+
+export type Target = { type:'nodeId'; value:string } | { type:'query'; value:string }


### PR DESCRIPTION
## Summary
- extend action presets with JSON logic, templating, variables, and throttle/debounce controls
- add evaluator and string templating utilities
- run actions with condition checks and timing guards and update dev UI for configuring actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b336c77f54832ca08b3d03e684b10f