### PR TITLE
feat(presets): bulk apply UI for interaction presets

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -24,6 +24,7 @@ import { useAutosave } from '@/hooks/useAutosave'
 import ActionGate from '@/components/interaction/ActionGate'
 import ActionDevConsole from '@/components/interaction/ActionDevConsole'
 import { useActionDebugStore } from '@/store/actionDebugStore'
+import PresetApplyBus from '@/components/interaction/PresetApplyBus'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -175,6 +176,7 @@ export default function BuilderPage() {
 
   return (
     <ActionGate enabled debug={debug} intercept={intercept}>
+      <PresetApplyBus />
       <div className="flex h-[calc(100vh-40px)]">
         <DndContext
           sensors={sensors}

--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -9,6 +9,8 @@ import { DEVICE_PRESETS } from '@/lib/devicePresets';
 import AnnotationsOverlay from '@/components/editor/AnnotationsOverlay';
 import { useSearchParams } from 'next/navigation';
 import '@/styles/preview.css';
+import ActionGate from '@/components/interaction/ActionGate';
+import PresetApplyBus from '@/components/interaction/PresetApplyBus';
 
 function renderNode(
   node: ComponentNode,
@@ -82,12 +84,15 @@ export default function PreviewPage() {
     />
   ) : null;
   return (
-    <div className="w-full h-full flex items-center justify-center bg-gray-100">
-      <div style={style}>
-        {safe}
-        {tree.map((n) => renderNode(n, components, sources, bindings))}
-        {showComments && <AnnotationsOverlay />}
+    <ActionGate enabled>
+      <PresetApplyBus />
+      <div className="w-full h-full flex items-center justify-center bg-gray-100">
+        <div style={style}>
+          {safe}
+          {tree.map((n) => renderNode(n, components, sources, bindings))}
+          {showComments && <AnnotationsOverlay />}
+        </div>
       </div>
-    </div>
+    </ActionGate>
   );
 }

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -6,6 +6,7 @@ import { useUnitStore } from '@/store/unitStore';
 import { worldToUnit, unitToWorld } from '@/lib/units';
 import AutoPropsForm from '@/components/props/AutoPropsForm';
 import { registry } from '@/lib/registry';
+import PresetApplyBar from '@/components/props/PresetApplyBar';
 
 export default function RightInspector() {
   const selected = useEditorStore((s) => s.selectedIds[0]);
@@ -242,10 +243,13 @@ export default function RightInspector() {
         </div>
       </div>
       {node && (
-        <ActionPresetField
-          nodeId={node.id}
-          value={node.props?.presetId ?? (node.props?.presetIds?.[0] ?? '')}
-        />
+        <>
+          <ActionPresetField
+            nodeId={node.id}
+            value={node.props?.presetId ?? (node.props?.presetIds?.[0] ?? '')}
+          />
+          <PresetApplyBar />
+        </>
       )}
     </div>
   );

--- a/web/components/interaction/PresetApplyBus.tsx
+++ b/web/components/interaction/PresetApplyBus.tsx
@@ -1,0 +1,36 @@
+'use client'
+import * as React from 'react'
+import { subscribeApply, type ApplyMode } from '@/lib/presetChannel'
+import { applyPresetToSelection, applyPresetToAll } from '@/store/editorStore'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
+import { useEditorStore } from '@/store/editorStore'
+import { normalizeNodePresets } from '@/lib/presetApply'
+
+export default function PresetApplyBus() {
+  React.useEffect(() => {
+    // sync legacy preset props on mount
+    const st = useEditorStore.getState()
+    st.tree.forEach((n: any) => {
+      const ids = normalizeNodePresets(n)
+      const props = n.props || {}
+      if (!Array.isArray(props.presetIds) || ids.length !== props.presetIds.length || ids.some((x, i) => x !== props.presetIds[i]) || props.presetId !== ids[0]) {
+        st.updateNode(n.id, { props: { ...props, presetIds: ids, presetId: ids[0] ?? null } })
+      }
+    })
+  }, [])
+
+  React.useEffect(() => {
+    return subscribeApply((m) => {
+      if (m.type !== 'apply') return
+      const { presetId, mode, scope } = m
+      if (scope === 'selection') applyPresetToSelection(presetId, mode as ApplyMode)
+      else if (scope === 'all') applyPresetToAll(presetId, mode as ApplyMode)
+      else if (scope === 'set-project-default') {
+        const r = useInteractionRegistry.getState()
+        const ids = presetId ? [presetId] : []
+        r.setProjectDefaults(ids)
+      }
+    })
+  }, [])
+  return null
+}

--- a/web/components/props/PresetApplyBar.tsx
+++ b/web/components/props/PresetApplyBar.tsx
@@ -1,0 +1,58 @@
+'use client'
+import * as React from 'react'
+import { useInteractionRegistry } from '@/store/interactionRegistry'
+import { emitApply } from '@/lib/presetChannel'
+
+export default function PresetApplyBar() {
+  const { presets } = useInteractionRegistry()
+  const [pid, setPid] = React.useState<string>('')
+  const [mode, setMode] = React.useState<'replace' | 'append' | 'remove'>('replace')
+  return (
+    <div className="mt-3 border-t border-neutral-800 pt-2">
+      <div className="text-xs text-neutral-300 mb-1">Bulk apply preset</div>
+      <div className="flex gap-2">
+        <select
+          className="flex-1 bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
+          value={pid}
+          onChange={(e) => setPid(e.target.value)}
+        >
+          <option value="">（選択してください）</option>
+          {presets.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className="bg-neutral-900 border border-neutral-700 rounded px-2 py-1 text-sm"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as any)}
+        >
+          <option value="replace">replace</option>
+          <option value="append">append</option>
+          <option value="remove">remove</option>
+        </select>
+      </div>
+      <div className="mt-2 flex gap-2">
+        <button
+          className="px-2 py-1 bg-neutral-800 rounded text-xs"
+          onClick={() => emitApply(pid || '', mode, 'selection')}
+        >
+          Apply to selection
+        </button>
+        <button
+          className="px-2 py-1 bg-neutral-800 rounded text-xs"
+          onClick={() => emitApply(pid || '', mode, 'all')}
+        >
+          Apply to all
+        </button>
+        <button
+          className="px-2 py-1 bg-neutral-800 rounded text-xs"
+          onClick={() => emitApply(pid || '', 'replace', 'set-project-default')}
+        >
+          Set as project default
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/lib/presetApply.ts
+++ b/web/lib/presetApply.ts
@@ -1,0 +1,35 @@
+'use client'
+import { useEditorStore } from '@/store/editorStore'
+
+export type ApplyMode = 'replace' | 'append' | 'remove'
+
+export function normalizeNodePresets(node: any) {
+  const ids = Array.isArray(node?.props?.presetIds)
+    ? (node.props.presetIds as string[])
+    : node?.props?.presetId
+      ? [node.props.presetId]
+      : []
+  return Array.from(new Set(ids))
+}
+
+export function buildNextPresetIds(cur: string[], mode: ApplyMode, id: string) {
+  if (mode === 'replace') return id ? [id] : []
+  if (mode === 'append') return Array.from(new Set([...cur, id].filter(Boolean)))
+  if (mode === 'remove') return cur.filter((x) => x !== id)
+  return cur
+}
+
+export function applyPresetToNode(nodeId: string, presetId: string | null, mode: ApplyMode) {
+  const st = useEditorStore.getState()
+  const node = st.tree.find((n: any) => n.id === nodeId)
+  if (!node) return
+  const cur = normalizeNodePresets(node)
+  const next = presetId
+    ? buildNextPresetIds(cur, mode, presetId)
+    : mode === 'replace'
+      ? []
+      : cur
+  const patch: any = { ...(node.props || {}), presetIds: next }
+  patch.presetId = next[0] ?? null // keep legacy in sync
+  st.updateNode(nodeId, { props: patch })
+}

--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -38,6 +38,7 @@ import { resolveComponentBinding } from "@/lib/binding/resolve";
 import { mapNodesForSwap } from "@/lib/override/compat";
 import { resolveOverrides } from "@/lib/override/resolve";
 import { MIN_ZOOM, MAX_ZOOM } from "@/lib/layout/constants";
+import { applyPresetToNode, type ApplyMode } from "@/lib/presetApply";
 import { reflectHandle } from "@/lib/vector/bezier";
 import { flattenPath } from "@/lib/vector/flatten";
 import {
@@ -1876,3 +1877,14 @@ useEditorStore.subscribe(() => {
     }
   }, SCHEDULE_MS);
 });
+
+export function applyPresetToSelection(presetId: string | null, mode: ApplyMode) {
+  const st = useEditorStore.getState()
+  const ids = (st.selectedIds as string[]) || []
+  ids.forEach((id) => applyPresetToNode(id, presetId, mode))
+}
+
+export function applyPresetToAll(presetId: string | null, mode: ApplyMode) {
+  const st = useEditorStore.getState()
+  st.tree.forEach((n: any) => applyPresetToNode(n.id, presetId, mode))
+}


### PR DESCRIPTION
## Summary
- add `presetApply` utilities for normalizing and applying preset IDs
- allow bulk preset operations via `PresetApplyBus` broadcast handler and `PresetApplyBar` UI
- mount cross-tab preset bus in builder and preview roots

## Testing
- `pnpm --filter ui-builder-web build` *(fails: Module not found: Can't resolve 'source-map-support')*

------
https://chatgpt.com/codex/tasks/task_e_68b3aa0363a8832c8e7a92702fd54283