### PR TITLE
feat: add onClick interactions with actions panel

### DIFF
--- a/web/components/CanvasFree.tsx
+++ b/web/components/CanvasFree.tsx
@@ -724,6 +724,8 @@ const CanvasFree: React.FC = () => {
         </div>
       </div>
     </div>
+    </div>
+  </div>
   )
 }
 

--- a/web/components/NodeRenderer.tsx
+++ b/web/components/NodeRenderer.tsx
@@ -6,6 +6,19 @@ import { registry } from '@/lib/registry.ts'
 import { resolveBinding } from '@/lib/binding/resolve'
 import { useRects } from './canvas/RectsStore'
 import { NodeWrapper } from '@/components/shared/NodeWrapper'
+import { useActionRunner } from '@/lib/actions/runActions'
+
+export function InstanceView({ inst, children }: { inst: any; children: React.ReactNode }) {
+  const run = useActionRunner()
+  const onClick = React.useCallback(
+    (e: React.MouseEvent) => {
+      if (!inst?.actions?.onClick?.length) return
+      run(inst.actions.onClick, { nodeId: inst.id })
+    },
+    [inst, run],
+  )
+  return <div onClick={onClick}>{children}</div>
+}
 
 export function NodeRenderer({ node }: { node: ComponentNode }) {
   const { selectComponent } = useEditorActions()
@@ -18,6 +31,7 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
   if (node.propValues) {
     resolvedProps = resolveBinding(resolvedProps, [], [])
   }
+
 
  
 
@@ -33,6 +47,22 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
   })
 
   const nodeName = node.name || node.props?.name
+  const rendered = (
+    <div
+      ref={ref}
+      style={{ position: 'absolute', ...style }}
+      onMouseDown={(e) => {
+        e.stopPropagation()
+        selectComponent(node.id)
+      }}
+    >
+      <Comp {...resolvedProps}>
+        {node.children?.map((child) => (
+          <NodeRenderer key={child.id} node={child} />
+        ))}
+      </Comp>
+    </div>
+  )
   return (
     <NodeWrapper
       nodeId={node.id}
@@ -43,20 +73,7 @@ export function NodeRenderer({ node }: { node: ComponentNode }) {
       hoverEffects={node.props?.hoverEffects}
       hoverTransitionMs={node.props?.hoverTransitionMs}
     >
-      <div
-        ref={ref}
-        style={{ position: 'absolute', ...style }}
-        onMouseDown={(e) => {
-          e.stopPropagation()
-          selectComponent(node.id)
-        }}
-      >
-        <Comp {...resolvedProps}>
-          {node.children?.map((child) => (
-            <NodeRenderer key={child.id} node={child} />
-          ))}
-        </Comp>
-      </div>
+      <InstanceView inst={node}>{rendered}</InstanceView>
     </NodeWrapper>
   )
 }

--- a/web/components/builder/RightSidebar.tsx
+++ b/web/components/builder/RightSidebar.tsx
@@ -1,12 +1,14 @@
 'use client'
 import React from 'react'
 import { AutoPropertyPanel } from '@/components/panel/AutoPropertyPanel'
