### PR TITLE
Ensure project IndexedDB store exists before transactions

### DIFF
--- a/web/lib/project/idb.ts
+++ b/web/lib/project/idb.ts
@@ -1,34 +1,55 @@
-const DB_NAME = 'ui-builder'
-const STORE = 'projects'
+const DB_NAME = "ui-builder";
+const STORE = "projects";
 function open() {
   return new Promise<IDBDatabase>((res, rej) => {
-    const req = indexedDB.open(DB_NAME, 1)
-    req.onupgradeneeded = () => {
-      const db = req.result
-      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE)
-    }
-    req.onsuccess = () => res(req.result)
-    req.onerror = () => rej(req.error)
-  })
+    const request = indexedDB.open(DB_NAME, 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+    };
+
+    request.onsuccess = () => {
+      const db = request.result;
+      if (db.objectStoreNames.contains(STORE)) {
+        res(db);
+        return;
+      }
+
+      // Handle databases that were created without the required store.
+      db.close();
+      const fix = indexedDB.open(DB_NAME, db.version + 1);
+      fix.onupgradeneeded = () => {
+        const upgradeDb = fix.result;
+        if (!upgradeDb.objectStoreNames.contains(STORE)) {
+          upgradeDb.createObjectStore(STORE);
+        }
+      };
+      fix.onsuccess = () => res(fix.result);
+      fix.onerror = () => rej(fix.error);
+    };
+
+    request.onerror = () => rej(request.error);
+  });
 }
 export async function idbSet(key: string, value: any) {
-  const db = await open()
+  const db = await open();
   await new Promise<void>((res, rej) => {
-    const tx = db.transaction(STORE, 'readwrite')
-    tx.objectStore(STORE).put(value, key)
-    tx.oncomplete = () => res()
-    tx.onerror = () => rej(tx.error)
-  })
-  db.close()
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).put(value, key);
+    tx.oncomplete = () => res();
+    tx.onerror = () => rej(tx.error);
+  });
+  db.close();
 }
 export async function idbGet<T>(key: string): Promise<T | undefined> {
-  const db = await open()
+  const db = await open();
   const out = await new Promise<T | undefined>((res, rej) => {
-    const tx = db.transaction(STORE, 'readonly')
-    const req = tx.objectStore(STORE).get(key)
-    req.onsuccess = () => res(req.result as any)
-    req.onerror = () => rej(req.error)
-  })
-  db.close()
-  return out
+    const tx = db.transaction(STORE, "readonly");
+    const req = tx.objectStore(STORE).get(key);
+    req.onsuccess = () => res(req.result as any);
+    req.onerror = () => rej(req.error);
+  });
+  db.close();
+  return out;
 }


### PR DESCRIPTION
## Summary
- guard against missing `projects` object store in project IndexedDB helper
- reopen database with incremented version to create store when absent

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41def87dc832cbd178a3823de1ff1