### PR TITLE
feat: add toggleable rulers with persistent UI state

### DIFF
--- a/web/app/builder/BuilderPage.tsx
+++ b/web/app/builder/BuilderPage.tsx
@@ -22,6 +22,7 @@ import ActionGate from '@/components/interaction/ActionGate'
 import ActionDevConsole from '@/components/interaction/ActionDevConsole'
 import { useActionDebugStore } from '@/store/actionDebugStore'
 import PresetApplyBus from '@/components/interaction/PresetApplyBus'
+import { useUIStore } from '@/store/uiStore'
 
 export default function BuilderPage() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -33,6 +34,7 @@ export default function BuilderPage() {
   const setGuides = useBuilderStore((s) => s.setGuides)
   const clearGuides = useBuilderStore((s) => s.clearGuides)
   const setElements = useBuilderStore((s) => s.setElements)
+  const toggleRulers = useUIStore((s) => s.toggleRulers)
 
   const debug = true
   const intercept = useActionDebugStore((s) => s.intercept)
@@ -162,6 +164,17 @@ export default function BuilderPage() {
   React.useEffect(() => {
     setTree(elements)
   }, [elements, setTree])
+
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && e.key.toLowerCase() === 'r') {
+        e.preventDefault()
+        toggleRulers()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [toggleRulers])
 
   return (
     <ActionGate enabled debug={debug} intercept={intercept}>

--- a/web/components/Canvas.tsx
+++ b/web/components/Canvas.tsx
@@ -15,6 +15,7 @@ import { OutlineOverlay } from './overlays/OutlineOverlay'
 import { GridToolbar } from '@/components/GridToolbar'
 import { CanvasRoot } from '@/components/CanvasRoot'
 import { NodeRenderer } from '@/components/NodeRenderer'
+import { useUIStore } from '@/store/uiStore'
 
 export default function Canvas() {
   const { tree } = useEditorState()
@@ -42,6 +43,7 @@ function CanvasInner({
   canvasRef: React.RefObject<HTMLDivElement>
 }) {
   const { vp } = useViewport()
+  const showRulers = useUIStore((s) => s.showRulers)
   return (
     <CanvasRoot>
       <Viewport>
@@ -59,7 +61,7 @@ function CanvasInner({
         zoom={vp.zoom}
         worldToScreenOffset={(wx, wy) => ({ sx: wx * vp.zoom + vp.x, sy: wy * vp.zoom + vp.y })}
       />
-      <Rulers width={2000} height={2000} canvasRef={canvasRef} />
+      {showRulers && <Rulers width={2000} height={2000} canvasRef={canvasRef} />}
       <HUDContainer />
       <SmartGuidesOverlay guides={guides} />
       <GuidesOverlay width={2000} height={2000} canvasRef={canvasRef} />

--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -11,6 +11,7 @@ import { FooterView } from './footer/FooterView'
 import { SidebarView } from '@/components/app/SidebarView'
 import { NodeWrapper } from '@/components/shared/NodeWrapper'
 import { Rulers } from './Rulers'
+import { useUIStore } from '@/store/uiStore'
 import { useUnitStore } from '@/store/unitStore'
 import { intersects } from '@/lib/geom'
 import { useViewStore } from '@/store/viewStore'
@@ -378,6 +379,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const gridSize = useGridStore((s) => s.size)
   const gridVisible = useGridStore((s) => s.visible)
   const setPercentBase = useUnitStore((s) => s.setPercentBase)
+  const showRulers = useUIStore((s) => s.showRulers)
   const [marquee, setMarquee] = React.useState<
     { x: number; y: number; w: number; h: number } | null
   >(null)
@@ -578,15 +580,17 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         </div>
         {selectedIds.length >= 2 && <SelectionBBox />}
         <CanvasOverlay marquee={marquee ?? undefined} />
-        <Rulers
-          width={1200}
-          height={720}
-          canvasRef={canvasRef}
-          screenToWorld={(p, axis) => {
-            const pt = screenToWorld(axis === 'x' ? p : 0, axis === 'y' ? p : 0)
-            return axis === 'x' ? pt.x : pt.y
-          }}
-        />
+        {showRulers && (
+          <Rulers
+            width={1200}
+            height={720}
+            canvasRef={canvasRef}
+            screenToWorld={(p, axis) => {
+              const pt = screenToWorld(axis === 'x' ? p : 0, axis === 'y' ? p : 0)
+              return axis === 'x' ? pt.x : pt.y
+            }}
+          />
+        )}
         <div className="absolute left-2 bottom-2 text-[11px] text-zinc-300 bg-black/50 px-2 py-1 rounded border border-zinc-800 flex gap-2 items-center">
           <span>{Math.round(zoom * 100)}%</span>
           <button

--- a/web/components/hud/BuilderHUD.tsx
+++ b/web/components/hud/BuilderHUD.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 import { useHudStore, type DeviceKind } from '@/store/hudStore'
+import { useUIStore } from '@/store/uiStore'
 
 function IconBtn(props: React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean }) {
   const { active, className, ...rest } = props
@@ -29,11 +30,10 @@ export function BuilderHUD() {
     toggleGrid,
     showOutline,
     toggleOutline,
-    showRulers,
-    toggleRulers,
     snapToPixel,
     toggleSnap,
   } = useHudStore()
+  const { showRulers, toggleRulers } = useUIStore()
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -49,7 +49,7 @@ export function BuilderHUD() {
         resetZoom()
       } else if (!meta && (e.key === 'g' || e.key === 'G')) {
         toggleGrid()
-      } else if (!meta && (e.key === 'r' || e.key === 'R')) {
+      } else if (e.shiftKey && !meta && e.key.toLowerCase() === 'r') {
         toggleRulers()
       } else if (!meta && (e.key === 'o' || e.key === 'O')) {
         toggleOutline()

--- a/web/components/hud/HUDBar.tsx
+++ b/web/components/hud/HUDBar.tsx
@@ -1,9 +1,11 @@
 'use client'
 import React from 'react'
 import { useHUD } from './hudStore'
+import { useUIStore } from '@/store/uiStore'
 
 export default function HUDBar(){
   const {hud, toggle} = useHUD()
+  const { showRulers, toggleRulers } = useUIStore()
   const Btn = ({k,label}:{k:keyof typeof hud,label:string})=> (
     <button
       onClick={(e)=>{ e.stopPropagation(); toggle(k) }}
@@ -13,12 +15,16 @@ export default function HUDBar(){
   )
   return (
     <div className="pointer-events-none absolute right-2 top-2 z-50">
-      <div className="pointer-events-auto flex gap-1 p-1 rounded-xl bg-white/70 shadow">
+      <div className="pointer-events-auto flex items-center gap-1 p-1 rounded-xl bg-white/70 shadow">
         <Btn k="arGuide" label="ARガイド"/>
         <Btn k="workMap" label="業務マップ"/>
         <Btn k="skillShortcuts" label="スキル"/>
         <Btn k="expGauge" label="EXP"/>
         <Btn k="contextNotify" label="通知"/>
+        <label className="flex items-center gap-1 text-xs ml-1">
+          <input type="checkbox" checked={showRulers} onChange={toggleRulers} />
+          Ruler
+        </label>
       </div>
     </div>
   )

--- a/web/components/hud/RulersOverlay.tsx
+++ b/web/components/hud/RulersOverlay.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react'
 import { useHudStore } from '@/store/hudStore'
+import { useUIStore } from '@/store/uiStore'
 
 type Props = {
   /** カンバスを包む要素の ref（サイズ & マウス位置の基準に使う） */
@@ -30,7 +31,7 @@ function chooseStep(pxPerUnit: number) {
 }
 
 export function RulersOverlay({ containerRef, offset, thickness = 24 }: Props) {
-  const show = useHudStore((s) => s.showRulers)
+  const show = useUIStore((s) => s.showRulers)
   const zoom = useHudStore((s) => s.zoom)
   const snap = useHudStore((s) => s.snapToPixel)
   const [size, setSize] = React.useState({ w: 0, h: 0 })

--- a/web/store/uiStore.ts
+++ b/web/store/uiStore.ts
@@ -1,0 +1,22 @@
+'use client';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type UIState = {
+  showRulers: boolean;
+};
+type UIActions = {
+  toggleRulers: () => void;
+  setRulers: (v: boolean) => void;
+};
+
+export const useUIStore = create<UIState & UIActions>()(
+  persist(
+    (set, get) => ({
+      showRulers: true, // 既定で表示
+      toggleRulers: () => set({ showRulers: !get().showRulers }),
+      setRulers: (v) => set({ showRulers: v }),
+    }),
+    { name: 'builder-ui' }
+  )
+);


### PR DESCRIPTION
## Summary
- persist ruler visibility via Zustand store
- toggle rulers from HUD bar and Shift+R shortcut
- render rulers only when enabled

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b55ab8ba18832c9b28c63a24e8cfaf