### PR TITLE
feat: sidebar presets and navigation generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 public/component-meta.json
 .next
+web/.generated/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,12 +186,18 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@1.21.7)
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       postcss:
         specifier: ^8.4.47
         version: 8.5.6
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.17(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -252,6 +258,162 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -770,6 +932,11 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -891,6 +1058,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1311,6 +1481,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -1437,6 +1610,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1584,6 +1762,84 @@ snapshots:
     dependencies:
       react: 18.3.1
       tslib: 2.8.1
+
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
+    optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.34.0(jiti@1.21.7))':
     dependencies:
@@ -2095,6 +2351,35 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -2231,6 +2516,10 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -2615,6 +2904,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -2755,6 +3046,13 @@ snapshots:
       yn: 3.1.1
 
   tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -2,6 +2,7 @@
 import '../registry.entry';
 import React, { useEffect } from 'react'
 import BuilderPage from './BuilderPage'
+import Sidebar from '@/components/layout/Sidebar'
 import { useBuilderStore } from '@/store/builderStore'
 import { loadProjectFromQuery, makeProject, saveProject } from '@/lib/project/io'
 import { mountLiveSync } from '@/store/liveSync'
@@ -51,5 +52,12 @@ export default function BuilderPageWrapper() {
     return () => { unsub1(); unsub2(); unsub3() }
   }, [])
 
-  return <BuilderPage />
+  return (
+    <div className="flex h-[calc(100vh-40px)]">
+      <Sidebar />
+      <div className="flex-1">
+        <BuilderPage />
+      </div>
+    </div>
+  )
 }

