### PR TITLE
feat(maps): add shared hover and pan/zoom to Japan map

### DIFF
--- a/web/components/domain/maps/HoverLabel.tsx
+++ b/web/components/domain/maps/HoverLabel.tsx
@@ -1,11 +1,22 @@
 'use client';
 import type { RendererProps } from '@/types/builder';
+import { useMapUIStore } from './mapStore';
+import { PREF_LABELS } from './data/labels';
 
 export default function HoverLabel({ values }: RendererProps) {
+  const code = useMapUIStore(s => s.hoverPref);
+  if (!code) {
+    return (
+      <div className="rounded-md border border-border bg-panel2 px-3 py-2 text-xs shadow">
+        <div className="text-muted">カーソルを地図に合わせると県名が表示されます</div>
+      </div>
+    );
+  }
+  const name = PREF_LABELS[code]?.name ?? code;
   return (
     <div className="rounded-md border border-border bg-panel2 px-3 py-2 text-xs shadow">
-      <div className="font-medium">Hover</div>
-      <div className="text-muted">県名をここに表示（後続で配線）</div>
+      <div className="font-medium">{name}</div>
+      <div className="text-muted text-[11px]">Code: {code}</div>
     </div>
   );
 }

--- a/web/components/domain/maps/JapanMap.tsx
+++ b/web/components/domain/maps/JapanMap.tsx
@@ -1,8 +1,9 @@
 'use client';
-import { useState } from 'react';
-import type { PrefCode } from './types';
+import { useRef } from 'react';
 import { PREF_PATHS } from './data/prefPaths';
 import { PREF_LABELS, CAPITAL_LABELS } from './data/labels';
+import { usePanZoom } from './usePanZoom';
+import { useMapUIStore, type PrefCode } from './mapStore';
 
 export type Visit = 'none'|'passed'|'visited'|'lived';
 
