### PR TITLE
feat: add instance-like preview renderer with variant and override support

### DIFF
--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -1,4 +1,7 @@
 'use client';
+import { useBuilderStore } from '@/store/builderStore';
+import { NodeRendererCompat } from '@/components/NodeRendererCompat';
+import { ENABLE_UNIFIED_PREVIEW } from '@/lib/flags';
 import { useEditorStore } from '@/store/editorStore';
 import type { ComponentNode, InstanceNode } from '@/types/editor';
 import { resolveVariant } from '@/lib/variantResolver';
@@ -50,6 +53,16 @@ function renderNode(
 }
 
 export default function PreviewPage() {
+  const elements = useBuilderStore((s) => s.elements);
+  if (ENABLE_UNIFIED_PREVIEW) {
+    return (
+      <div data-actions-enabled="true" className="w-full h-screen relative">
+        {elements.filter((e: any) => !e.parentId).map((n: any) => (
+          <NodeRendererCompat key={String(n.id)} node={n} />
+        ))}
+      </div>
+    );
+  }
   const tree = useEditorStore((s) => s.tree);
   const components = useEditorStore((s) => s.components);
   const sources = useBindingStore((s) => s.sources);

--- a/web/components/NodeRendererCompat.tsx
+++ b/web/components/NodeRendererCompat.tsx
@@ -1,0 +1,26 @@
+'use client'
+import React from 'react'
+import { toInstanceLike } from '@/lib/legacyAdapter'
+import { resolveProps } from '@/lib/resolveProps'
+import type { InstanceLike } from '@/types/instanceLike'
+import { getDef } from '@/lib/registry'
+import { NodeWrapper } from '@/components/shared/NodeWrapper'
+import { useActionRunner } from '@/lib/actions/runActions'
+
+export function NodeRendererCompat({ node }: { node: any }) {
+  const inst: InstanceLike = toInstanceLike(node)
+  const def = getDef(inst.componentId as any) as any
+  if (!def?.cmp) return null
+  const run = useActionRunner()
+  const props = resolveProps({ defDefault: def.defaultProps, variants: def.variants, inst })
+  const Cmp = def.cmp
+  const onClick = inst.actions?.onClick?.length ? () => run(inst.actions?.onClick, { nodeId: inst.id }) : undefined
+  return (
+    <NodeWrapper nodeId={inst.id} nodeType={def.key || inst.componentId} nodeName={inst.name} presetId={undefined}>
+      <div style={{ position: 'absolute', left: inst.x ?? 0, top: inst.y ?? 0, width: inst.w ?? undefined, height: inst.h ?? undefined }} onClick={onClick}>
+        <Cmp {...props} />
+        {Array.isArray(inst.children) && inst.children.map((ch:any)=><NodeRendererCompat key={String(ch.id)} node={ch} />)}
+      </div>
+    </NodeWrapper>
+  )
+}

--- a/web/components/builder/RightSidebar.tsx
+++ b/web/components/builder/RightSidebar.tsx
@@ -1,39 +1,30 @@
 'use client'
 import React from 'react'
+import { VariantPanelCompat } from '@/components/panel/VariantPanelCompat'
+import { OverridePanelCompat } from '@/components/panel/OverridePanelCompat'
 import { AutoPropertyPanel } from '@/components/panel/AutoPropertyPanel'
 import { InteractionPanel } from '@/components/panel/InteractionPanel'
 import { useBuilderStore } from '@/store/builderStore'
 
 export function RightSidebar() {
   const selectedIds = useBuilderStore(s=>s.selectedIds)
-  const tree = useBuilderStore(s=>s.tree as any)
+  const elements = useBuilderStore(s=>s.elements as any)
   const updateProp = useBuilderStore(s=>s.updateProp as any)
   const updateActions = useBuilderStore(s=>s.updateActions as any)
+  const setMeta = useBuilderStore(s=>s.setMeta as any)
   const node = React.useMemo(()=>{
     const id = selectedIds?.[0]
     if (!id) return null
-    const q: any[] = [...(tree||[])]
-    while (q.length) {
-      const n: any = q.shift()
-      if (n?.id === id) return n
-      if (n?.children) q.push(...n.children)
-    }
-    return null
-  }, [selectedIds, tree])
-
-  if (!node || node.type !== 'instance') return <div className="p-2 text-sm text-gray-500">No selection</div>
-
+    return (elements as any[]).find(e=>e.id===id) || null
+  }, [selectedIds, elements])
+  if (!node) return <div className="p-2 text-sm text-gray-500">No selection</div>
+  const meta = (node.meta || {}) as any
   return (
     <div className="flex flex-col gap-4">
-      <AutoPropertyPanel
-        componentKey={node.componentId}
-        propValues={node.propValues}
-        onChange={(k,v)=>updateProp(node.id, k, v)}
-      />
-      <InteractionPanel
-        value={node.actions}
-        onChange={(v)=>updateActions(node.id, v)}
-      />
+      <VariantPanelCompat componentKey={String(node.componentId || node.type)} value={meta.variant ?? null} onChange={(v)=>setMeta(node.id, { ...meta, variant: v })} />
+      <AutoPropertyPanel componentKey={String(node.componentId || node.type)} propValues={node.propValues} onChange={(k,v)=>updateProp(node.id, k, v)} />
+      <OverridePanelCompat value={meta.overrides} onChange={(v)=>setMeta(node.id, { ...meta, overrides: v })} />
+      <InteractionPanel value={node.actions} onChange={(v)=>updateActions(node.id, v)} />
     </div>
   )
 }

