### PR TITLE
feat: add snapshot-based history with undo/redo and autosave

### DIFF
--- a/web/app/builder/BuilderPage.tsx
+++ b/web/app/builder/BuilderPage.tsx
@@ -18,7 +18,6 @@ import { usePageStore } from '@/store/pageStore'
 import { DeviceFrame } from '@/components/hud/DeviceFrame'
 import { GridOverlay } from '@/components/hud/GridOverlay'
 import { BuilderHUD } from '@/components/hud/BuilderHUD'
-import { useAutosave } from '@/hooks/useAutosave'
 import ActionGate from '@/components/interaction/ActionGate'
 import ActionDevConsole from '@/components/interaction/ActionDevConsole'
 import { useActionDebugStore } from '@/store/actionDebugStore'
@@ -34,7 +33,6 @@ export default function BuilderPage() {
   const setGuides = useBuilderStore((s) => s.setGuides)
   const clearGuides = useBuilderStore((s) => s.clearGuides)
   const setElements = useBuilderStore((s) => s.setElements)
-  useAutosave()
 
   const debug = true
   const intercept = useActionDebugStore((s) => s.intercept)

--- a/web/app/builder/layout.tsx
+++ b/web/app/builder/layout.tsx
@@ -1,4 +1,5 @@
 'use client'
+import React, { useEffect } from 'react'
 import '@/store/builderStoreHandle'
 import { SaveIndicator } from '@/components/builder/SaveIndicator'
 import { AlignToolbar } from '@/components/builder/AlignToolbar'
@@ -6,16 +7,21 @@ import { useAlignShortcuts } from '@/components/hooks/useAlignShortcuts'
 import { ShareMenu } from '@/components/builder/ShareMenu'
 import ReflectDeployMenu from '@/components/builder/ReflectDeployMenu'
 import ProjectMetaMenu from '@/components/builder/ProjectMetaMenu'
+import UndoRedoButtons from '@/components/builder/UndoRedoButtons'
+import HistoryHotkeys from '@/components/hud/HistoryHotkeys'
+import { mountHistorySync } from '@/store/historySync'
 import StatusCenter from '@/components/hud/StatusCenter'
 import ErrorBoundary from '@/components/hud/ErrorBoundary'
 import DevConsoleHUD from '@/components/hud/DevConsoleHUD'
 
 export default function BuilderLayout({ children }: { children: React.ReactNode }) {
   useAlignShortcuts()
+  useEffect(() => { mountHistorySync() }, [])
   return (
     <div data-actions-enabled="true" suppressHydrationWarning>
       <div className="w-full h-10 px-3 border-b flex items-center gap-3">
         <div className="text-sm font-semibold mr-auto">Builder</div>
+        <UndoRedoButtons />
         <ProjectMetaMenu />
         <ShareMenu />
         <ReflectDeployMenu />
@@ -26,6 +32,7 @@ export default function BuilderLayout({ children }: { children: React.ReactNode 
         {children}
       </ErrorBoundary>
       <StatusCenter />
+      <HistoryHotkeys />
       {process.env.NODE_ENV !== 'production' && <DevConsoleHUD />}
     </div>
   )

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -2,8 +2,10 @@
 import React, { useEffect } from 'react'
 import BuilderPage from './BuilderPage'
 import { useBuilderStore } from '@/store/builderStore'
-import { loadProjectFromQuery, makeProject, saveProject } from '@/lib/project/io'
+import { loadProjectFromQuery, makeProject } from '@/lib/project/io'
 import { mountLiveSync } from '@/store/liveSync'
+import { useDesignTokens } from '@/store/designTokensStore'
+import { useHistoryStore } from '@/store/historyStore'
 
 export default function BuilderPageWrapper() {
   useEffect(() => {
@@ -11,26 +13,23 @@ export default function BuilderPageWrapper() {
     ;(async () => {
       const pj = await loadProjectFromQuery()
       if (mounted) {
-        if (pj) useBuilderStore.setState({ elements: pj.elements, meta: pj.meta || {} })
-        else
+        if (pj) {
+          useBuilderStore.setState({ elements: pj.elements, meta: pj.meta || {} })
+          useDesignTokens.getState().replaceAll?.(pj.designTokens || {})
+        } else {
           useBuilderStore.setState({
             elements: makeProject([], { id: 'local', name: 'Local Project' }).elements,
             meta: { id: 'local', name: 'Local Project' },
           })
+          useDesignTokens.getState().replaceAll?.({})
+        }
+        useHistoryStore.getState().initFromCurrent()
       }
       mountLiveSync('builder')
     })()
     return () => {
       mounted = false
     }
-  }, [])
-
-  useEffect(() => {
-    const unsub = useBuilderStore.subscribe((s) => {
-      const meta = (s as any).meta || { id: 'local', name: 'Local Project' }
-      saveProject({ schemaVersion: 1, meta, elements: s.elements, designTokens: {}, assets: [] })
-    })
-    return () => unsub()
   }, [])
 
   return <BuilderPage />

--- a/web/components/builder/UndoRedoButtons.tsx
+++ b/web/components/builder/UndoRedoButtons.tsx
@@ -1,0 +1,16 @@
+'use client'
+import React from 'react'
+import { useHistoryStore } from '@/store/historyStore'
+
+export default function UndoRedoButtons() {
+  const undo = useHistoryStore((s) => s.undo)
+  const redo = useHistoryStore((s) => s.redo)
+  const counts = useHistoryStore((s) => s.getCounts())
+  return (
+    <div className="flex items-center gap-2">
+      <button className="border rounded px-2 h-7 disabled:opacity-50" disabled={counts.past===0} onClick={undo}>Undo ({counts.past})</button>
+      <button className="border rounded px-2 h-7 disabled:opacity-50" disabled={counts.future===0} onClick={redo}>Redo ({counts.future})</button>
+    </div>
+  )
+}
+

--- a/web/components/hud/HistoryHotkeys.tsx
+++ b/web/components/hud/HistoryHotkeys.tsx
@@ -1,0 +1,21 @@
+'use client'
+import React, { useEffect } from 'react'
+import { useHistoryStore } from '@/store/historyStore'
+
+export default function HistoryHotkeys() {
+  const undo = useHistoryStore((s) => s.undo)
+  const redo = useHistoryStore((s) => s.redo)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mac = navigator.platform.toLowerCase().includes('mac')
+      const mod = mac ? e.metaKey : e.ctrlKey
+      if (!mod) return
+      if (e.key.toLowerCase() === 'z' && !e.shiftKey) { e.preventDefault(); undo() }
+      else if ((e.key.toLowerCase() === 'z' && e.shiftKey) || e.key.toLowerCase() === 'y') { e.preventDefault(); redo() }
+    }
+    window.addEventListener('keydown', onKey, { capture: true })
+    return () => window.removeEventListener('keydown', onKey, { capture: true } as any)
+  }, [undo, redo])
+  return null
+}
+

--- a/web/lib/history/fingerprint.ts
+++ b/web/lib/history/fingerprint.ts
@@ -1,0 +1,24 @@
+export function fingerprint(elements: any[], meta: any, tokens: any): string {
+  return djb2(
+    JSON.stringify({
+      elements,
+      meta,
+      tokens,
+    })
+  )
+}
+
+function djb2(str: string): string {
+  let h = 5381
+  for (let i = 0; i < str.length; i++) h = ((h << 5) + h) + str.charCodeAt(i)
+  return String(h >>> 0)
+}
+
+export function debounce<T extends (...args: any[]) => void>(fn: T, ms: number) {
+  let t: any
+  return (...args: any[]) => {
+    clearTimeout(t)
+    t = setTimeout(() => fn(...args), ms)
+  }
+}
+

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -1,6 +1,6 @@
 'use client'
 import { create } from 'zustand'
-import { produce, produceWithPatches } from 'immer'
+import { produce } from 'immer'
 import type { DocgenMetaItem } from '@/lib/builder/docgen'
 import { parseValue } from '@/lib/builder/docgen'
 import { registry, type RegistryKey } from '@/lib/registry.ts'
@@ -145,11 +145,7 @@ function defaultsFor(key: string) {
 
 export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) => {
   const apply = (recipe: (draft: BuilderState) => void) => {
-    set((state) => {
-      const [next, patches, inverse] = produceWithPatches(state, recipe)
-      useHistoryStore.getState().push(patches, inverse)
-      return next
-    })
+    set((state) => produce(state, recipe))
   }
 
   return {
@@ -665,34 +661,24 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
   },
 
   undo() {
-    set((state) => useHistoryStore.getState().undo(state))
+    useHistoryStore.getState().undo()
   },
 
   redo() {
-    set((state) => useHistoryStore.getState().redo(state))
+    useHistoryStore.getState().redo()
   },
 
   beginBatch() {
-    const history = useHistoryStore.getState()
-    set((s) => {
-      const depth = s.historyBatchDepth + 1
-      if (depth === 1) history.start()
-      return { historyBatchDepth: depth }
-    })
+    set((s) => ({ historyBatchDepth: s.historyBatchDepth + 1 }))
   },
 
   endBatch() {
-    const history = useHistoryStore.getState()
-    set((s) => {
-      const depth = Math.max(0, s.historyBatchDepth - 1)
-      if (s.historyBatchDepth > 0 && depth === 0) history.commit()
-      return { historyBatchDepth: depth }
-    })
+    set((s) => ({ historyBatchDepth: Math.max(0, s.historyBatchDepth - 1) }))
   },
 
-  updateMany(patches, recordHistory = true) {
-    set((state) => {
-      const [next, patchList, inverse] = produceWithPatches(state, (draft: BuilderState) => {
+  updateMany(patches, _recordHistory = true) {
+    set((state) =>
+      produce(state, (draft: BuilderState) => {
         patches.forEach((p) => {
           const el = draft.elements.find((e) => e.id === p.id)
           if (!el) return
@@ -703,11 +689,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
           if (p.props) el.props = { ...(el.props || {}), ...(p.props || {}) }
         })
       })
-      if (recordHistory || state.historyBatchDepth > 0) {
-        useHistoryStore.getState().push(patchList, inverse)
-      }
-      return next
-    })
+    )
   },
 
   setElements(els) {

--- a/web/store/designTokensStore.ts
+++ b/web/store/designTokensStore.ts
@@ -1,0 +1,18 @@
+'use client'
+import { create } from 'zustand'
+
+type State = {
+  tokens: Record<string, any>
+}
+
+type Actions = {
+  getAll: () => Record<string, any>
+  replaceAll: (t: Record<string, any>) => void
+}
+
+export const useDesignTokens = create<State & Actions>((set, get) => ({
+  tokens: {},
+  getAll: () => get().tokens,
+  replaceAll: (t) => set({ tokens: t }),
+}))
+

--- a/web/store/historyStore.ts
+++ b/web/store/historyStore.ts
@@ -1,75 +1,98 @@
+'use client'
 import { create } from 'zustand'
-import { Patch, applyPatches } from 'immer'
+import { useBuilderStore } from '@/store/builderStore'
+import { useDesignTokens } from '@/store/designTokensStore'
 
-interface Entry {
-  patches: Patch[]
-  inverse: Patch[]
+export type Snapshot = {
+  elements: any[]
+  meta?: any
+  designTokens?: any
 }
 
-interface HistoryState {
-  stack: Entry[]
-  index: number
-  limit: number
-  draft: Entry | null
-  push: (patches: Patch[], inverse: Patch[]) => void
-  start: () => void
-  commit: () => void
-  undo: <T>(state: T) => T
-  redo: <T>(state: T) => T
+type State = {
+  past: Snapshot[]
+  present: Snapshot | null
+  future: Snapshot[]
+  capacity: number
+  busy: boolean
+}
+type Actions = {
+  initFromCurrent: () => void
+  push: (snap: Snapshot) => void
+  undo: () => void
+  redo: () => void
   clear: () => void
+  setCapacity: (n: number) => void
+  apply: (snap: Snapshot) => void
+  getCounts: () => { past: number; future: number }
+  getPresent: () => Snapshot | null
 }
 
-export const useHistoryStore = create<HistoryState>((set, get) => ({
-  stack: [],
-  index: -1,
-  limit: 100,
-  draft: null,
-  push(patches, inverse) {
-    const draft = get().draft
-    if (draft) {
-      draft.patches.push(...patches)
-      draft.inverse = [...inverse, ...draft.inverse]
-      set({ draft })
-      return
-    }
-    let stack = get().stack.slice(0, get().index + 1)
-    stack.push({ patches, inverse })
-    if (stack.length > get().limit) {
-      stack = stack.slice(stack.length - get().limit)
-    }
-    set({ stack, index: stack.length - 1 })
+export const useHistoryStore = create<State & Actions>((set, get) => ({
+  past: [],
+  present: null,
+  future: [],
+  capacity: 50,
+  busy: false,
+  initFromCurrent: () => {
+    const s = snapshotFromStores()
+    set({ past: [], present: s, future: [] })
   },
-  start() {
-    set({ draft: { patches: [], inverse: [] } })
+  push: (snap) => {
+    const { present, past, capacity } = get()
+    if (!present) { set({ present: snap }); return }
+    const np = [...past, present]
+    const trimmed = np.length > capacity ? np.slice(np.length - capacity) : np
+    set({ past: trimmed, present: snap, future: [] })
   },
-  commit() {
-    const draft = get().draft
-    if (draft && draft.patches.length) {
-      let stack = get().stack.slice(0, get().index + 1)
-      stack.push(draft)
-      if (stack.length > get().limit) {
-        stack = stack.slice(stack.length - get().limit)
-      }
-      set({ stack, index: stack.length - 1, draft: null })
-    } else {
-      set({ draft: null })
-    }
+  undo: () => {
+    const { past, present, future } = get()
+    if (past.length === 0 || !present) return
+    const prev = past[past.length - 1]
+    const rest = past.slice(0, -1)
+    set({ past: rest, present: prev, future: [present, ...future], busy: true })
+    applyToStores(prev)
+    set({ busy: false })
   },
-  undo(state) {
-    const { index, stack } = get()
-    if (index < 0) return state
-    const entry = stack[index]
-    set({ index: index - 1 })
-    return applyPatches(state, entry.inverse)
+  redo: () => {
+    const { future, present, past } = get()
+    if (future.length === 0 || !present) return
+    const next = future[0]
+    const rest = future.slice(1)
+    set({ past: [...past, present], present: next, future: rest, busy: true })
+    applyToStores(next)
+    set({ busy: false })
   },
-  redo(state) {
-    const { index, stack } = get()
-    if (index + 1 >= stack.length) return state
-    const entry = stack[index + 1]
-    set({ index: index + 1 })
-    return applyPatches(state, entry.patches)
+  clear: () => set({ past: [], present: get().present, future: [] }),
+  setCapacity: (n) => set({ capacity: Math.max(1, Math.min(500, n)) }),
+  apply: (snap) => {
+    set({ busy: true })
+    applyToStores(snap)
+    set({ busy: false })
   },
-  clear() {
-    set({ stack: [], index: -1, draft: null })
-  },
+  getCounts: () => ({ past: get().past.length, future: get().future.length }),
+  getPresent: () => get().present,
 }))
+
+function snapshotFromStores(): Snapshot {
+  const s = useBuilderStore.getState()
+  const meta = (s as any).meta || { id: 'local', name: 'Local Project' }
+  const tokens = useDesignTokens.getState().getAll?.() ?? useDesignTokens.getState().tokens
+  return { elements: s.elements, meta, designTokens: tokens }
+}
+
+function applyToStores(snap: Snapshot) {
+  useBuilderStore.setState({ elements: snap.elements, meta: snap.meta || {} })
+  if (snap.designTokens) {
+    useDesignTokens.getState().replaceAll?.(snap.designTokens)
+  }
+}
+
+export function makeSnapshot(): Snapshot {
+  return {
+    elements: useBuilderStore.getState().elements,
+    meta: (useBuilderStore.getState() as any).meta || { id: 'local', name: 'Local Project' },
+    designTokens: useDesignTokens.getState().getAll?.() ?? useDesignTokens.getState().tokens
+  }
+}
+

--- a/web/store/historySync.ts
+++ b/web/store/historySync.ts
@@ -1,0 +1,34 @@
+'use client'
+import { useBuilderStore } from '@/store/builderStore'
+import { useDesignTokens } from '@/store/designTokensStore'
+import { useHistoryStore, makeSnapshot } from '@/store/historyStore'
+import { fingerprint, debounce } from '@/lib/history/fingerprint'
+import { saveProject } from '@/lib/project/io'
+
+let mounted = false
+export function mountHistorySync() {
+  if (mounted || typeof window === 'undefined') return
+  mounted = true
+  let last = ''
+  const pushIfChanged = debounce(() => {
+    const snap = makeSnapshot()
+    const fp = fingerprint(snap.elements, snap.meta, snap.designTokens)
+    if (fp !== last) {
+      last = fp
+      useHistoryStore.getState().push(snap)
+      saveProject({ schemaVersion: 1, meta: snap.meta, elements: snap.elements, designTokens: snap.designTokens, assets: [] })
+    }
+  }, 150)
+
+  useHistoryStore.getState().initFromCurrent()
+
+  useBuilderStore.subscribe((_s) => {
+    if (useHistoryStore.getState().busy) return
+    pushIfChanged()
+  })
+  useDesignTokens.subscribe((_s) => {
+    if (useHistoryStore.getState().busy) return
+    pushIfChanged()
+  })
+}
+


### PR DESCRIPTION
## Summary
- add snapshot-based history store and sync with builder and tokens
- expose undo/redo buttons and hotkeys in builder layout
- initialize history on project load and rely on unified autosave

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41f591608832cbe18add28177bbe8