--- a/web/app/dev/sidebar/page.tsx
+++ b/web/app/dev/sidebar/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+import * as React from 'react';
+import { buildAutoTree, mergeMenu } from '@/lib/menu';
+import { useSidebarStore } from '@/store/sidebarStore';
+import type { OverlayNode } from '@/types/sidebar';
+
+function AutoPreview() {
+  const tree = buildAutoTree();
+  return (
+    <div className="rounded border p-3">
+      <div className="font-medium mb-2">Auto (scan)</div>
+      <pre className="text-xs overflow-auto max-h-72">{JSON.stringify(tree, null, 2)}</pre>
+    </div>
+  );
+}
+
+function OverlayEditor({ value, onChange }: { value: OverlayNode[]; onChange: (v: OverlayNode[]) => void; }) {
+  const [txt, setTxt] = React.useState(JSON.stringify(value, null, 2));
+  return (
+    <div className="rounded border p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="font-medium">Overlay (JSON)</div>
+        <button className="btn btn-xs" onClick={() => { try { onChange(JSON.parse(txt)); } catch { alert('JSON parse error'); } }}>
+          Apply
+        </button>
+      </div>
+      <textarea className="w-full h-64 font-mono text-xs p-2 rounded border bg-[color:var(--panel2)]"
+        value={txt} onChange={(e)=>setTxt(e.target.value)} />
+    </div>
+  );
+}
+
+export default function SidebarDev() {
+  const { presets, activeId, apply, upsert, remove } = useSidebarStore();
+  const preset = presets.find(p => p.id === activeId)!;
+  const merged = React.useMemo(() => mergeMenu(preset), [preset]);
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-6">
+      <h1 className="text-xl font-semibold">Sidebar Presets</h1>
+
+      <section className="space-y-2">
+        <div className="flex flex-wrap gap-2">
+          {presets.map(p => (
+            <button key={p.id} className={`btn btn-sm ${p.id===activeId?'btn-primary':''}`} onClick={()=>apply(p.id)}>
+              {p.name}
+            </button>
+          ))}
+          <button className="btn btn-sm"
+            onClick={()=> upsert({ id: crypto.randomUUID(), name: 'New Preset', mode:'auto+overlay', include:[], exclude:[], overlay:[], rootHidden:false }) }>
+            + New
+          </button>
+          <button className="btn btn-sm btn-danger" onClick={()=>remove(activeId)}>Delete</button>
+        </div>
+      </section>
+
+      <section className="grid md:grid-cols-2 gap-4">
+        <AutoPreview />
+        <div className="rounded border p-3">
+          <div className="font-medium mb-2">Merged (preview)</div>
+          <pre className="text-xs overflow-auto max-h-72">{JSON.stringify(merged, null, 2)}</pre>
+        </div>
+      </section>
+
+      <section className="grid md:grid-cols-2 gap-4">
+        <div className="rounded border p-3 space-y-3">
+          <div className="font-medium">Filters</div>
+          <label className="text-sm">Include (comma)</label>
+          <input className="input input-sm w-full"
+            value={(preset.include??[]).join(',')}
+            onChange={(e)=>upsert({ ...preset, include: e.target.value.split(',').map(s=>s.trim()).filter(Boolean) })}/>
+          <label className="text-sm mt-2">Exclude (comma)</label>
+          <input className="input input-sm w-full"
+            value={(preset.exclude??[]).join(',')}
+            onChange={(e)=>upsert({ ...preset, exclude: e.target.value.split(',').map(s=>s.trim()).filter(Boolean) })}/>
+          <div className="flex items-center gap-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={!preset.rootHidden}
+                onChange={(e)=>upsert({ ...preset, rootHidden: !e.target.checked })}/>
+              Show Sidebar
+            </label>
+          </div>
+        </div>
+
+        <OverlayEditor
+          value={preset.overlay ?? []}
+          onChange={(overlay)=>upsert({ ...preset, overlay })}
+        />
+      </section>
+
+      <p className="text-xs text-[color:var(--muted)]">
+        Overlay は <code>[[{"ref":"/builder","label":"Builder","children":[...]}}]</code> のように、
+        参照（ref）で並びと階層を定義します。ref は自動ツリーの id（= パス）に合わせてください。
+      </p>
+    </div>
+  );
+}

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -1,0 +1,36 @@
+'use client';
+import Link from 'next/link';
+import { mergeMenu } from '@/lib/menu';
+import { useSidebarStore } from '@/store/sidebarStore';
+
+function NodeView({ n }: { n: any }) {
+  if (n.hidden) return null;
+  return (
+    <li>
+      <Link href={n.href} className="block px-3 py-1.5 rounded hover:bg-[color:var(--panel2)]">
+        {n.label}
+      </Link>
+      {n.children?.length ? (
+        <ul className="ml-3 border-l border-[color:var(--border)] pl-2 space-y-1">
+          {n.children.map((c: any) => <NodeView key={c.id} n={c} />)}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+export default function Sidebar() {
+  const preset = useSidebarStore(s => s.active());
+  if (preset.rootHidden) return null;
+  const tree = mergeMenu(preset);
+
+  return (
+    <aside className="w-64 shrink-0 border-r"
+           style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
+      <div className="p-3 text-xs uppercase tracking-wide text-[color:var(--muted)]">Menu</div>
+      <ul className="px-2 pb-4 space-y-1">
+        {tree.map((n) => <NodeView key={n.id} n={n} />)}
+      </ul>
+    </aside>
+  );
+}

--- a/web/lib/menu.ts
+++ b/web/lib/menu.ts
@@ -1,0 +1,70 @@
+import type { MenuNode, OverlayNode, SidebarPreset } from '@/types/sidebar';
+import { GENERATED_MENU } from '../.generated/menu.gen';
+
+export function buildAutoTree(): MenuNode[] {
+  const root: MenuNode = { id: '/', href: '/', label: 'Home', children: [] };
+  const byPath = new Map<string, MenuNode>([['/', root]]);
+
+  for (const item of GENERATED_MENU) {
+    const parts = item.segments;
+    let parent = root;
+    let path = '';
+    for (let i = 0; i < parts.length; i++) {
+      path += '/' + parts[i];
+      if (!byPath.has(path)) {
+        const node: MenuNode = { id: path, href: path, label: i === parts.length - 1 ? item.label : parts[i], children: [] };
+        byPath.set(path, node);
+        parent.children!.push(node);
+      }
+      parent = byPath.get(path)!;
+    }
+  }
+  return root.children ?? [];
+}
+
+function applyIncludeExclude(nodes: MenuNode[], include?: string[], exclude?: string[]) {
+  const inc = include && include.length ? new Set(include) : null;
+  const exc = new Set(exclude ?? []);
+  const walk = (arr: MenuNode[]): MenuNode[] =>
+    arr
+      .filter(n => (!inc || inc.has(n.id) || (n.children && n.children.some(c => inc!.has(c.id)))) && !exc.has(n.id))
+      .map(n => ({ ...n, children: n.children ? walk(n.children) : undefined }));
+  return walk(nodes);
+}
+
+function buildIndex(nodes: MenuNode[], idx = new Map<string, MenuNode>()): Map<string, MenuNode> {
+  for (const n of nodes) { idx.set(n.id, n); if (n.children) buildIndex(n.children, idx); }
+  return idx;
+}
+
+function materializeOverlay(overlay: OverlayNode[], index: Map<string, MenuNode>): MenuNode[] {
+  const mat = (o: OverlayNode): MenuNode | null => {
+    const base = index.get(o.ref);
+    if (!base) return null;
+    return {
+      id: base.id,
+      href: base.href,
+      label: o.label ?? base.label,
+      hidden: o.hidden ?? base.hidden,
+      children: o.children ? o.children.map(mat).filter(Boolean) as MenuNode[] : undefined,
+    };
+  };
+  return overlay.map(mat).filter(Boolean) as MenuNode[];
+}
+
+export function mergeMenu(preset: SidebarPreset): MenuNode[] {
+  const auto = buildAutoTree();
+  if (preset.mode === 'manual') {
+    const idx = buildIndex(auto);
+    return preset.overlay ? materializeOverlay(preset.overlay, idx) : [];
+  }
+  const filtered = applyIncludeExclude(auto, preset.include, preset.exclude);
+  if (!preset.overlay?.length) return filtered;
+
+  const idx = buildIndex(filtered);
+  const over = materializeOverlay(preset.overlay, idx);
+  const used = new Set<string>();
+  (function mark(arr: MenuNode[]) { arr.forEach(n => { used.add(n.id); if (n.children) mark(n.children); }); })(over);
+  const rest = filtered.filter(n => !used.has(n.id));
+  return [...over, ...rest];
+}

--- a/web/package.json
+++ b/web/package.json
@@ -4,12 +4,17 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "gen:menu": "tsx scripts/generate-menu.ts",
+    "predev": "pnpm gen:menu",
+    "prebuild": "pnpm gen:menu"
   },
   "dependencies": {
     "@core": "workspace:*",
     "@data": "workspace:*",
     "@domain-components": "workspace:*",
+    "@repo/comp-maps-jp": "workspace:*",
+    "@repo/types": "workspace:*",
     "@schemas": "workspace:*",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",
@@ -20,15 +25,15 @@
     "next": "14.2.5",
     "octokit": "^5.0.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "@repo/types": "workspace:*",
-    "@repo/comp-maps-jp": "workspace:*"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "eslint": "^9.34.0",
+    "fast-glob": "^3.3.3",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.10",
+    "tsx": "^4.20.5",
     "typescript": "^5.4.0"
   }
 }

--- a/web/scripts/generate-menu.ts
+++ b/web/scripts/generate-menu.ts
@@ -1,0 +1,36 @@
+import fg from 'fast-glob';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const APP_DIR = join(process.cwd(), 'app');
+
+// 除外ルール（適宜調整）
+const IGNORE = [
+  '**/api/**',
+  '**/_*/*',
+  // '**/(*)/**', // ルートグループ
+  '**/node_modules/**',
+  '**/.*',
+];
+
+function humanize(seg: string) {
+  return seg.replace(/^\[(.+)\]$/, '$1').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+async function main() {
+  const files = await fg(['**/page.tsx', '**/page.ts'], { cwd: APP_DIR, ignore: IGNORE });
+  const routes = files.map(f => {
+    const dir = f.replace(/\/page\.tsx?$/, '');
+    const href = '/' + dir.replace(/\\/g, '/');
+    const segments = href.split('/').filter(Boolean);
+    const label = humanize(segments[segments.length - 1] || 'Home');
+    return { id: href || '/', href: href || '/', label, segments };
+  });
+
+  const out = `// GENERATED FILE. DO NOT EDIT.\nexport type GeneratedItem = { id: string; href: string; label: string; segments: string[] };\nexport const GENERATED_MENU: GeneratedItem[] = ${JSON.stringify(routes, null, 2)};\n`;
+  const outDir = join(process.cwd(), '.generated');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'menu.gen.ts'), out, 'utf8');
+  console.log('Generated', routes.length, 'routes.');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/web/store/sidebarStore.ts
+++ b/web/store/sidebarStore.ts
@@ -1,0 +1,41 @@
+'use client';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { SidebarPreset } from '@/types/sidebar';
+
+const DEFAULTS: SidebarPreset[] = [{
+  id: 'auto-default',
+  name: 'Auto (all)',
+  mode: 'auto+overlay',
+  include: [],
+  exclude: [],
+  overlay: [],
+  rootHidden: false,
+}];
+
+type State = { presets: SidebarPreset[]; activeId: string; };
+type Actions = {
+  apply: (id: string) => void;
+  upsert: (p: SidebarPreset) => void;
+  remove: (id: string) => void;
+  active: () => SidebarPreset;
+};
+
+export const useSidebarStore = create<State & Actions>()(
+  persist(
+    (set, get) => ({
+      presets: DEFAULTS,
+      activeId: DEFAULTS[0].id,
+      apply: (id) => set({ activeId: id }),
+      upsert: (p) => {
+        const list = [...get().presets];
+        const i = list.findIndex(x => x.id === p.id);
+        if (i >= 0) list[i] = p; else list.push(p);
+        set({ presets: list });
+      },
+      remove: (id) => set({ presets: get().presets.filter(p => p.id !== id) }),
+      active: () => get().presets.find(p => p.id === get().activeId)!,
+    }),
+    { name: 'sidebar-presets' }
+  )
+);

--- a/web/types/sidebar.ts
+++ b/web/types/sidebar.ts
@@ -1,0 +1,27 @@
+export type RouteId = string; // 例: "/builder"
+
+export type MenuNode = {
+  id: RouteId;
+  label: string;
+  href: string;
+  children?: MenuNode[];
+  hidden?: boolean;
+  icon?: string;
+};
+
+export type OverlayNode = {
+  ref: RouteId;             // 自動ノードの参照（href と同じ）
+  label?: string;           // ラベル上書き
+  hidden?: boolean;
+  children?: OverlayNode[]; // 再親化＆並び替え
+};
+
+export type SidebarPreset = {
+  id: string;
+  name: string;
+  mode: 'auto+overlay' | 'manual';
+  include?: RouteId[];      // 自動から許可（空=全許可）
+  exclude?: RouteId[];      // 非表示
+  overlay?: OverlayNode[];  // 手動オーバーレイ
+  rootHidden?: boolean;     // サイドバー自体の表示/非表示
+};


### PR DESCRIPTION
## Summary
- add sidebar type definitions and automated menu generator
- build menu tree with overlay merge logic
- persistable sidebar presets with editor and runtime sidebar

## Testing
- `pnpm -C web gen:menu`
- `pnpm -C web build` *(fails: Can't resolve '@core/action-bus', '@domain-components', '@data', 'next-auth/react')*


------
https://chatgpt.com/codex/tasks/task_e_68b65f7ef048832ca5c3f902c22ba2a0