--- a/web/components/panel/OverridePanelCompat.tsx
+++ b/web/components/panel/OverridePanelCompat.tsx
@@ -1,0 +1,52 @@
+'use client'
+import React from 'react'
+import type { OverrideOp } from '@/types/instanceLike'
+
+export function OverridePanelCompat({ value, onChange }: { value?: OverrideOp[]; onChange:(v:OverrideOp[])=>void }) {
+  const list = value ?? []
+  function add(op: OverrideOp) { onChange([...(list||[]), op]) }
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-gray-500">Overrides</div>
+        <div className="flex gap-1">
+          <button className="border rounded px-2 h-7" onClick={()=>add({ op:'setProp', path:'className', value:'' })}>+ setProp</button>
+          <button className="border rounded px-2 h-7" onClick={()=>add({ op:'mergeStyle', value:{} })}>+ style</button>
+          <button className="border rounded px-2 h-7" onClick={()=>add({ op:'appendClass', value:'' })}>+ class</button>
+        </div>
+      </div>
+      <div className="space-y-2">
+        {list.length===0 ? <div className="text-xs text-gray-500">No overrides</div> : list.map((op,i)=>(
+          <div key={i} className="grid grid-cols-5 gap-2 items-center">
+            <select className="border p-1 rounded text-sm" value={op.op} onChange={(e)=>{
+              const t = e.target.value as OverrideOp['op']
+              const next: OverrideOp = t==='setProp' ? { op:'setProp', path:'', value:'' } : t==='mergeStyle' ? { op:'mergeStyle', value:{} } : { op:'appendClass', value:'' }
+              onChange(list.map((x,idx)=> idx===i ? next : x))
+            }}>
+              <option value="setProp">setProp</option>
+              <option value="mergeStyle">mergeStyle</option>
+              <option value="appendClass">appendClass</option>
+            </select>
+            {op.op==='setProp' && (
+              <>
+                <input className="col-span-2 border p-1 rounded text-sm" placeholder="path" value={(op as any).path||''} onChange={(e)=>onChange(list.map((x,idx)=> idx===i ? { ...op, path:e.target.value } : x))} />
+                <input className="col-span-2 border p-1 rounded text-sm" placeholder="value (json)" defaultValue={JSON.stringify((op as any).value ?? '')} onBlur={(e)=>{
+                  try { onChange(list.map((x,idx)=> idx===i ? { ...op, value: JSON.parse(e.target.value) } : x)) } catch {}
+                }} />
+              </>
+            )}
+            {op.op==='mergeStyle' && (
+              <input className="col-span-4 border p-1 rounded text-sm" placeholder='{"background":"#000"}' defaultValue={JSON.stringify((op as any).value||{})} onBlur={(e)=>{
+                try { onChange(list.map((x,idx)=> idx===i ? { ...op, value: JSON.parse(e.target.value) } : x)) } catch {}
+              }} />
+            )}
+            {op.op==='appendClass' && (
+              <input className="col-span-4 border p-1 rounded text-sm" placeholder="class names" value={(op as any).value||''} onChange={(e)=>onChange(list.map((x,idx)=> idx===i ? { ...op, value:e.target.value } : x))} />
+            )}
+            <button className="border rounded px-2 h-7" onClick={()=>onChange(list.filter((_,idx)=>idx!==i))}>Del</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/components/panel/VariantPanelCompat.tsx
+++ b/web/components/panel/VariantPanelCompat.tsx
@@ -1,0 +1,17 @@
+'use client'
+import React from 'react'
+import { getDef } from '@/lib/registry'
+
+export function VariantPanelCompat({ componentKey, value, onChange }: { componentKey: string; value?: string|null; onChange:(v:string|null)=>void }) {
+  const def = getDef(componentKey as any) as any
+  const list = def?.variants ?? []
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-semibold text-gray-500">Variant</div>
+      <select className="w-full border p-1 rounded text-sm" value={value ?? ''} onChange={(e)=>onChange(e.target.value || null)}>
+        <option value="">(none)</option>
+        {list.map((v:any)=><option key={v.id} value={v.id}>{v.label}</option>)}
+      </select>
+    </div>
+  )
+}

--- a/web/lib/flags.ts
+++ b/web/lib/flags.ts
@@ -1,1 +1,2 @@
 export const ENABLE_DYNAMIC_ELM_IMPORT = false
+export const ENABLE_UNIFIED_PREVIEW = true

--- a/web/lib/legacyAdapter.ts
+++ b/web/lib/legacyAdapter.ts
@@ -1,0 +1,24 @@
+import type { InstanceLike, OverrideOp } from '@/types/instanceLike'
+
+export function toInstanceLike(n: any): InstanceLike {
+  const meta = (n.meta || {}) as any
+  const actions = (n.actions || meta.actions || undefined) as any
+  const variant = (n.variant ?? meta.variant ?? null) as string | null
+  const overrides = (n.overrides ?? meta.overrides ?? undefined) as OverrideOp[] | undefined
+  return {
+    id: String(n.id),
+    componentId: String(n.componentId || n.type || n.key || n.code?.key || ''),
+    props: n.props || {},
+    propValues: n.propValues || {},
+    variant,
+    overrides,
+    actions,
+    x: typeof n.x === 'number' ? n.x : undefined,
+    y: typeof n.y === 'number' ? n.y : undefined,
+    w: typeof n.w === 'number' ? n.w : undefined,
+    h: typeof n.h === 'number' ? n.h : undefined,
+    name: n.name,
+    parentId: n.parentId ?? null,
+    children: Array.isArray(n.children) ? n.children : [],
+  }
+}

--- a/web/lib/ovr.ts
+++ b/web/lib/ovr.ts
@@ -1,0 +1,23 @@
+import type { OverrideOp } from '@/types/instanceLike'
+
+function setDeep(obj: any, path: string, value: any) {
+  const keys = path.split('.')
+  let cur = obj
+  for (let i=0;i<keys.length-1;i++) {
+    const k = keys[i]
+    if (cur[k] == null || typeof cur[k] !== 'object') cur[k] = {}
+    cur = cur[k]
+  }
+  cur[keys[keys.length-1]] = value
+}
+
+export function applyOverrides(baseProps: any, ops: OverrideOp[] | undefined) {
+  if (!ops?.length) return baseProps
+  const out = { ...(baseProps||{}) }
+  for (const op of ops) {
+    if (op.op === 'setProp') setDeep(out, op.path, op.value)
+    else if (op.op === 'mergeStyle') out.style = { ...(out.style||{}), ...(op.value||{}) }
+    else if (op.op === 'appendClass') out.className = [out.className, op.value].filter(Boolean).join(' ')
+  }
+  return out
+}

--- a/web/lib/registry.tsx
+++ b/web/lib/registry.tsx
@@ -63,9 +63,25 @@ const ContainerMeta: BuilderNodeMeta = {
 }
 
 export const registry = {
-  button:   { cmp: Button,   meta: ButtonMeta },
-  container:{ cmp: Container,meta: ContainerMeta },
-  text:     { cmp: Text,     meta: TextMeta },
+  button: {
+    cmp: Button,
+    meta: ButtonMeta,
+    defaultProps: { text: 'Button', variant: 'solid', color: '#2563eb' },
+    variants: [
+      { id: 'solid', label: 'Solid', props: { variant: 'solid' } },
+      { id: 'ghost', label: 'Ghost', props: { variant: 'ghost' } },
+    ],
+  },
+  container: { cmp: Container, meta: ContainerMeta },
+  text: {
+    cmp: Text,
+    meta: TextMeta,
+    defaultProps: { text: 'Text', color: '#e5e7eb', size: 14 },
+    variants: [
+      { id: 'body', label: 'Body', props: { size: 14 } },
+      { id: 'title', label: 'Title', props: { size: 24 } },
+    ],
+  },
   header:   { cmp: Header,   meta: HeaderMeta },
   footer:   { cmp: Footer,   meta: FooterMeta },
   sidebar:  { cmp: Sidebar,  meta: SidebarMeta },

--- a/web/lib/resolveProps.ts
+++ b/web/lib/resolveProps.ts
@@ -1,0 +1,37 @@
+import type { InstanceLike, VariantDef } from '@/types/instanceLike'
+import { applyOverrides } from '@/lib/ovr'
+
+export type BindingValue = { source: 'data'; path: string }
+
+function isBinding(v: any): v is BindingValue {
+  return v && typeof v === 'object' && v.source === 'data' && typeof v.path === 'string'
+}
+
+function resolveBinding(props: any) {
+  const walk = (val: any): any => {
+    if (Array.isArray(val)) return val.map(walk)
+    if (isBinding(val)) return undefined
+    if (val && typeof val === 'object') {
+      const out: any = {}
+      for (const k of Object.keys(val)) out[k] = walk(val[k])
+      return out
+    }
+    return val
+  }
+  return walk(props)
+}
+
+export function resolveProps(opts: {
+  defDefault?: Record<string, any>
+  variants?: VariantDef[]
+  inst: InstanceLike
+}) {
+  const base = { ...(opts.defDefault||{}) }
+  const variant = opts.inst.variant ? (opts.variants||[]).find(v=>v.id===opts.inst.variant) : undefined
+  let merged = { ...base, ...(variant?.props||{}), ...(opts.inst.props||{}), ...(opts.inst.propValues||{}) }
+  if (variant?.className) merged.className = [merged.className, variant.className].filter(Boolean).join(' ')
+  if (variant?.style) merged.style = { ...(merged.style||{}), ...variant.style }
+  merged = applyOverrides(merged, opts.inst.overrides)
+  merged = resolveBinding(merged)
+  return merged
+}

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -94,6 +94,7 @@ type BuilderActions = {
   ) => void
   updateProp: (nodeId: string, key: string, value: any) => void,
   updateActions: (nodeId: string, map: ActionMap) => void,
+  setMeta: (id: string, meta: any) => void,
   reorder: (idsInOrder: string[]) => void
   reorderWithinParent: (parentId: string | null, orderedIds: string[]) => void
   setVisible: (id: string, v: boolean) => void
@@ -466,6 +467,15 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
         }
         if ((n as any).children) q.push(...(n as any).children)
       }
+    })
+  },
+
+  setMeta(id, meta) {
+    set((s) => {
+      const els = s.elements.slice()
+      const n: any = els.find((e: any) => e.id === id)
+      if (n) n.meta = meta
+      return { elements: els }
     })
   },
 

--- a/web/types/instanceLike.ts
+++ b/web/types/instanceLike.ts
@@ -1,0 +1,20 @@
+export type VariantDef = { id: string; label: string; props?: Record<string, any>; className?: string; style?: React.CSSProperties }
+export type OverrideOp = { op: 'setProp'; path: string; value: any } | { op: 'mergeStyle'; value: React.CSSProperties } | { op: 'appendClass'; value: string }
+export type Action = { type: 'openUrl'; url: string; target?: '_self'|'_blank' } | { type: 'navigate'; path: string }
+export type ActionMap = { onClick?: Action[] }
+export type InstanceLike = {
+  id: string
+  componentId: string
+  props?: Record<string, any>
+  propValues?: Record<string, any>
+  variant?: string | null
+  overrides?: OverrideOp[]
+  actions?: ActionMap
+  x?: number
+  y?: number
+  w?: number
+  h?: number
+  name?: string
+  parentId?: string | null
+  children?: any[]
+}


### PR DESCRIPTION
## Summary
- introduce InstanceLike types and override resolution
- adapt legacy nodes via NodeRendererCompat and enable unified preview
- add variant/override panels and registry entries for Button/Text

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dea32e00832c82bafe7155e19664