### PR TITLE
feat: auto-generate property panel from schema

### DIFF
--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import { useEditorActions, ComponentNode } from './store'
-import { registry } from '@/lib/registry'
+import { registry } from '@/lib/registry.ts'
+import { resolveBinding } from '@/lib/binding/resolve'
 import { useRects } from './canvas/RectsStore'
 import { NodeWrapper } from '@/components/shared/NodeWrapper'
 
@@ -11,8 +12,12 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
   const { setRect } = useRects()
   const ref = React.useRef<HTMLDivElement>(null)
   const entry = (registry as any)[node.type]
-  const Comp = entry?.Comp || ((p: any) => <div {...p}>{p.children}</div>)
+  const Comp = entry?.cmp || ((p: any) => <div {...p}>{p.children}</div>)
   const style = node.props?.style || {}
+  let resolvedProps = node.propValues || {}
+  if (node.propValues) {
+    resolvedProps = resolveBinding(resolvedProps, [], [])
+  }
 
  
 
@@ -46,7 +51,7 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
           selectComponent(node.id)
         }}
       >
-        <Comp {...node.props}>
+        <Comp {...resolvedProps}>
           {node.children?.map((child) => (
             <NodeRenderer key={child.id} node={child} />
           ))}

--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import type { ElmType } from '@/store/builderStore'
-import { registry, type RegistryKey } from '@/lib/registry'
+import { registry, type RegistryKey } from '@/lib/registry.ts'
 import { loadDocgenMeta, type DocgenMetaItem } from '@/lib/builder/docgen'
 
 function DraggableItem({ type, label }: { type: ElmType; label: string }) {

--- a/web/components/builder/RightSidebar.tsx
+++ b/web/components/builder/RightSidebar.tsx
@@ -1,0 +1,31 @@
+'use client'
+import React from 'react'
+import { AutoPropertyPanel } from '@/components/panel/AutoPropertyPanel'
+import { useBuilderStore } from '@/store/builderStore'
+
+export function RightSidebar() {
+  const selectedIds = useBuilderStore(s=>s.selectedIds)
+  const tree = useBuilderStore(s=>s.tree as any)
+  const updateProp = useBuilderStore(s=>s.updateProp as any)
+  const node = React.useMemo(()=>{
+    const id = selectedIds?.[0]
+    if (!id) return null
+    const q: any[] = [...(tree||[])]
+    while (q.length) {
+      const n: any = q.shift()
+      if (n?.id === id) return n
+      if (n?.children) q.push(...n.children)
+    }
+    return null
+  }, [selectedIds, tree])
+
+  if (!node || node.type !== 'instance') return <div className="p-2 text-sm text-gray-500">No selection</div>
+
+  return (
+    <AutoPropertyPanel
+      componentKey={node.componentId}
+      propValues={node.propValues}
+      onChange={(k,v)=>updateProp(node.id, k, v)}
+    />
+  )
+}

--- a/web/components/domain/Button.tsx
+++ b/web/components/domain/Button.tsx
@@ -1,0 +1,14 @@
+'use client'
+import React from 'react'
+
+type Props = {
+  label?: string
+  href?: string
+  variant?: 'primary'|'secondary'|'ghost'
+  disabled?: boolean
+}
+export function Button(p: Props) {
+  const cls = p.variant === 'secondary' ? 'bg-gray-200' : p.variant === 'ghost' ? 'bg-transparent border' : 'bg-blue-600 text-white'
+  if (p.href) return <a className={`inline-flex px-3 h-9 items-center rounded ${cls} ${p.disabled?'opacity-50 pointer-events-none':''}`} href={p.href}>{p.label}</a>
+  return <button className={`inline-flex px-3 h-9 items-center rounded ${cls}`} disabled={p.disabled}>{p.label}</button>
+}

--- a/web/components/domain/Text.tsx
+++ b/web/components/domain/Text.tsx
@@ -1,0 +1,8 @@
+'use client'
+import React from 'react'
+type Props = { text?: string; size?: 'sm'|'base'|'lg'|'xl'; color?: string; bold?: boolean }
+export function Text(p: Props) {
+  const s = p.size === 'sm' ? 'text-sm' : p.size === 'lg' ? 'text-lg' : p.size === 'xl' ? 'text-xl' : 'text-base'
+  const w = p.bold ? 'font-bold' : 'font-normal'
+  return <span className={`${s} ${w}`} style={{ color: p.color }}>{p.text}</span>
+}

--- a/web/components/domain/meta/buttonMeta.ts
+++ b/web/components/domain/meta/buttonMeta.ts
@@ -1,0 +1,14 @@
+import type { BuilderMeta } from '@/types/propertySchema'
+export const BUTTON_META: BuilderMeta = {
+  displayName: 'Button',
+  propertySchema: [
+    { id: 'label', label: 'Label', kind: 'string', default: 'Button', bindable: true },
+    { id: 'variant', label: 'Variant', kind: 'select', options: [
+      { label: 'Primary', value: 'primary' },
+      { label: 'Secondary', value: 'secondary' },
+      { label: 'Ghost', value: 'ghost' },
+    ], default: 'primary' },
+    { id: 'href', label: 'Href', kind: 'string', placeholder: 'https://', bindable: true },
+    { id: 'disabled', label: 'Disabled', kind: 'boolean', default: false },
+  ],
+}

--- a/web/components/domain/meta/textMeta.ts
+++ b/web/components/domain/meta/textMeta.ts
@@ -1,0 +1,15 @@
+import type { BuilderMeta } from '@/types/propertySchema'
+export const TEXT_META: BuilderMeta = {
+  displayName: 'Text',
+  propertySchema: [
+    { id: 'text', label: 'Text', kind: 'string', default: 'Lorem ipsum', bindable: true },
+    { id: 'size', label: 'Size', kind: 'select', options: [
+      { label: 'Sm', value: 'sm' },
+      { label: 'Base', value: 'base' },
+      { label: 'Lg', value: 'lg' },
+      { label: 'Xl', value: 'xl' },
+    ], default: 'base' },
+    { id: 'color', label: 'Color', kind: 'color', default: '#111827' },
+    { id: 'bold', label: 'Bold', kind: 'boolean', default: false },
+  ],
+}

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -5,7 +5,7 @@ import ActionPresetField from '@/components/props/ActionPresetField';
 import { useUnitStore } from '@/store/unitStore';
 import { worldToUnit, unitToWorld } from '@/lib/units';
 import AutoPropsForm from '@/components/props/AutoPropsForm';
-import { registry } from '@/lib/registry';
+import { registry } from '@/lib/registry.ts';
 import PresetApplyBar from '@/components/props/PresetApplyBar';
 
 export default function RightInspector() {

--- a/web/components/panel/AutoPropertyPanel.tsx
+++ b/web/components/panel/AutoPropertyPanel.tsx
@@ -1,0 +1,74 @@
+'use client'
+import React, { useMemo } from 'react'
+import { getDef } from '@/lib/registry.ts'
+import type { PropertyDef } from '@/types/propertySchema'
+
+type Props = {
+  componentKey: string
+  propValues: Record<string, any> | undefined
+  onChange: (id: string, v: any) => void
+}
+
+function Control({ def, value, onChange }: { def: PropertyDef; value: any; onChange: (v:any)=>void }) {
+  if (def.kind === 'string') return <input className="w-full border p-1 rounded" placeholder={def.placeholder} value={value ?? ''} onChange={(e)=>onChange(e.target.value)} />
+  if (def.kind === 'number') return <input type="number" className="w-full border p-1 rounded" value={value ?? ''} onChange={(e)=>onChange(e.target.value === '' ? undefined : Number(e.target.value))} min={def.min} max={def.max} step={def.step ?? 1} />
+  if (def.kind === 'boolean') return <input type="checkbox" checked={!!value} onChange={(e)=>onChange(e.target.checked)} />
+  if (def.kind === 'select') return (
+    <select className="w-full border p-1 rounded" value={value ?? ''} onChange={(e)=>onChange(e.target.value)}>
+      {(def.options ?? []).map(o=> <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  )
+  if (def.kind === 'multiselect') return (
+    <select multiple className="w-full border p-1 rounded" value={Array.isArray(value)?value:[]} onChange={(e)=>onChange(Array.from(e.target.selectedOptions).map(o=>o.value))}>
+      {(def.options ?? []).map(o=> <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  )
+  if (def.kind === 'color') return <input type="color" value={value ?? '#000000'} onChange={(e)=>onChange(e.target.value)} />
+  return null
+}
+
+export function AutoPropertyPanel({ componentKey, propValues, onChange }: Props) {
+  const meta = getDef(componentKey as any).meta
+  const groups = useMemo(() => {
+    const map = new Map<string, PropertyDef[]>()
+    meta.propertySchema.forEach(d => {
+      const g = d.group ?? 'General'
+      if (!map.has(g)) map.set(g, [])
+      map.get(g)!.push(d)
+    })
+    return Array.from(map.entries())
+  }, [meta])
+
+  return (
+    <div className="space-y-4 p-2">
+      {groups.map(([g, defs]) => (
+        <div key={g} className="space-y-2">
+          <div className="text-xs font-semibold text-gray-500">{g}</div>
+          {defs.map(def => {
+            const v = propValues?.[def.id] ?? def.default
+            return (
+              <div key={def.id} className="grid grid-cols-3 gap-2 items-center">
+                <label className="text-sm col-span-1">{def.label}</label>
+                <div className="col-span-2">
+                  <Control def={def} value={v} onChange={(nv)=>onChange(def.id, nv)} />
+                  {def.bindable && (
+                    <details className="mt-1">
+                      <summary className="text-[11px] cursor-pointer">Bind</summary>
+                      <div className="flex gap-1">
+                        <select defaultValue="data" onChange={(e)=>onChange(def.id, { source: e.target.value, path: '' })} className="border p-1 rounded">
+                          <option value="data">data</option>
+                        </select>
+                        <input className="flex-1 border p-1 rounded" placeholder="path e.g. user.name" value={typeof v==='object'&&v? v.path ?? '' : ''} onChange={(e)=>onChange(def.id, { source: 'data', path: e.target.value })} />
+                        <button className="border px-2 rounded" onClick={()=>onChange(def.id, def.default)}>Reset</button>
+                      </div>
+                    </details>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -1,0 +1,15 @@
+import type { ComponentType } from 'react'
+import type { BuilderMeta } from '@/types/propertySchema'
+import { Button } from '@/components/domain/Button'
+import { Text } from '@/components/domain/Text'
+import { BUTTON_META } from '@/components/domain/meta/buttonMeta'
+import { TEXT_META } from '@/components/domain/meta/textMeta'
+
+export type ComponentDef = { key: string; cmp: ComponentType<any>; meta: BuilderMeta }
+export const REGISTRY: Record<string, ComponentDef> = {
+  'ui.button': { key: 'ui.button', cmp: Button, meta: BUTTON_META },
+  'ui.text': { key: 'ui.text', cmp: Text, meta: TEXT_META },
+}
+export const registry = REGISTRY
+export type RegistryKey = keyof typeof REGISTRY
+export function getDef(key: RegistryKey) { return REGISTRY[key] }

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 import { produce, produceWithPatches } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
-import { registry, type RegistryKey } from '@/lib/registry'
+import { registry, getDef, type RegistryKey } from '@/lib/registry.ts'
 import { useGridStore } from '@/store/gridStore'
 import { useHistoryStore } from './historyStore'
 
@@ -35,6 +35,7 @@ export type Elm = {
       href?: string
     }
   }
+  propValues?: Record<string, any>
   code?: {
     displayName: string
     importPath: string
@@ -47,6 +48,7 @@ export type ElmPatch = { id: string; x?: number; y?: number; w?: number; h?: num
 
 type BuilderState = {
   elements: Elm[]
+  tree: Elm[]
   selectedId: string | null
   selectedIds: string[]
   ui: {
@@ -88,6 +90,7 @@ type BuilderActions = {
     id: string,
     patch: Partial<Elm['props']> & { code?: Partial<Elm['code']> },
   ) => void
+  updateProp: (nodeId: string, key: string, value: any) => void,
   reorder: (idsInOrder: string[]) => void
   reorderWithinParent: (parentId: string | null, orderedIds: string[]) => void
   setVisible: (id: string, v: boolean) => void
@@ -122,6 +125,15 @@ function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
   return { ...size, text }
 }
 
+function defaultsFor(key: string) {
+  const meta = getDef(key as any).meta
+  const o: Record<string, any> = {}
+  meta.propertySchema.forEach(d => {
+    if (typeof d.default !== 'undefined') o[d.id] = d.default
+  })
+  return o
+}
+
 export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => {
   const apply = (recipe: (draft: BuilderState) => void) => {
     set((state) => {
@@ -133,6 +145,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
 
   return {
     elements: [],
+    tree: [],
     selectedId: null,
     selectedIds: [],
     ui: { guides: [] },
@@ -171,6 +184,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
           },
         })
       } else {
+        const defaults = defaultsFor(type as string)
         draft.elements.push({
           id,
           type,
@@ -183,11 +197,8 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
           parentId: null,
           name: type.charAt(0).toUpperCase() + type.slice(1),
           children: [],
-          props: {
-            text,
-            bg: type === 'button' ? '#0ea5e9' : '#111827',
-            color: '#e5e7eb',
-          },
+          propValues: defaults,
+          props: { ...defaults },
         })
       }
       draft.selectedId = id
@@ -412,6 +423,26 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
             ...(e.code?.props ?? {}),
             ...(code.props ?? {}),
           },
+        }
+      }
+    })
+  },
+  updateProp(nodeId, key, value) {
+    apply((draft: BuilderState) => {
+      const stack: any[] = [...draft.elements]
+      while (stack.length) {
+        const n: any = stack.pop()
+        if (n?.id === nodeId) {
+          if (!n.propValues) n.propValues = {}
+          n.propValues[key] = value
+          if (n.props) n.props[key] = value
+          break
+        }
+        if (n?.children) {
+          n.children.forEach((cid: string) => {
+            const c = draft.elements.find((e) => e.id === cid)
+            if (c) stack.push(c)
+          })
         }
       }
     })
@@ -650,6 +681,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     set(
       produce((draft: BuilderState) => {
         draft.elements = els
+        draft.tree = els
       }),
     )
   },
@@ -662,7 +694,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     try {
       const data = JSON.parse(json)
       if (Array.isArray(data.elements)) {
-        set({ elements: data.elements, selectedId: null, selectedIds: [], ui: { guides: [] } })
+        set({ elements: data.elements, tree: data.elements, selectedId: null, selectedIds: [], ui: { guides: [] } })
       }
     } catch (e) {
       console.error('Failed to hydrate builder state', e)

--- a/web/types/propertySchema.ts
+++ b/web/types/propertySchema.ts
@@ -1,0 +1,20 @@
+export type PropKind = 'string' | 'number' | 'boolean' | 'select' | 'multiselect' | 'color'
+export type Option = { label: string; value: string }
+export type PropertyDef = {
+  id: string
+  label: string
+  kind: PropKind
+  default?: any
+  options?: Option[]
+  min?: number
+  max?: number
+  step?: number
+  placeholder?: string
+  group?: string
+  bindable?: boolean
+}
+export type BuilderMeta = {
+  displayName: string
+  icon?: string
+  propertySchema: PropertyDef[]
+}


### PR DESCRIPTION
## Summary
- add `BuilderMeta` and property schema infrastructure
- auto-generate property panel and hook it to builder store
- initialize and bind instance prop values, updated Button/Text components

## Testing
- `pnpm -F ui-builder-web typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm -F ui-builder-web build` *(fails: Module not found: Can't resolve 'source-map-support')*


------
https://chatgpt.com/codex/tasks/task_e_68b3c3c9c25c832ca8f1c04056eb6261