### PR TITLE
feat(storage): add auto-save with IndexedDB

### DIFF
--- a/web/app/builder/layout.tsx
+++ b/web/app/builder/layout.tsx
@@ -1,3 +1,17 @@
+'use client'
+import '@/store/builderStoreHandle'
+import { SaveIndicator } from '@/components/builder/SaveIndicator'
+
 export default function BuilderLayout({ children }: { children: React.ReactNode }) {
-  return <div data-actions-enabled="true">{children}</div>
+  return (
+    <div data-actions-enabled="true">
+      <div className="w-full h-10 px-3 border-b flex items-center justify-between">
+        <div className="text-sm font-semibold">Builder</div>
+        <div className="flex items-center gap-3">
+          <SaveIndicator projectId="local" schemaVersion={1} />
+        </div>
+      </div>
+      {children}
+    </div>
+  )
 }

--- a/web/components/builder/SaveIndicator.tsx
+++ b/web/components/builder/SaveIndicator.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useRef } from 'react'
+import { useAutoSave } from '@/components/hooks/useAutoSave'
+import { loadLatest } from '@/lib/idb'
+
+type Props = { projectId: string; schemaVersion: number }
+
+export function SaveIndicator({ projectId, schemaVersion }: Props) {
+  const st = useAutoSave(projectId, schemaVersion)
+  const fileRef = useRef<HTMLInputElement | null>(null)
+
+  async function exportJson() {
+    const latest = await loadLatest(projectId)
+    const blob = new Blob([JSON.stringify(latest?.data ?? {}, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${projectId}-${Date.now()}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function importJson(file: File | null) {
+    if (!file) return
+    const txt = await file.text()
+    let data: any
+    try { data = JSON.parse(txt) } catch { return }
+    ;(window as any).useBuilderStore?.setState ? (window as any).useBuilderStore.setState({ ...(data || {}) }) : null
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span>{st.saving ? '保存中…' : st.error ? '保存エラー' : st.lastSavedAt ? '保存済み' : '待機中'}</span>
+      <button className="border rounded px-2 h-7" onClick={exportJson}>エクスポート</button>
+      <button className="border rounded px-2 h-7" onClick={()=>fileRef.current?.click()}>インポート</button>
+      <button className="border rounded px-2 h-7" onClick={()=>location.reload()}>再読み込み</button>
+      <input
+        ref={fileRef}
+        type="file"
+        accept="application/json"
+        className="hidden"
+        onChange={(e)=>importJson(e.target.files?.[0] ?? null)}
+      />
+    </div>
+  )
+}

--- a/web/components/hooks/useAutoSave.ts
+++ b/web/components/hooks/useAutoSave.ts
@@ -1,0 +1,74 @@
+'use client'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { loadLatest, saveState, addSnapshot, trimSnapshots } from '@/lib/idb'
+import { useBuilderStore } from '@/store/builderStore'
+
+type AutoSaveStatus = { saving: boolean; lastSavedAt: number | null; error: string | null }
+
+function selectSerializableState(s: any) {
+  return { tree: s.tree, components: s.components, meta: s.meta }
+}
+
+function uid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+export function useAutoSave(projectId: string, schemaVersion: number, debounceMs = 800): AutoSaveStatus {
+  const [status, setStatus] = useState<AutoSaveStatus>({ saving: false, lastSavedAt: null, error: null })
+  const subRef = useRef<() => void>()
+  const timer = useRef<any>(null)
+  const lastJson = useRef<string>('')
+
+  useEffect(() => {
+    let mounted = true
+    ;(async () => {
+      const latest = await loadLatest(projectId)
+      if (mounted && latest?.data) {
+        useBuilderStore.setState({ ...(latest.data || {}) })
+      }
+    })()
+    return () => { mounted = false }
+  }, [projectId])
+
+  const selector = useMemo(() => (s: any) => selectSerializableState(s), [])
+  useEffect(() => {
+    const unsub = useBuilderStore.subscribe(selector, async (next) => {
+      const j = JSON.stringify(next)
+      if (j === lastJson.current) return
+      lastJson.current = j
+      if (timer.current) clearTimeout(timer.current)
+      timer.current = setTimeout(async () => {
+        try {
+          setStatus(s => ({ ...s, saving: true, error: null }))
+          const payload = { schemaVersion, projectId, updatedAt: Date.now(), data: next }
+          await saveState(payload)
+          const snap: any = { id: uid(), projectId, createdAt: payload.updatedAt, data: next }
+          await addSnapshot(snap)
+          await trimSnapshots(projectId, 20, 24, 30)
+          setStatus({ saving: false, lastSavedAt: payload.updatedAt, error: null })
+        } catch (e: any) {
+          setStatus({ saving: false, lastSavedAt: status.lastSavedAt, error: e?.message || 'save failed' })
+        }
+      }, debounceMs)
+    })
+    subRef.current = unsub
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+      unsub()
+    }
+  }, [projectId, schemaVersion, debounceMs])
+
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (status.saving) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [status.saving])
+
+  return status
+}
+

--- a/web/lib/idb.ts
+++ b/web/lib/idb.ts
@@ -1,24 +1,173 @@
-import Dexie from 'dexie';
+const DB_NAME = 'ui-builder'
+const DB_VER = 1
+const STORE_STATE = 'states'
+const STORE_SNAP = 'snapshots'
+const STORE_KV = 'kv'
 
-class EditorDB extends Dexie {
-  data!: Dexie.Table<{ key: string; value: string }, string>;
-  constructor() {
-    super('uibuilder');
-    this.version(1).stores({ data: '&key' });
-  }
+export type BuilderStatePayload = {
+  schemaVersion: number
+  projectId: string
+  updatedAt: number
+  data: any
 }
 
-const db = new EditorDB();
+export type Snapshot = {
+  id: string
+  projectId: string
+  createdAt: number
+  tag?: string
+  data: any
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((res, rej) => {
+    const req = indexedDB.open(DB_NAME, DB_VER)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE_KV)) {
+        db.createObjectStore(STORE_KV, { keyPath: 'key' })
+      }
+      if (!db.objectStoreNames.contains(STORE_STATE)) {
+        db.createObjectStore(STORE_STATE, { keyPath: 'projectId' })
+      }
+      if (!db.objectStoreNames.contains(STORE_SNAP)) {
+        const s = db.createObjectStore(STORE_SNAP, { keyPath: 'id' })
+        s.createIndex('byProject', 'projectId', { unique: false })
+        s.createIndex('byProjectCreated', ['projectId', 'createdAt'], {
+          unique: false,
+        })
+      }
+    }
+    req.onsuccess = () => res(req.result)
+    req.onerror = () => rej(req.error)
+  })
+}
+
+export async function loadLatest(
+  projectId: string,
+): Promise<BuilderStatePayload | null> {
+  const db = await openDB()
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE_STATE, 'readonly')
+    const store = tx.objectStore(STORE_STATE)
+    const get = store.get(projectId)
+    get.onsuccess = () => res(get.result ?? null)
+    get.onerror = () => rej(get.error)
+  })
+}
+
+export async function saveState(payload: BuilderStatePayload): Promise<void> {
+  const db = await openDB()
+  await new Promise<void>((res, rej) => {
+    const tx = db.transaction(STORE_STATE, 'readwrite')
+    const store = tx.objectStore(STORE_STATE)
+    store.put(payload)
+    tx.oncomplete = () => res()
+    tx.onerror = () => rej(tx.error)
+  })
+}
+
+export async function addSnapshot(s: Snapshot): Promise<void> {
+  const db = await openDB()
+  await new Promise<void>((res, rej) => {
+    const tx = db.transaction(STORE_SNAP, 'readwrite')
+    tx.objectStore(STORE_SNAP).put(s)
+    tx.oncomplete = () => res()
+    tx.onerror = () => rej(tx.error)
+  })
+}
+
+export async function listSnapshots(projectId: string): Promise<Snapshot[]> {
+  const db = await openDB()
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE_SNAP, 'readonly')
+    const idx = tx.objectStore(STORE_SNAP).index('byProjectCreated')
+    const range = IDBKeyRange.bound(
+      [projectId, 0],
+      [projectId, Number.MAX_SAFE_INTEGER],
+    )
+    const out: Snapshot[] = []
+    const cur = idx.openCursor(range, 'prev')
+    cur.onsuccess = () => {
+      const c = cur.result
+      if (c) {
+        out.push(c.value as Snapshot)
+        c.continue()
+      } else {
+        res(out)
+      }
+    }
+    cur.onerror = () => rej(cur.error)
+  })
+}
+
+export async function trimSnapshots(
+  projectId: string,
+  keepLatest: number,
+  keepHours: number,
+  keepDays: number,
+): Promise<void> {
+  const snaps = await listSnapshots(projectId)
+  const latest = snaps.slice(0, keepLatest)
+  const latestIds = new Set(latest.map((s) => s.id))
+  const now = Date.now()
+  const hourly = new Map<string, Snapshot>()
+  const daily = new Map<string, Snapshot>()
+  for (const s of snaps) {
+    if (latestIds.has(s.id)) continue
+    const d = new Date(s.createdAt)
+    const hKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}`
+    const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+    if (now - s.createdAt <= keepHours * 3600_000) {
+      if (!hourly.has(hKey)) hourly.set(hKey, s)
+    } else if (now - s.createdAt <= keepDays * 86400_000) {
+      if (!daily.has(dayKey)) daily.set(dayKey, s)
+    }
+  }
+  const keep = new Set<string>([
+    ...latestIds,
+    ...Array.from(hourly.values()).map((v) => v.id),
+    ...Array.from(daily.values()).map((v) => v.id),
+  ])
+  const toDelete = snaps.filter((s) => !keep.has(s.id))
+  if (!toDelete.length) return
+  const db = await openDB()
+  await new Promise<void>((res, rej) => {
+    const tx = db.transaction(STORE_SNAP, 'readwrite')
+    const st = tx.objectStore(STORE_SNAP)
+    toDelete.forEach((s) => st.delete(s.id))
+    tx.oncomplete = () => res()
+    tx.onerror = () => rej(tx.error)
+  })
+}
 
 export const idbStorage = {
   async getItem(name: string) {
-    const row = await db.data.get(name);
-    return row?.value ?? null;
+    const db = await openDB()
+    return new Promise<string | null>((res, rej) => {
+      const tx = db.transaction(STORE_KV, 'readonly')
+      const req = tx.objectStore(STORE_KV).get(name)
+      req.onsuccess = () => res(req.result?.value ?? null)
+      req.onerror = () => rej(req.error)
+    })
   },
   async setItem(name: string, value: string) {
-    await db.data.put({ key: name, value });
+    const db = await openDB()
+    await new Promise<void>((res, rej) => {
+      const tx = db.transaction(STORE_KV, 'readwrite')
+      tx.objectStore(STORE_KV).put({ key: name, value })
+      tx.oncomplete = () => res()
+      tx.onerror = () => rej(tx.error)
+    })
   },
   async removeItem(name: string) {
-    await db.data.delete(name);
+    const db = await openDB()
+    await new Promise<void>((res, rej) => {
+      const tx = db.transaction(STORE_KV, 'readwrite')
+      tx.objectStore(STORE_KV).delete(name)
+      tx.oncomplete = () => res()
+      tx.onerror = () => rej(tx.error)
+    })
   },
-};
+}
+

--- a/web/store/builderStoreHandle.ts
+++ b/web/store/builderStoreHandle.ts
@@ -1,0 +1,6 @@
+'use client'
+import { useBuilderStore } from '@/store/builderStore'
+if (typeof window !== 'undefined') {
+  ;(window as any).useBuilderStore = useBuilderStore
+}
+


### PR DESCRIPTION
## Summary
- add IndexedDB module for builder state and snapshot rotation
- auto-save builder state with debounce and hydration hook
- show save status with export/import controls and expose store handle

## Testing
- `pnpm --filter ui-builder-web typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm --filter ui-builder-web build` *(fails: Can't resolve 'source-map-support')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d042277c832c8a00d4fc334063a8