+import { InteractionPanel } from '@/components/panel/InteractionPanel'
 import { useBuilderStore } from '@/store/builderStore'
 
 export function RightSidebar() {
   const selectedIds = useBuilderStore(s=>s.selectedIds)
   const tree = useBuilderStore(s=>s.tree as any)
   const updateProp = useBuilderStore(s=>s.updateProp as any)
+  const updateActions = useBuilderStore(s=>s.updateActions as any)
   const node = React.useMemo(()=>{
     const id = selectedIds?.[0]
     if (!id) return null
@@ -22,10 +24,16 @@ export function RightSidebar() {
   if (!node || node.type !== 'instance') return <div className="p-2 text-sm text-gray-500">No selection</div>
 
   return (
-    <AutoPropertyPanel
-      componentKey={node.componentId}
-      propValues={node.propValues}
-      onChange={(k,v)=>updateProp(node.id, k, v)}
-    />
+    <div className="flex flex-col gap-4">
+      <AutoPropertyPanel
+        componentKey={node.componentId}
+        propValues={node.propValues}
+        onChange={(k,v)=>updateProp(node.id, k, v)}
+      />
+      <InteractionPanel
+        value={node.actions}
+        onChange={(v)=>updateActions(node.id, v)}
+      />
+    </div>
   )
 }

--- a/web/components/panel/InteractionPanel.tsx
+++ b/web/components/panel/InteractionPanel.tsx
@@ -1,0 +1,68 @@
+'use client'
+import React from 'react'
+import type { Action, ActionMap } from '@/types/actions'
+
+type Props = {
+  value: ActionMap | undefined
+  onChange: (v: ActionMap) => void
+}
+
+function ActionRow({ a, onChange, onDelete }: { a: Action; onChange: (na: Action)=>void; onDelete: ()=>void }) {
+  if (a.type === 'openUrl') {
+    return (
+      <div className="grid grid-cols-5 gap-2 items-center">
+        <span className="text-xs">openUrl</span>
+        <input className="col-span-3 border p-1 rounded text-sm" placeholder="https://example.com" value={a.url} onChange={(e)=>onChange({ ...a, url: e.target.value })} />
+        <select className="border p-1 rounded text-sm" value={a.target || '_self'} onChange={(e)=>onChange({ ...a, target: e.target.value as any })}>
+          <option value="_self">_self</option>
+          <option value="_blank">_blank</option>
+        </select>
+        <button className="border rounded px-2 h-7" onClick={onDelete}>Del</button>
+      </div>
+    )
+  }
+  if (a.type === 'navigate') {
+    return (
+      <div className="grid grid-cols-5 gap-2 items-center">
+        <span className="text-xs">navigate</span>
+        <input className="col-span-3 border p-1 rounded text-sm" placeholder="/about" value={a.path} onChange={(e)=>onChange({ ...a, path: e.target.value })} />
+        <div />
+        <button className="border rounded px-2 h-7" onClick={onDelete}>Del</button>
+      </div>
+    )
+  }
+  return null
+}
+
+export function InteractionPanel({ value, onChange }: Props) {
+  const list = value?.onClick ?? []
+  function add(kind: 'openUrl'|'navigate') {
+    const a: Action = kind === 'openUrl' ? { type: 'openUrl', url: '', target: '_self' } : { type: 'navigate', path: '/' }
+    onChange({ onClick: [...list, a] })
+  }
+  return (
+    <div className="space-y-2 p-2">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-gray-500">Interactions: onClick</div>
+        <div className="flex items-center gap-1">
+          <button className="border rounded px-2 h-7" onClick={()=>add('openUrl')}>+ openUrl</button>
+          <button className="border rounded px-2 h-7" onClick={()=>add('navigate')}>+ navigate</button>
+        </div>
+      </div>
+      {list.length === 0 ? (
+        <div className="text-xs text-gray-500">No actions</div>
+      ) : (
+        <div className="space-y-2">
+          {list.map((a, i)=>(
+            <ActionRow
+              key={i}
+              a={a}
+              onChange={(na)=>onChange({ onClick: list.map((x,idx)=> idx===i ? na : x) })}
+              onDelete={()=>onChange({ onClick: list.filter((_,idx)=> idx!==i) })}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/lib/actions/runActions.ts
+++ b/web/lib/actions/runActions.ts
@@ -1,0 +1,22 @@
+'use client'
+import { Action, ActionContext } from '@/types/actions'
+import { useRouter } from 'next/navigation'
+import React from 'react'
+
+export function useActionRunner() {
+  const router = useRouter()
+  return React.useCallback(async (actions: Action[] | undefined, ctx: ActionContext) => {
+    if (!actions || actions.length === 0) return
+    const gate = document.querySelector('[data-actions-enabled="true"]')
+    if (!gate) return
+    for (const a of actions) {
+      if (a.type === 'openUrl') {
+        const t = a.target || '_self'
+        if (t === '_blank') window.open(a.url, '_blank', 'noopener,noreferrer')
+        else location.assign(a.url)
+      } else if (a.type === 'navigate') {
+        router.push(a.path)
+      }
+    }
+  }, [router])
+}

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -6,6 +6,7 @@ import { parseValue } from '@/lib/builder/docgen'
 import { registry, getDef, type RegistryKey } from '@/lib/registry.ts'
 import { useGridStore } from '@/store/gridStore'
 import { useHistoryStore } from './historyStore'
+import type { ActionMap } from '@/types/actions'
 
 export type ElmType = RegistryKey | 'code'
 
@@ -42,6 +43,7 @@ export type Elm = {
     exportName?: string
     props: Record<string, unknown>
   }
+  actions?: ActionMap
 }
 
 export type ElmPatch = { id: string; x?: number; y?: number; w?: number; h?: number; props?: any }
@@ -91,6 +93,7 @@ type BuilderActions = {
     patch: Partial<Elm['props']> & { code?: Partial<Elm['code']> },
   ) => void
   updateProp: (nodeId: string, key: string, value: any) => void,
+  updateActions: (nodeId: string, map: ActionMap) => void,
   reorder: (idsInOrder: string[]) => void
   reorderWithinParent: (parentId: string | null, orderedIds: string[]) => void
   setVisible: (id: string, v: boolean) => void
@@ -444,6 +447,20 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
             if (c) stack.push(c)
           })
         }
+      }
+    })
+  },
+  updateActions(nodeId, map) {
+    apply((draft: BuilderState) => {
+      const q: any[] = draft.tree.slice()
+      while (q.length) {
+        const n = q.pop()
+        if (!n) continue
+        if (n.id === nodeId) {
+          ;(n as any).actions = map
+          break
+        }
+        if ((n as any).children) q.push(...(n as any).children)
       }
     })
   },

--- a/web/types/actions.ts
+++ b/web/types/actions.ts
@@ -1,0 +1,5 @@
+export type OpenUrlAction = { type: 'openUrl'; url: string; target?: '_self' | '_blank' }
+export type NavigateAction = { type: 'navigate'; path: string }
+export type Action = OpenUrlAction | NavigateAction
+export type ActionMap = { onClick?: Action[] }
+export type ActionContext = { nodeId: string }


### PR DESCRIPTION
## Summary
- define simple action types and runner
- support updating node actions in builder store
- add onClick InteractionPanel and mount it in right sidebar
- run actions on node click via InstanceView gate check
- fix missing closing tags in CanvasFree

## Testing
- `pnpm -C web exec tsc --noEmit` *(fails: numerous TS errors across project)*
- `pnpm -C web build` *(fails: module and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dac29578832c9a2698dcbcbdcc69