### PR TITLE
feat: add Japan map component pack

### DIFF
--- a/packages/comp-maps-jp/package.json
+++ b/packages/comp-maps-jp/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/comp-maps-jp",
+  "version": "0.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": { ".": "./src/register.ts" },
+  "dependencies": { "@repo/types": "workspace:*" }
+}

--- a/packages/comp-maps-jp/src/JapanMap.tsx
+++ b/packages/comp-maps-jp/src/JapanMap.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useState } from 'react';
+import { PREF_PATHS } from './data/prefPaths';
+import { PREF_LABELS, CAPITAL_LABELS } from './data/labels';
+import { PrefShape } from './components/PrefShape';
+import { colorOf } from './utils/color';
+import type { PrefCode, VisitStatus, JapanMapProps } from './types';
+
+const CYCLE: VisitStatus[] = ['none','passed','visited','lived'];
+
+export function JapanMap(props: JapanMapProps) {
+  const { values, showLabels, palette, strokeWidth, labelKind, onChange, onHover } = props;
+  const [hover, setHover] = useState<PrefCode | null>(null);
+  const nextOf = (v?: VisitStatus) => CYCLE[(CYCLE.indexOf(v ?? 'none') + 1) % CYCLE.length];
+
+  const handleClick = (code: PrefCode) => {
+    if (!onChange) return;
+    const next = { ...values, [code]: nextOf(values[code]) };
+    onChange(next);
+  };
+
+  const labels = labelKind === 'capital' ? CAPITAL_LABELS : PREF_LABELS;
+
+  return (
+    <svg viewBox="0 0 480 480" className="w-full h-auto select-none">
+      <g>
+        {(Object.keys(PREF_PATHS) as PrefCode[]).map((code) => {
+          const d = PREF_PATHS[code];
+          const fill = colorOf(values[code], palette);
+          return (
+            <PrefShape
+              key={code}
+              code={code}
+              d={d}
+              fill={fill}
+              stroke={palette.stroke}
+              strokeWidth={strokeWidth}
+              onClick={handleClick}
+              onEnter={(c) => { setHover(c); onHover?.(c); }}
+              onLeave={() => { setHover(null); onHover?.(null); }}
+            />
+          );
+        })}
+      </g>
+
+      {showLabels && (
+        <g fontSize="10" className="text-muted fill-current">
+          {(Object.keys(labels) as PrefCode[]).map((code) => {
+            const L = labels[code]; if (!L) return null;
+            return <text key={code} x={L.x} y={L.y}>{L.name}</text>;
+          })}
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/packages/comp-maps-jp/src/JapanMapAdapter.tsx
+++ b/packages/comp-maps-jp/src/JapanMapAdapter.tsx
@@ -1,0 +1,22 @@
+'use client';
+import type { RendererProps } from '@repo/types/src/builder';
+import { JapanMap } from './JapanMap';
+import type { JapanMapProps, VisitStatus, PrefCode } from './types';
+
+export default function JapanMapAdapter({ nodeId, values }: RendererProps) {
+  const props: JapanMapProps = {
+    values: (values.values ?? {}) as Record<PrefCode, VisitStatus>,
+    showLabels: values.showLabels ?? true,
+    palette: {
+      visited: values.colorVisited ?? '#22c55e',
+      lived:   values.colorLived   ?? '#0ea5e9',
+      passed:  values.colorPassed  ?? '#f59e0b',
+      none:    values.colorDefault ?? '#1f2937',
+      stroke:  values.colorStroke  ?? '#0b1020',
+    },
+    strokeWidth: values.strokeWidth ?? 1,
+    labelKind: values.labelKind ?? 'pref',
+    // onChange: (next) => {/* 後で親の store に反映させる */},
+  };
+  return <JapanMap {...props} />;
+}

--- a/packages/comp-maps-jp/src/components/PrefShape.tsx
+++ b/packages/comp-maps-jp/src/components/PrefShape.tsx
@@ -1,0 +1,22 @@
+'use client';
+import type { PrefCode } from '../types';
+export function PrefShape({
+  code, d, fill, stroke, strokeWidth, onClick, onEnter, onLeave,
+}: {
+  code: PrefCode; d: string; fill: string; stroke: string; strokeWidth: number;
+  onClick?: (c: PrefCode)=>void; onEnter?: (c: PrefCode)=>void; onLeave?: ()=>void;
+}) {
+  if (!d) return null;
+  return (
+    <path
+      d={d}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      onClick={() => onClick?.(code)}
+      onMouseEnter={() => onEnter?.(code)}
+      onMouseLeave={() => onLeave?.()}
+      className="transition-colors duration-100"
+    />
+  );
+}

--- a/packages/comp-maps-jp/src/data/labels.ts
+++ b/packages/comp-maps-jp/src/data/labels.ts
@@ -1,0 +1,6 @@
+import type { PrefCode } from '../types';
+export const PREF_LABELS: Record<PrefCode, { x: number; y: number; name: string }> = {
+  '01': { x: 50, y: 40, name: '北海道' },
+  '13': { x: 140, y: 140, name: '東京' },
+} as any;
+export const CAPITAL_LABELS: typeof PREF_LABELS = {} as any;

--- a/packages/comp-maps-jp/src/data/prefPaths.ts
+++ b/packages/comp-maps-jp/src/data/prefPaths.ts
@@ -1,0 +1,6 @@
+import type { PrefCode } from '../types';
+export const PREF_PATHS: Record<PrefCode, string> = {
+  '01': 'M10,10 h80 v60 h-80 z', // TODO: real SVG path
+  '13': 'M120,120 h40 v30 h-40 z', // …
+  // 以外はとりあえず四角 or 空文字でも可（描画されなくてもビルドは通る）
+} as any;

--- a/packages/comp-maps-jp/src/register.ts
+++ b/packages/comp-maps-jp/src/register.ts
@@ -1,0 +1,27 @@
+import type { ComponentDef } from '@repo/types/src/builder';
+import { register } from '../../../web/lib/registry'; // 既存のレジストリを直接呼ぶ（今回は簡易に）
+import JapanMapAdapter from './JapanMapAdapter';
+
+const def: ComponentDef = {
+  meta: {
+    id: 'maps/japan',
+    displayName: 'Japan Map',
+    group: 'Maps',
+    props: [
+      { id: 'values',       label: 'Values(JSON)', control: 'json',   default: {} },
+      { id: 'showLabels',   label: 'Labels',       control: 'switch', default: true },
+      { id: 'labelKind',    label: 'Label Type',   control: 'select', default: 'pref',
+        options: [{label:'Pref',value:'pref'},{label:'Capital',value:'capital'},{label:'None',value:'none'}] },
+      { id: 'strokeWidth',  label: 'Stroke',       control: 'number', default: 1, min:0, max:4, step:0.5 },
+      { id: 'colorVisited', label: 'Visited',      control: 'color',  default: '#22c55e' },
+      { id: 'colorLived',   label: 'Lived',        control: 'color',  default: '#0ea5e9' },
+      { id: 'colorPassed',  label: 'Passed',       control: 'color',  default: '#f59e0b' },
+      { id: 'colorDefault', label: 'Default',      control: 'color',  default: '#1f2937' },
+      { id: 'colorStroke',  label: 'Stroke',       control: 'color',  default: '#0b1020' },
+    ],
+    allowChildren: false,
+  },
+  Render: JapanMapAdapter,
+};
+
+register(def);

--- a/packages/comp-maps-jp/src/types.ts
+++ b/packages/comp-maps-jp/src/types.ts
@@ -1,0 +1,15 @@
+export type PrefCode =
+ '01'|'02'|'03'|'04'|'05'|'06'|'07'|'08'|'09'|'10'|'11'|'12'|'13'|'14'|'15'|'16'|'17'|'18'|'19'|'20'|
+ '21'|'22'|'23'|'24'|'25'|'26'|'27'|'28'|'29'|'30'|'31'|'32'|'33'|'34'|'35'|'36'|'37'|'38'|'39'|'40'|
+ '41'|'42'|'43'|'44'|'45'|'46'|'47';
+export type VisitStatus = 'none'|'passed'|'visited'|'lived';
+
+export type JapanMapProps = {
+  values: Partial<Record<PrefCode, VisitStatus>>;
+  showLabels: boolean;
+  palette: { visited: string; lived: string; passed: string; none: string; stroke: string; };
+  strokeWidth: number;
+  labelKind: 'pref'|'capital'|'none';
+  onChange?: (next: JapanMapProps['values']) => void;
+  onHover?: (code: PrefCode | null) => void;
+};

--- a/packages/comp-maps-jp/src/utils/color.ts
+++ b/packages/comp-maps-jp/src/utils/color.ts
@@ -1,0 +1,6 @@
+import type { VisitStatus } from '../types';
+import type { JapanMapProps } from '../types';
+export function colorOf(st: VisitStatus | undefined, p: JapanMapProps['palette']) {
+  switch (st) { case 'visited': return p.visited; case 'lived': return p.lived;
+    case 'passed': return p.passed; default: return p.none; }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,1 @@
+{ "name": "@repo/types", "version": "0.0.0", "type": "module", "sideEffects": false }

--- a/packages/types/src/builder.ts
+++ b/packages/types/src/builder.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+export type PropControl = 'text'|'number'|'color'|'select'|'switch'|'json'|'component';
+
+export type PropMeta<T=unknown> = {
+  id: string; label: string; control: PropControl; default: T;
+  options?: { label: string; value: any }[]; min?: number; max?: number; step?: number;
+};
+
+export type ComponentMeta = {
+  id: string; displayName: string; group?: string; icon?: string;
+  props: PropMeta[]; allowChildren?: boolean;
+};
+
+export type RendererProps = { nodeId: string; values: Record<string, any>; children?: ReactNode; };
+
+export type ComponentDef = { meta: ComponentMeta; Render: (p: RendererProps)=> JSX.Element | null; };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@18.3.24)(immer@10.0.0)(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.47.0
+        version: 1.55.0
       '@types/react':
         specifier: ^18.2.47
         version: 18.3.24
@@ -75,6 +78,12 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
+
+  packages/comp-maps-jp:
+    dependencies:
+      '@repo/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/core:
     dependencies:
@@ -118,6 +127,8 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
 
+  packages/types: {}
+
   web:
     dependencies:
       '@core':
@@ -129,6 +140,12 @@ importers:
       '@domain-components':
         specifier: workspace:*
         version: link:../packages/domain-components
+      '@repo/comp-maps-jp':
+        specifier: workspace:*
+        version: link:../packages/comp-maps-jp
+      '@repo/types':
+        specifier: workspace:*
+        version: link:../packages/types
       '@schemas':
         specifier: workspace:*
         version: link:../packages/schemas
@@ -152,7 +169,7 @@ importers:
         version: 5.1.5
       next:
         specifier: 14.2.5
-        version: 14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       octokit:
         specifier: ^5.0.3
         version: 5.0.3
@@ -498,6 +515,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -857,6 +879,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1140,6 +1167,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -1829,6 +1866,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
@@ -2183,6 +2224,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2340,7 +2384,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
@@ -2361,6 +2405,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.5
       '@next/swc-win32-ia32-msvc': 14.2.5
       '@next/swc-win32-x64-msvc': 14.2.5
+      '@playwright/test': 1.55.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -2432,6 +2477,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import '../registry.entry';
 import React, { useEffect } from 'react'
 import BuilderPage from './BuilderPage'
 import { useBuilderStore } from '@/store/builderStore'

--- a/web/app/registry.entry.ts
+++ b/web/app/registry.entry.ts
@@ -1,0 +1,2 @@
+// ここに「採用するパック」を import すると副作用で登録される
+import '@repo/comp-maps-jp';

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,8 +1,21 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    externalDir: true,
+export default {
+  outputFileTracingRoot: path.join(__dirname, '..'),
+  experimental: { externalDir: true },
+  transpilePackages: ['@repo/types','@repo/comp-maps-jp'],
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@core': path.resolve(__dirname, 'core'),
+      '@core/action-bus': path.resolve(__dirname, 'core/action-bus'),
+      '@domain-components': path.resolve(__dirname, 'components/domain'),
+      '@data': path.resolve(__dirname, 'data'),
+    };
+    return config;
   },
 };
-
-export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,9 @@
     "next": "14.2.5",
     "octokit": "^5.0.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "@repo/types": "workspace:*",
+    "@repo/comp-maps-jp": "workspace:*"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Summary
- add shared builder types package
- introduce Japan Map component pack and register it
- configure Next.js to transpile new packages and load maps pack in builder

## Testing
- `pnpm -w install`
- `pnpm -w -C web dev`

------
https://chatgpt.com/codex/tasks/task_e_68b55e27e880832ca4cc738a9df31001