### PR TITLE
feat: add site chrome with login placeholder

### DIFF
--- a/web/app/builder/layout.tsx
+++ b/web/app/builder/layout.tsx
@@ -19,6 +19,10 @@ import ModalHost from '@/components/hud/ModalHost'
 export default function BuilderLayout({ children }: { children: React.ReactNode }) {
   useAlignShortcuts()
   useEffect(() => { mountHistorySync() }, [])
+  useEffect(() => {
+    document.body.classList.add('no-site-chrome')
+    return () => document.body.classList.remove('no-site-chrome')
+  }, [])
   return (
     <div data-actions-enabled="true" suppressHydrationWarning>
       <div className="w-full h-10 px-3 border-b flex items-center gap-3">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2,3 +2,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.no-site-chrome header,
+.no-site-chrome footer { display: none; }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,31 +1,22 @@
 import './globals.css'
-import React, { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { cookies } from 'next/headers'
-import { HUDProvider } from '../components/hud/hudStore'
-import PerfHUD from '@/components/dev/PerfHUD'
-import EventLog from '@/components/dev/EventLog'
-import { ThemeProvider } from '../lib/theme/ThemeProvider'
-import DataProvider from '@/providers/DataProvider'
+import Providers from './providers'
+import SiteHeader from '@/components/layout/SiteHeader'
+import SiteFooter from '@/components/layout/SiteFooter'
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  const theme = cookies().get('ui-theme')?.value ?? 'light'
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const cookieStore = await cookies()
+  const uiTheme = cookieStore.get('ui-theme')?.value ?? 'light'
 
   return (
-    <html lang="en" data-theme={theme} suppressHydrationWarning>
+    <html lang="ja" data-theme={uiTheme} suppressHydrationWarning>
       <body>
-        <ThemeProvider>
-          <DataProvider>
-            <HUDProvider>
-              {children}
-              {process.env.NODE_ENV !== 'production' && (
-                <>
-                  <PerfHUD />
-                  <EventLog />
-                </>
-              )}
-            </HUDProvider>
-          </DataProvider>
-        </ThemeProvider>
+        <Providers initialTheme={uiTheme}>
+          <SiteHeader />
+          <main className="min-h-[calc(100vh-6rem)]">{children}</main>
+          <SiteFooter />
+        </Providers>
       </body>
     </html>
   )

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,23 +1,8 @@
-'use client'
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-export default function Page() {
-  const [email,setEmail]=useState('')
-  const [password,setPassword]=useState('')
-  const router=useRouter()
-  const submit=async(e:React.FormEvent)=>{
-    e.preventDefault()
-    const res=await fetch('/auth/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email,password})})
-    if(!res.ok) return
-    const data=await res.json()
-    localStorage.setItem('token',data.access_token)
-    router.push('/builder')
-  }
-  return(
-    <form onSubmit={submit} className="flex flex-col gap-2 p-4">
-      <input type="email" value={email} onChange={e=>setEmail(e.target.value)} className="border p-2"/>
-      <input type="password" value={password} onChange={e=>setPassword(e.target.value)} className="border p-2"/>
-      <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">Login</button>
-    </form>
+export default function LoginPage() {
+  return (
+    <div className="mx-auto max-w-md p-6 space-y-3">
+      <h1 className="text-xl font-semibold">ログイン（準備中）</h1>
+      <p className="text-[color:var(--muted)]">後で認証を接続します。今はヘッダーのボタン表示のみ。</p>
+    </div>
   )
 }

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { HUDProvider } from '@/components/hud/hudStore'
+import PerfHUD from '@/components/dev/PerfHUD'
+import EventLog from '@/components/dev/EventLog'
+import { ThemeProvider } from '@/lib/theme/ThemeProvider'
+import DataProvider from '@/providers/DataProvider'
+
+export default function Providers({ children, initialTheme }: { children: ReactNode; initialTheme: string }) {
+  return (
+    <ThemeProvider initialTheme={initialTheme}>
+      <DataProvider>
+        <HUDProvider>
+          {children}
+          {process.env.NODE_ENV !== 'production' && (
+            <>
+              <PerfHUD />
+              <EventLog />
+            </>
+          )}
+        </HUDProvider>
+      </DataProvider>
+    </ThemeProvider>
+  )
+}

--- a/web/components/layout/SiteFooter.tsx
+++ b/web/components/layout/SiteFooter.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+function openPopup(u: string) {
+  window.open(u, '_blank', 'noopener,noreferrer,width=560,height=600')
+}
+
+function shareTo(site: 'x'|'line'|'facebook') {
+  const url = encodeURIComponent(location.href)
+  const text = encodeURIComponent(document.title)
+  if (site === 'x')        openPopup(`https://x.com/intent/tweet?url=${url}&text=${text}`)
+  else if (site === 'line')openPopup(`https://social-plugins.line.me/lineit/share?url=${url}`)
+  else                     openPopup(`https://www.facebook.com/sharer/sharer.php?u=${url}`)
+}
+
+async function systemShare() {
+  const data = { title: document.title, url: location.href }
+  if ((navigator as any).share) {
+    try { await (navigator as any).share(data); return; } catch {}
+  }
+  await navigator.clipboard.writeText(data.url).catch(() => {})
+  alert('リンクをコピーしました')
+}
+
+export default function SiteFooter() {
+  return (
+    <footer className="w-full border-t"
+            style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
+      <div className="mx-auto max-w-6xl flex flex-col md:flex-row items-center justify-between gap-3 px-4 py-3">
+        <small className="text-[color:var(--muted)]">© {new Date().getFullYear()} UI Builder</small>
+        <div className="flex items-center gap-2">
+          <button className="btn btn-sm" onClick={systemShare} title="端末の共有メニュー">共有</button>
+          <button className="btn btn-sm" onClick={() => shareTo('x')} aria-label="Xで共有">X</button>
+          <button className="btn btn-sm" onClick={() => shareTo('line')} aria-label="LINEで共有">LINE</button>
+          <button className="btn btn-sm" onClick={() => shareTo('facebook')} aria-label="Facebookで共有">Facebook</button>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/web/components/layout/SiteHeader.tsx
+++ b/web/components/layout/SiteHeader.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export default function SiteHeader() {
+  const [busy, setBusy] = useState(false)
+
+  // next-auth が入っていれば signIn()、無ければ /login に遷移
+  const handleLogin = async () => {
+    try {
+      setBusy(true)
+      // 動的 import（未導入でも落ちない）
+      const mod = await import('next-auth/react').catch(() => null)
+      if (mod?.signIn) await mod.signIn()
+      else window.location.href = '/login'
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <header className="w-full border-b"
+            style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
+      <div className="mx-auto max-w-6xl flex items-center justify-between gap-4 px-4 h-12">
+        <div className="flex items-center gap-3">
+          <Link href="/" className="font-semibold">UI Builder</Link>
+          <nav className="hidden md:flex items-center gap-3 text-sm text-[color:var(--muted)]">
+            <Link href="/builder">Builder</Link>
+            <Link href="/dev/pages">Dev</Link>
+          </nav>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleLogin}
+            className="btn btn-sm"
+            disabled={busy}
+            aria-busy={busy}
+          >
+            {busy ? '…' : 'ログイン'}
+          </button>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/web/lib/theme/ThemeProvider.tsx
+++ b/web/lib/theme/ThemeProvider.tsx
@@ -29,8 +29,8 @@ function setCookie(name: string, value: string) {
   document.cookie = `${name}=${value}; path=/; max-age=31536000`
 }
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>('light')
+export function ThemeProvider({ children, initialTheme }: { children: React.ReactNode; initialTheme: string }) {
+  const [theme, setThemeState] = useState<Theme>(initialTheme === 'dark' ? 'dark' : 'light')
   const system: Theme =
     typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
       ? 'dark'


### PR DESCRIPTION
## Summary
- add site header with login button
- add footer sharing controls
- wire header/footer into root layout and hide on builder

## Testing
- `pnpm -w -C web dev`

------
https://chatgpt.com/codex/tasks/task_e_68b560646ab8832c9afadf0695d22a66