### PR TITLE
fix: restore header and footer palette items

### DIFF
--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -1,15 +1,8 @@
-import type { ComponentType } from 'react'
-import type { BuilderMeta } from '@/types/propertySchema'
-import { Button } from '@/components/domain/Button'
-import { Text } from '@/components/domain/Text'
-import { BUTTON_META } from '@/components/domain/meta/buttonMeta'
-import { TEXT_META } from '@/components/domain/meta/textMeta'
+import { registry } from './registry.tsx'
 
-export type ComponentDef = { key: string; cmp: ComponentType<any>; meta: BuilderMeta }
-export const REGISTRY: Record<string, ComponentDef> = {
-  'ui.button': { key: 'ui.button', cmp: Button, meta: BUTTON_META },
-  'ui.text': { key: 'ui.text', cmp: Text, meta: TEXT_META },
+export { registry }
+export type Registry = typeof registry
+export type RegistryKey = keyof Registry
+export function getDef(key: RegistryKey): any {
+  return (registry as any)[key]
 }
-export const registry = REGISTRY
-export type RegistryKey = keyof typeof REGISTRY
-export function getDef(key: RegistryKey) { return REGISTRY[key] }

--- a/web/lib/registry.tsx
+++ b/web/lib/registry.tsx
@@ -63,13 +63,13 @@ const ContainerMeta: BuilderNodeMeta = {
 }
 
 export const registry = {
-  button:   { Comp: Button,   meta: ButtonMeta },
-  container:{ Comp: Container,meta: ContainerMeta },
-  text:     { Comp: Text,     meta: TextMeta },
-  header: { Comp: Header, meta: HeaderMeta },
-  footer: { Comp: Footer, meta: FooterMeta },
-  sidebar: { Comp: Sidebar, meta: SidebarMeta },
-  hud: { Comp: Hud, meta: HudMeta },
+  button:   { cmp: Button,   meta: ButtonMeta },
+  container:{ cmp: Container,meta: ContainerMeta },
+  text:     { cmp: Text,     meta: TextMeta },
+  header:   { cmp: Header,   meta: HeaderMeta },
+  footer:   { cmp: Footer,   meta: FooterMeta },
+  sidebar:  { cmp: Sidebar,  meta: SidebarMeta },
+  hud:      { cmp: Hud,      meta: HudMeta },
 } as const
 
 export type Registry = typeof registry

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 import { produce, produceWithPatches } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
-import { registry, getDef, type RegistryKey } from '@/lib/registry.ts'
+import { registry, type RegistryKey } from '@/lib/registry.ts'
 import { useGridStore } from '@/store/gridStore'
 import { useHistoryStore } from './historyStore'
 import type { ActionMap } from '@/types/actions'
@@ -129,11 +129,15 @@ function defaultSize(type: ElmType): { w: number; h: number; text?: string } {
 }
 
 function defaultsFor(key: string) {
-  const meta = getDef(key as any).meta
+  const meta = (registry as any)[key]?.meta
   const o: Record<string, any> = {}
-  meta.propertySchema.forEach(d => {
-    if (typeof d.default !== 'undefined') o[d.id] = d.default
-  })
+  const schema = meta?.propertySchema
+  if (schema?.kind === 'object') {
+    Object.entries(schema.properties).forEach(([k, v]) => {
+      const def = v as any
+      if (typeof def.default !== 'undefined') o[k] = def.default
+    })
+  }
   return o
 }
 


### PR DESCRIPTION
## Summary
- ensure registry exposes header, footer, sidebar, and hud components for the builder palette
- re-export new registry for existing imports
- handle default prop extraction with the new schema format

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dc9a8dc0832c9ee76ab31234c2c7