### PR TITLE
feat: add StatusCenter HUD with GitHub PR and deploy status

### DIFF
--- a/web/app/api/gh/pr-status/route.ts
+++ b/web/app/api/gh/pr-status/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { getOctokit, GH_OWNER, GH_REPO } from '@/lib/gh/octokit'
+
+type Req = { prNumber: number }
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as Req
+    if (!body?.prNumber) return NextResponse.json({ error: 'prNumber required' }, { status: 400 })
+    const oc = getOctokit()
+    const pr = await oc.rest.pulls.get({ owner: GH_OWNER, repo: GH_REPO, pull_number: body.prNumber })
+    const headSha = pr.data.head.sha
+    const checks = await oc.rest.checks.listForRef({ owner: GH_OWNER, repo: GH_REPO, ref: headSha, per_page: 100 })
+    return NextResponse.json({
+      number: pr.data.number,
+      state: pr.data.state,
+      merged: pr.data.merged,
+      headSha,
+      htmlUrl: pr.data.html_url,
+      checks: checks.data.check_runs.map(r => ({
+        name: r.name,
+        status: r.status,
+        conclusion: r.conclusion,
+        htmlUrl: r.html_url,
+        startedAt: r.started_at,
+        completedAt: r.completed_at,
+      })),
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 })
+  }
+}

--- a/web/app/api/gh/workflow-runs/route.ts
+++ b/web/app/api/gh/workflow-runs/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { getOctokit, GH_OWNER, GH_REPO } from '@/lib/gh/octokit'
+
+type Req = { workflowId?: string; per_page?: number }
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as Req
+    const oc = getOctokit()
+    const workflow_id = body.workflowId || 'Deploy.yml'
+    const per_page = body.per_page || 5
+    const runs = await oc.rest.actions.listWorkflowRuns({
+      owner: GH_OWNER,
+      repo: GH_REPO,
+      workflow_id,
+      per_page,
+    })
+    return NextResponse.json({
+      total: runs.data.total_count,
+      items: runs.data.workflow_runs.map(r => ({
+        id: r.id,
+        status: r.status,
+        conclusion: r.conclusion,
+        event: r.event,
+        url: r.html_url,
+        headBranch: r.head_branch,
+        headSha: r.head_sha,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      })),
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 })
+  }
+}

--- a/web/app/builder/layout.tsx
+++ b/web/app/builder/layout.tsx
@@ -5,6 +5,8 @@ import { AlignToolbar } from '@/components/builder/AlignToolbar'
 import { useAlignShortcuts } from '@/components/hooks/useAlignShortcuts'
 import { ShareMenu } from '@/components/builder/ShareMenu'
 import ReflectDeployMenu from '@/components/builder/ReflectDeployMenu'
+import ProjectMetaMenu from '@/components/builder/ProjectMetaMenu'
+import StatusCenter from '@/components/hud/StatusCenter'
 import ErrorBoundary from '@/components/hud/ErrorBoundary'
 import DevConsoleHUD from '@/components/hud/DevConsoleHUD'
 
