### PR TITLE
Fix left sidebar layer scroll and remove duplicate panel

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -13,7 +13,6 @@ import { Canvas } from '@/components/builder/Canvas'
 import { Inspector } from '@/components/builder/Inspector'
 import { useBuilderStore, type Elm } from '@/store/builderStore'
 import { collectSnapPoints, snapRect } from '@/lib/builder/snap'
-import LayersPanel from '@/components/builder/LayersPanel'
 import LeftSidebar from '@/components/builder/LeftSidebar'
 import { usePageStore } from '@/store/pageStore'
 import { DeviceFrame } from '@/components/hud/DeviceFrame'
@@ -170,7 +169,6 @@ export default function BuilderPage() {
       <div className="flex h-[calc(100vh-40px)]">
         <DndContext sensors={sensors} onDragStart={onDragStart} onDragMove={onDragMove} onDragEnd={onDragEnd}>
           <LeftSidebar />
-          <LayersPanel />
           <main className="flex-1 relative">
             <DeviceFrame>
               <div className="relative w-full h-full">

--- a/web/components/builder/LayersPanel.tsx
+++ b/web/components/builder/LayersPanel.tsx
@@ -198,7 +198,6 @@ export function LayersContent() {
           ungroup(selectedIds[0])
         }
       }}
-      className="overflow-auto"
     >
       <DndContext onDragEnd={onDragEnd}>
         <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
@@ -229,7 +228,11 @@ export default function LayersPanel() {
           </button>
         </div>
       </div>
-      {!collapsed && <LayersContent />}
+      {!collapsed && (
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <LayersContent />
+        </div>
+      )}
     </aside>
   )
 }

--- a/web/components/builder/LeftSidebar.tsx
+++ b/web/components/builder/LeftSidebar.tsx
@@ -40,6 +40,8 @@ function SortablePanel({
   onToggle,
   children,
   extraHeader,
+  className,
+  contentClassName,
 }: {
   id: PanelId
   title: string
@@ -47,6 +49,8 @@ function SortablePanel({
   onToggle: () => void
   children: React.ReactNode
   extraHeader?: React.ReactNode
+  className?: string
+  contentClassName?: string
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id })
@@ -55,7 +59,11 @@ function SortablePanel({
     transition,
   }
   return (
-    <div ref={setNodeRef} style={style} className="border border-zinc-800 rounded">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`border border-zinc-800 rounded flex flex-col ${className || ''}`}
+    >
       <div
         className="flex items-center justify-between bg-zinc-900 px-2 py-1 cursor-grab select-none"
         {...attributes}
@@ -72,7 +80,9 @@ function SortablePanel({
           </button>
         </div>
       </div>
-      {!collapsed && <div className="p-2">{children}</div>}
+      {!collapsed && (
+        <div className={`p-2 ${contentClassName || ''}`}>{children}</div>
+      )}
     </div>
   )
 }
@@ -132,6 +142,8 @@ export default function LeftSidebar() {
                 setCollapsed((c) => ({ ...c, [id]: !c[id] }))
               }
               extraHeader={panels[id].extra}
+              className={id === 'layers' ? 'flex-1 min-h-0' : undefined}
+              contentClassName={id === 'layers' ? 'flex-1 min-h-0 overflow-y-auto' : undefined}
             >
               {panels[id].render()}
             </SortablePanel>


### PR DESCRIPTION
## Summary
- ensure layer list in sidebar is scrollable by flexing panel and adding overflow-y
- remove obsolete right-side LayersPanel from builder page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d7c7f3f0832ca7fa0f8c5bb510a2