### PR TITLE
feat: make builder sidebar panels sortable

### DIFF
--- a/src/components/custom/MyCard.tsx
+++ b/src/components/custom/MyCard.tsx
@@ -4,6 +4,8 @@ interface MyCardProps {
   title: string
   highlighted: boolean
   tone: 'info' | 'warn'
+  className?: string
+  children?: React.ReactNode
 }
 
 const MyCard: React.FC<MyCardProps> = ({ title, highlighted, tone, children, className }) => {

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -9,13 +9,12 @@ import {
   DragStartEvent,
   DragMoveEvent,
 } from '@dnd-kit/core'
-import { Palette } from '@/components/builder/Palette'
 import { Canvas } from '@/components/builder/Canvas'
 import { Inspector } from '@/components/builder/Inspector'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
-import { PagesPanel } from '@/components/builder/PagesPanel'
 import LayersPanel from '@/components/builder/LayersPanel'
+import LeftSidebar from '@/components/builder/LeftSidebar'
 import { usePageStore } from '@/store/pageStore'
 import { DeviceFrame } from '@/components/hud/DeviceFrame'
 import { GridOverlay } from '@/components/hud/GridOverlay'
@@ -184,13 +183,7 @@ export default function BuilderPage() {
           onDragMove={onDragMove}
           onDragEnd={onDragEnd}
         >
-          <aside className="w-48 border-r border-zinc-800 bg-zinc-950/40 p-3">
-            <PagesPanel />
-          </aside>
-          <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-3">
-            <h2 className="text-sm font-semibold mb-2">パレット</h2>
-            <Palette />
-          </aside>
+          <LeftSidebar />
           <LayersPanel />
           <main className="flex-1 relative">
             <DeviceFrame>

--- a/web/components/builder/LayersPanel.tsx
+++ b/web/components/builder/LayersPanel.tsx
@@ -133,6 +133,8 @@ export default function LayersPanel() {
   const group = useBuilderStore((s) => s.group)
   const ungroup = useBuilderStore((s) => s.ungroup)
 
+  const [collapsed, setCollapsed] = React.useState(false)
+
   const canGroup = React.useMemo(() => {
     if (selectedIds.length < 2) return false
     const first = elements.find((e) => e.id === selectedIds[0])
@@ -173,7 +175,7 @@ export default function LayersPanel() {
     >
       <div className="px-2 py-2 border-b border-zinc-800 flex items-center gap-2">
         <div className="font-medium text-sm">Layers</div>
-        <div className="ml-auto flex gap-2">
+        <div className="ml-auto flex gap-2 items-center">
           <button
             className="px-2 py-1 bg-zinc-800 rounded disabled:opacity-50"
             disabled={!canGroup}
@@ -188,17 +190,26 @@ export default function LayersPanel() {
           >
             Ungroup
           </button>
+          <button
+            className="px-1 text-xs border border-zinc-700 rounded"
+            onClick={() => setCollapsed((v) => !v)}
+            title="Toggle collapse"
+          >
+            {collapsed ? '+' : '−'}
+          </button>
         </div>
       </div>
-      <div className="flex-1 overflow-auto">
-        <DndContext onDragEnd={onDragEnd}>
-          <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
-            {rootIds.map((id) => (
-              <Row key={id} id={id} />
-            ))}
-          </SortableContext>
-        </DndContext>
-      </div>
+      {!collapsed && (
+        <div className="flex-1 overflow-auto">
+          <DndContext onDragEnd={onDragEnd}>
+            <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
+              {rootIds.map((id) => (
+                <Row key={id} id={id} />
+              ))}
+            </SortableContext>
+          </DndContext>
+        </div>
+      )}
     </aside>
   )
 }

--- a/web/components/builder/LeftSidebar.tsx
+++ b/web/components/builder/LeftSidebar.tsx
@@ -1,0 +1,122 @@
+'use client'
+import React from 'react'
+import {
+  DndContext,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { PagesPanel } from './PagesPanel'
+import { Palette } from './Palette'
+import { usePageStore } from '@/store/pageStore'
+
+type PanelId = 'pages' | 'palette'
+
+function AddPageButton() {
+  const addPage = usePageStore((s) => s.addPage)
+  return (
+    <button
+      className="px-1 text-xs border border-zinc-700 rounded"
+      onClick={() => addPage()}
+    >
+      +
+    </button>
+  )
+}
+
+function SortablePanel({
+  id,
+  title,
+  collapsed,
+  onToggle,
+  children,
+  extraHeader,
+}: {
+  id: PanelId
+  title: string
+  collapsed: boolean
+  onToggle: () => void
+  children: React.ReactNode
+  extraHeader?: React.ReactNode
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id })
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+  return (
+    <div ref={setNodeRef} style={style} className="border border-zinc-800 rounded">
+      <div
+        className="flex items-center justify-between bg-zinc-900 px-2 py-1 cursor-grab select-none"
+        {...attributes}
+        {...listeners}
+      >
+        <span className="text-sm font-semibold">{title}</span>
+        <div className="flex items-center gap-2">
+          {extraHeader}
+          <button
+            className="px-1 text-xs border border-zinc-700 rounded"
+            onClick={onToggle}
+          >
+            {collapsed ? '+' : '−'}
+          </button>
+        </div>
+      </div>
+      {!collapsed && <div className="p-2">{children}</div>}
+    </div>
+  )
+}
+
+export default function LeftSidebar() {
+  const panels: Record<PanelId, { title: string; render: () => React.ReactNode; extra?: React.ReactNode }> = {
+    pages: { title: 'Pages', render: () => <PagesPanel showHeader={false} />, extra: <AddPageButton /> },
+    palette: { title: 'パレット', render: () => <Palette /> },
+  }
+  const [order, setOrder] = React.useState<PanelId[]>(['pages', 'palette'])
+  const [collapsed, setCollapsed] = React.useState<Record<PanelId, boolean>>({
+    pages: false,
+    palette: false,
+  })
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
+
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e
+    if (!over || active.id === over.id) return
+    const oldIndex = order.indexOf(active.id as PanelId)
+    const newIndex = order.indexOf(over.id as PanelId)
+    setOrder(arrayMove(order, oldIndex, newIndex))
+  }
+
+  return (
+    <aside className="w-64 border-r border-zinc-800 bg-zinc-950/40 p-2 flex flex-col gap-2">
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <SortableContext items={order} strategy={verticalListSortingStrategy}>
+          {order.map((id) => (
+            <SortablePanel
+              key={id}
+              id={id}
+              title={panels[id].title}
+              collapsed={collapsed[id]}
+              onToggle={() =>
+                setCollapsed((c) => ({ ...c, [id]: !c[id] }))
+              }
+              extraHeader={panels[id].extra}
+            >
+              {panels[id].render()}
+            </SortablePanel>
+          ))}
+        </SortableContext>
+      </DndContext>
+    </aside>
+  )
+}
+

--- a/web/components/builder/PagesPanel.tsx
+++ b/web/components/builder/PagesPanel.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { usePageStore } from '@/store/pageStore'
 
-export function PagesPanel() {
+export function PagesPanel({ showHeader = true }: { showHeader?: boolean }) {
   const pages = usePageStore((s) => s.pages)
   const current = usePageStore((s) => s.currentPageId)
   const selectPage = usePageStore((s) => s.selectPage)
@@ -10,15 +10,17 @@ export function PagesPanel() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-2">
-        <h2 className="text-sm font-semibold">Pages</h2>
-        <button
-          className="px-1 text-xs border border-zinc-700 rounded"
-          onClick={() => addPage()}
-        >
-          +
-        </button>
-      </div>
+      {showHeader && (
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-sm font-semibold">Pages</h2>
+          <button
+            className="px-1 text-xs border border-zinc-700 rounded"
+            onClick={() => addPage()}
+          >
+            +
+          </button>
+        </div>
+      )}
       <ul className="space-y-1">
         {pages.map((p) => (
           <li key={p.id}>


### PR DESCRIPTION
## Summary
- add draggable left sidebar to reorder Pages and Palette panels
- allow collapsing layers panel and sidebar sections
- expose headerless PagesPanel for reuse
- fix MyCard props to include children and className

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c752ae18832c92c2773ee7dabd6a