@@ -22,53 +23,64 @@ const CYCLE: Visit[] = ['none','passed','visited','lived'];
 export default function JapanMap({
   values, showLabels, labelKind, colors, strokeWidth, interactive, onChange, onHover
 }: JapanMapProps) {
-  const [hover, setHover] = useState<PrefCode|null>(null);
-  const nextOf = (v?: Visit) => CYCLE[(CYCLE.indexOf(v ?? 'none') + 1) % CYCLE.length];
+  const contRef = useRef<HTMLDivElement>(null);
+  const { transform, zoomIn, zoomOut, reset } = usePanZoom(contRef, { viewBoxW: 480, viewBoxH: 480 });
+
+  const setHover = useMapUIStore(s => s.setHover);
+  const labels = labelKind === 'capital' ? CAPITAL_LABELS : PREF_LABELS;
 
   const handleClick = (code: PrefCode) => {
     if (!interactive || !onChange) return;
-    const next = { ...values, [code]: nextOf(values[code]) };
-    onChange(next);
+    const nextOf = (v?: Visit) => CYCLE[(CYCLE.indexOf(v ?? 'none') + 1) % CYCLE.length];
+    onChange({ ...values, [code]: nextOf(values[code]) });
   };
 
-  const labels = labelKind === 'capital' ? CAPITAL_LABELS : PREF_LABELS;
-
   return (
-    <svg viewBox="0 0 480 480" className="w-full h-auto select-none" aria-label="Japan map">
-      <g>
-        {(Object.keys(PREF_PATHS) as PrefCode[]).map((code) => {
-          const d = PREF_PATHS[code];
-          const st = values[code] ?? 'none';
-          const fill = st === 'visited' ? colors.visited :
-                       st === 'lived'   ? colors.lived   :
-                       st === 'passed'  ? colors.passed  : colors.none;
-          return (
-            <path
-              key={code}
-              d={d}
-              fill={fill}
-              stroke={colors.stroke}
-              strokeWidth={strokeWidth}
-              role="button"
-              aria-label={`${code}:${st}`}
-              tabIndex={interactive ? 0 : -1}
-              onClick={() => handleClick(code)}
-              onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleClick(code)}
-              onMouseEnter={() => { setHover(code); onHover?.(code); }}
-              onMouseLeave={() => { setHover(null); onHover?.(null); }}
-              className="transition-colors duration-100"
-            />
-          );
-        })}
-      </g>
-      {showLabels && (
-        <g fontSize="10" className="text-muted fill-current">
-          {(Object.keys(labels) as PrefCode[]).map((code) => {
-            const L = labels[code]; if (!L) return null;
-            return <text key={code} x={L.x} y={L.y}>{L.name}</text>;
+    <div ref={contRef} className="relative w-full h-full overflow-hidden select-none">
+      {/* 操作用ドック（右下） */}
+      <div className="absolute bottom-2 right-2 z-10 flex gap-1">
+        <button className="btn btn-xs" onClick={zoomOut} title="Zoom out">−</button>
+        <button className="btn btn-xs" onClick={reset}   title="Reset">Fit</button>
+        <button className="btn btn-xs" onClick={zoomIn}  title="Zoom in">＋</button>
+      </div>
+
+      <svg viewBox="0 0 480 480" className="absolute inset-0 w-full h-full" aria-label="Japan map">
+        <g transform={transform}>
+          {(Object.keys(PREF_PATHS) as PrefCode[]).map((code) => {
+            const d = PREF_PATHS[code];
+            const st = values[code] ?? 'none';
+            const fill =
+              st === 'visited' ? colors.visited :
+              st === 'lived'   ? colors.lived   :
+              st === 'passed'  ? colors.passed  : colors.none;
+            return (
+              <path
+                key={code}
+                d={d}
+                fill={fill}
+                stroke={colors.stroke}
+                strokeWidth={strokeWidth}
+                role="button"
+                aria-label={`${code}:${st}`}
+                tabIndex={interactive ? 0 : -1}
+                onClick={() => handleClick(code)}
+                onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleClick(code)}
+                onMouseEnter={() => { setHover(code); onHover?.(code); }}
+                onMouseLeave={() => { setHover(null); onHover?.(null); }}
+                className="transition-colors duration-100"
+              />
+            );
           })}
+          {showLabels && (
+            <g fontSize="10" className="text-muted fill-current">
+              {(Object.keys(labels) as PrefCode[]).map((code) => {
+                const L = labels[code]; if (!L) return null;
+                return <text key={code} x={L.x} y={L.y}>{L.name}</text>;
+              })}
+            </g>
+          )}
         </g>
-      )}
-    </svg>
+      </svg>
+    </div>
   );
 }

--- a/web/components/domain/maps/mapStore.ts
+++ b/web/components/domain/maps/mapStore.ts
@@ -1,0 +1,16 @@
+'use client';
+import { create } from 'zustand';
+
+export type PrefCode =
+  | '01'|'02'|'03'|'04'|'05'|'06'|'07'|'08'|'09'|'10'|'11'|'12'|'13'|'14'|'15'|'16'|'17'|'18'|'19'|'20'
+  | '21'|'22'|'23'|'24'|'25'|'26'|'27'|'28'|'29'|'30'|'31'|'32'|'33'|'34'|'35'|'36'|'37'|'38'|'39'|'40'
+  | '41'|'42'|'43'|'44'|'45'|'46'|'47';
+
+type MapUIState = {
+  hoverPref: PrefCode | null;
+  setHover: (c: PrefCode | null) => void;
+};
+export const useMapUIStore = create<MapUIState>((set) => ({
+  hoverPref: null,
+  setHover: (c) => set({ hoverPref: c }),
+}));

--- a/web/components/domain/maps/usePanZoom.ts
+++ b/web/components/domain/maps/usePanZoom.ts
@@ -1,0 +1,95 @@
+'use client';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type Opts = {
+  viewBoxW: number; viewBoxH: number;
+  minScale?: number; maxScale?: number; step?: number;
+};
+
+/** SVGの内側<g>に当てるための pan/zoom フック */
+export function usePanZoom(refContainer: React.RefObject<HTMLElement>, opts: Opts) {
+  const { viewBoxW, viewBoxH, minScale = 0.5, maxScale = 4, step = 0.1 } = opts;
+  const [scale, setScale] = useState(1);
+  const [tx, setTx] = useState(0);
+  const [ty, setTy] = useState(0);
+  const dragging = useRef<null | { x: number; y: number; tx0: number; ty0: number }>(null);
+
+  // ホイールでズーム（マウス位置に合わせて拡大縮小）
+  const onWheel = useCallback((e: WheelEvent) => {
+    // ctrlKey のズーム拡大抑止（ブラウザの拡大を避ける）
+    e.preventDefault();
+    const cont = refContainer.current;
+    if (!cont) return;
+    const rect = cont.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    const k = Math.exp(-Math.sign(e.deltaY) * step); // deltaY>0で縮小
+    const next = Math.min(maxScale, Math.max(minScale, scale * k));
+    const zx = (mx / rect.width) * viewBoxW;
+    const zy = (my / rect.height) * viewBoxH;
+
+    // ピボット( zx, zy ) を保つように平行移動
+    const txNext = zx - (zx - tx) * (next / scale);
+    const tyNext = zy - (zy - ty) * (next / scale);
+
+    setScale(next);
+    setTx(txNext);
+    setTy(tyNext);
+  }, [refContainer, scale, step, maxScale, minScale, tx, ty, viewBoxW, viewBoxH]);
+
+  // ドラッグでパン
+  const onPointerDown = useCallback((e: PointerEvent) => {
+    const cont = refContainer.current; if (!cont) return;
+    cont.setPointerCapture(e.pointerId);
+    dragging.current = { x: e.clientX, y: e.clientY, tx0: tx, ty0: ty };
+  }, [refContainer, tx, ty]);
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    if (!dragging.current) return;
+    const rect = refContainer.current!.getBoundingClientRect();
+    const dxPx = e.clientX - dragging.current.x;
+    const dyPx = e.clientY - dragging.current.y;
+    const dx = (dxPx / rect.width) * (viewBoxW / scale);
+    const dy = (dyPx / rect.height) * (viewBoxH / scale);
+    setTx(dragging.current.tx0 + dx);
+    setTy(dragging.current.ty0 + dy);
+  }, [refContainer, scale, viewBoxW, viewBoxH]);
+
+  const onPointerUp = useCallback((e: PointerEvent) => {
+    const cont = refContainer.current; if (!cont) return;
+    try { cont.releasePointerCapture(e.pointerId); } catch {}
+    dragging.current = null;
+  }, [refContainer]);
+
+  // リスナー登録
+  useEffect(() => {
+    const el = refContainer.current;
+    if (!el) return;
+    const w = (e: WheelEvent) => onWheel(e);
+    const d = (e: PointerEvent) => onPointerDown(e);
+    const m = (e: PointerEvent) => onPointerMove(e);
+    const u = (e: PointerEvent) => onPointerUp(e);
+    el.addEventListener('wheel', w, { passive: false });
+    el.addEventListener('pointerdown', d);
+    el.addEventListener('pointermove', m);
+    el.addEventListener('pointerup', u);
+    el.addEventListener('pointercancel', u);
+    return () => {
+      el.removeEventListener('wheel', w);
+      el.removeEventListener('pointerdown', d);
+      el.removeEventListener('pointermove', m);
+      el.removeEventListener('pointerup', u);
+      el.removeEventListener('pointercancel', u);
+    };
+  }, [refContainer, onWheel, onPointerDown, onPointerMove, onPointerUp]);
+
+  // 外から呼べる操作
+  const zoomIn  = () => setScale((s) => Math.min(maxScale, s * (1 + step * 2)));
+  const zoomOut = () => setScale((s) => Math.max(minScale, s * (1 - step * 2)));
+  const reset   = () => { setScale(1); setTx(0); setTy(0); };
+
+  const transform = useMemo(() => `translate(${tx} ${ty}) scale(${scale})`, [tx, ty, scale]);
+
+  return { transform, zoomIn, zoomOut, reset, scale };
+}


### PR DESCRIPTION
## Summary
- add global hover store for Japan map components
- enable pan and zoom interactions with control dock
- connect HoverLabel to shared hover state

## Testing
- `pnpm test` *(fails: Module '@/lib/registry' has no exported member 'listDefs')*

------
https://chatgpt.com/codex/tasks/task_e_68b649acb3d4832cba02bc21ba3f5fbd