### PR TITLE
Fix Immer patches runtime error

### DIFF
--- a/web/store/editorStore.ts
+++ b/web/store/editorStore.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import { produceWithPatches } from "immer";
+import { produceWithPatches, enablePatches } from "immer";
 import type {
   EditorState,
   ComponentNode,
@@ -56,6 +56,8 @@ import {
   type SnapshotDoc,
 } from "@/lib/persist/snapshot";
 import { commitWithRetry } from "@/lib/persist/commit";
+
+enablePatches();
 
 const updateUsageCounts = (draft: EditorState) => {
   const counts: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- enable Immer patches plugin so produceWithPatches works without runtime errors

## Testing
- `pnpm test` (fails: Property 'children' does not exist on type 'MyCardProps')

------
https://chatgpt.com/codex/tasks/task_e_68b3c2e965ac832ca95dbe4d9d791371