@@ -12,20 +14,19 @@ export default function BuilderLayout({ children }: { children: React.ReactNode 
   useAlignShortcuts()
   return (
     <div data-actions-enabled="true" suppressHydrationWarning>
-      <div className="w-full h-10 px-3 border-b flex items-center justify-between">
-        <div className="text-sm font-semibold">Builder</div>
-        <div className="flex items-center gap-3">
-          <ShareMenu />
-          <ReflectDeployMenu />
-          <AlignToolbar />
-          <SaveIndicator projectId="local" schemaVersion={1} />
-        </div>
+      <div className="w-full h-10 px-3 border-b flex items-center gap-3">
+        <div className="text-sm font-semibold mr-auto">Builder</div>
+        <ProjectMetaMenu />
+        <ShareMenu />
+        <ReflectDeployMenu />
+        <AlignToolbar />
+        <SaveIndicator projectId="local" schemaVersion={1} />
       </div>
       <ErrorBoundary>
         {children}
       </ErrorBoundary>
+      <StatusCenter />
       {process.env.NODE_ENV !== 'production' && <DevConsoleHUD />}
     </div>
   )
 }
-

--- a/web/components/builder/ProjectMetaMenu.tsx
+++ b/web/components/builder/ProjectMetaMenu.tsx
@@ -1,0 +1,20 @@
+'use client'
+import React, { useState } from 'react'
+import { useBuilderStore } from '@/store/builderStore'
+
+export default function ProjectMetaMenu() {
+  const meta = useBuilderStore(s => (s as any).meta || { id: 'local', name: 'Local Project' })
+  const setElements = useBuilderStore(s => s.setElements)
+  const [id, setId] = useState<string>(meta.id || 'local')
+  const [name, setName] = useState<string>(meta.name || 'Local Project')
+  function apply() {
+    useBuilderStore.setState({ elements: useBuilderStore.getState().elements, meta: { id, name } })
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <input className="border rounded h-7 px-2 w-32 text-xs" value={id} onChange={(e)=>setId(e.target.value)} placeholder="project id" />
+      <input className="border rounded h-7 px-2 w-40 text-xs" value={name} onChange={(e)=>setName(e.target.value)} placeholder="project name" />
+      <button className="border rounded px-2 h-7" onClick={apply}>Apply</button>
+    </div>
+  )
+}

--- a/web/components/builder/ReflectDeployMenu.tsx
+++ b/web/components/builder/ReflectDeployMenu.tsx
@@ -1,11 +1,14 @@
 'use client'
 import React, { useState } from 'react'
 import { useBuilderStore } from '@/store/builderStore'
+import { useStatusCenter } from '@/store/statusCenterStore'
 
 export default function ReflectDeployMenu() {
   const state = useBuilderStore(s => ({ elements: s.elements, meta: (s as any).meta || { id: 'local', name: 'Local Project' } }))
   const [busy, setBusy] = useState<'reflect'|'deploy'|null>(null)
   const [msg, setMsg] = useState<string>('')
+  const setLastPr = useStatusCenter(s=>s.setLastPr)
+  const toggle = useStatusCenter(s=>s.toggle)
 
   async function reflect() {
     try {
@@ -19,6 +22,8 @@ export default function ReflectDeployMenu() {
       const j = await res.json()
       if (!res.ok) throw new Error(j?.error || 'reflect failed')
       setMsg(j.prUrl || 'PR created')
+      if (j.prNumber) setLastPr(j.prNumber, j.prUrl)
+      toggle(true)
     } catch (e: any) {
       setMsg(String(e?.message || e))
     } finally {
@@ -34,6 +39,7 @@ export default function ReflectDeployMenu() {
       const j = await res.json()
       if (!res.ok) throw new Error(j?.error || 'deploy failed')
       setMsg('Deploy started')
+      toggle(true)
     } catch (e: any) {
       setMsg(String(e?.message || e))
     } finally {

--- a/web/components/hud/StatusCenter.tsx
+++ b/web/components/hud/StatusCenter.tsx
@@ -1,0 +1,77 @@
+'use client'
+import React, { useEffect } from 'react'
+import { useStatusCenter } from '@/store/statusCenterStore'
+
+export default function StatusCenter() {
+  const open = useStatusCenter(s=>s.open)
+  const toggle = useStatusCenter(s=>s.toggle)
+  const busy = useStatusCenter(s=>s.busy)
+  const pr = useStatusCenter(s=>s.pr)
+  const runs = useStatusCenter(s=>s.runs)
+  const lastPrNumber = useStatusCenter(s=>s.lastPrNumber)
+  const lastPrUrl = useStatusCenter(s=>s.lastPrUrl)
+  const fetchPr = useStatusCenter(s=>s.fetchPr)
+  const fetchRuns = useStatusCenter(s=>s.fetchRuns)
+
+  useEffect(() => {
+    if (!open) return
+    const t = setInterval(() => {
+      if (lastPrNumber) fetchPr(lastPrNumber)
+      fetchRuns()
+    }, 10000)
+    return () => clearInterval(t)
+  }, [open, lastPrNumber, fetchPr, fetchRuns])
+
+  if (!open) return null
+  return (
+    <div className="fixed right-2 top-12 z-[9997] w-[520px] max-h-[70vh] bg-zinc-900/95 border border-zinc-700 rounded-lg overflow-hidden text-sm">
+      <div className="h-9 px-2 border-b border-zinc-700 flex items-center gap-2">
+        <div className="font-semibold">Status Center</div>
+        <div className="ml-auto flex items-center gap-2">
+          <button className="border rounded h-7 px-2" onClick={()=>{ if (lastPrNumber) fetchPr(lastPrNumber) }}>Refresh PR</button>
+          <button className="border rounded h-7 px-2" onClick={fetchRuns}>Refresh Runs</button>
+          <button className="border rounded h-7 px-2" onClick={()=>toggle(false)}>Close</button>
+        </div>
+      </div>
+      <div className="p-3 space-y-3 overflow-auto">
+        <div>
+          <div className="text-xs opacity-70 mb-1">Pull Request</div>
+          {lastPrNumber ? (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <a className="underline" href={lastPrUrl} target="_blank" rel="noreferrer">PR #{lastPrNumber}</a>
+                <span className="text-xs opacity-70">{pr?.state}{pr?.merged ? ' (merged)' : ''}</span>
+              </div>
+              <div className="text-xs opacity-70">HEAD {pr?.headSha?.slice(0,7)}</div>
+              <div className="space-y-1">
+                {(pr?.checks||[]).map((c,i)=>(
+                  <div key={i} className="flex items-center gap-2">
+                    <span className="w-28 truncate">{c.name}</span>
+                    <span className="text-xs">{c.status}{c.conclusion ? ` / ${c.conclusion}` : ''}</span>
+                    {c.htmlUrl ? <a className="text-xs underline" href={c.htmlUrl} target="_blank" rel="noreferrer">details</a> : null}
+                  </div>
+                ))}
+                {(!pr?.checks || pr.checks.length===0) && <div className="text-xs opacity-70">No checks</div>}
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs opacity-70">No PR yet</div>
+          )}
+        </div>
+        <div>
+          <div className="text-xs opacity-70 mb-1">Deploy Workflow Runs</div>
+          <div className="space-y-1">
+            {(runs?.items||[]).map(it=>(
+              <div key={it.id} className="flex items-center gap-2">
+                <a className="underline" href={it.url} target="_blank" rel="noreferrer">{it.event} #{it.id}</a>
+                <span className="text-xs">{it.status}{it.conclusion ? ` / ${it.conclusion}` : ''}</span>
+                <span className="text-xs opacity-70">{it.headBranch} {it.headSha.slice(0,7)}</span>
+              </div>
+            ))}
+            {(!runs?.items || runs.items.length===0) && <div className="text-xs opacity-70">No recent runs</div>}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/store/statusCenterStore.ts
+++ b/web/store/statusCenterStore.ts
@@ -1,0 +1,48 @@
+'use client'
+import { create } from 'zustand'
+
+type PRStatus = { number: number; state: string; merged: boolean; headSha: string; htmlUrl: string; checks: { name: string; status: string | null; conclusion: string | null; htmlUrl: string | null; startedAt?: string | null; completedAt?: string | null }[] }
+type Runs = { total: number; items: { id: number; status: string | null; conclusion: string | null; event: string; url: string; headBranch: string; headSha: string; createdAt: string; updatedAt: string }[] }
+
+type State = {
+  lastPrNumber?: number
+  lastPrUrl?: string
+  pr?: PRStatus
+  runs?: Runs
+  open: boolean
+  busy: boolean
+}
+type Actions = {
+  setLastPr: (num?: number, url?: string) => void
+  toggle: (v?: boolean) => void
+  fetchPr: (num: number) => Promise<void>
+  fetchRuns: () => Promise<void>
+}
+export const useStatusCenter = create<State & Actions>((set, get) => ({
+  open: false,
+  busy: false,
+  setLastPr: (num, url) => set({ lastPrNumber: num, lastPrUrl: url }),
+  toggle: (v) => set(s => ({ open: typeof v === 'boolean' ? v : !s.open })),
+  fetchPr: async (num: number) => {
+    set({ busy: true })
+    try {
+      const res = await fetch('/api/gh/pr-status', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prNumber: num }) })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j?.error || 'failed')
+      set({ pr: j, lastPrNumber: j.number, lastPrUrl: j.htmlUrl })
+    } finally {
+      set({ busy: false })
+    }
+  },
+  fetchRuns: async () => {
+    set({ busy: true })
+    try {
+      const res = await fetch('/api/gh/workflow-runs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j?.error || 'failed')
+      set({ runs: j })
+    } finally {
+      set({ busy: false })
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- add PR status and workflow runs APIs
- add StatusCenter HUD with polling
- add ProjectMetaMenu to edit project id/name
- mount new menus and HUD in builder header

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b419c23a00832ca0c8eaf6a8e76df7