### PR TITLE
feat: add preset palette with Japan map card

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -12,6 +12,8 @@ import type {
 import { buildPresetCss } from '@/lib/interactionCss'
 import { emitApply } from '@/lib/presetChannel'
 import { useEditorStore } from '@/store/editorStore'
+import { useBuilderStore } from '@/store/builderStore'
+import { PRESETS } from '@/lib/presets'
 
 const ALL_TRIGGERS: Trigger[] = ['hover','active','focus','focusWithin','groupHover']
 const EFFECT_OPTIONS: Effect['kind'][] = ['bgColor','textColor','borderColor','shadow','scale','opacity','translate','rotate','outline','cursor']
@@ -24,11 +26,23 @@ export default function ActionDesignerPage() {
   const onNew = () => add({ name:'New Preset', triggers:['hover'], effects:[], transitionMs:120, easing:'cubic-bezier(.2,.8,.2,1)' })
   const sel = presets.find(p => p.id === selectedId)
   const selectedNodeId = useEditorStore(s => s.selectedIds[0])
+  const placePreset = useBuilderStore((s) => s.placePreset)
 
   const css = useMemo(() => sel ? buildPresetCss('preview-node', sel) : '', [sel])
 
   return (
     <div className="h-full flex bg-neutral-950 text-neutral-100">
+      <div className="absolute top-2 left-2 flex gap-2 z-50">
+        {PRESETS.map((p) => (
+          <button
+            key={p.id}
+            className="px-2 py-1 bg-neutral-800 rounded text-xs"
+            onClick={() => placePreset(p.id)}
+          >
+            Place: {p.displayName}
+          </button>
+        ))}
+      </div>
       {/* 左：一覧 */}
       <div className="w-72 border-r border-neutral-800 p-3 flex flex-col gap-2">
         <div className="flex gap-2">

--- a/web/components/Card.tsx
+++ b/web/components/Card.tsx
@@ -1,0 +1,29 @@
+'use client'
+import React from 'react'
+
+type CardProps = {
+  title?: string
+  toolbar?: React.ReactNode
+  className?: string
+  children?: React.ReactNode
+}
+
+export default function Card({ title, toolbar, className, children }: CardProps) {
+  return (
+    <div
+      className={[
+        'rounded-2xl shadow-sm border bg-background',
+        'flex flex-col min-w-[240px] min-h-[160px]',
+        className ?? '',
+      ].join(' ')}
+    >
+      {(title || toolbar) && (
+        <div className="px-3 py-2 border-b flex items-center justify-between">
+          <div className="text-sm font-medium truncate">{title}</div>
+          <div className="flex items-center gap-2">{toolbar}</div>
+        </div>
+      )}
+      <div className="p-3 flex-1 overflow-auto">{children}</div>
+    </div>
+  )
+}

--- a/web/components/domain/JapanMap.tsx
+++ b/web/components/domain/JapanMap.tsx
@@ -1,0 +1,43 @@
+'use client'
+import React from 'react'
+
+export type PrefCode = string // e.g. '13' for Tokyo
+export type JapanMapProps = {
+  valuesByPref?: Record<PrefCode, number>
+  selected?: PrefCode | null
+  onSelect?: (pref: PrefCode) => void
+}
+
+const PREFS: PrefCode[] = [
+  '01','02','03','04','05','06','07','08','09','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47'
+]
+
+export default function JapanMap({ valuesByPref, selected, onSelect }: JapanMapProps) {
+  const safeValues: Record<PrefCode, number> = valuesByPref ?? {}
+  const maxVal = PREFS.reduce((m, p) => Math.max(m, safeValues[p] ?? 0), 0)
+
+  return (
+    <div className="grid grid-cols-6 gap-1 text-xs select-none">
+      {PREFS.map((code) => {
+        const v = safeValues[code] ?? 0
+        const intensity = maxVal > 0 ? Math.round((v / maxVal) * 90) : 0
+        const isSel = selected === code
+        return (
+          <button
+            key={code}
+            onClick={() => onSelect?.(code)}
+            className={[
+              'h-8 rounded-md border flex items-center justify-center',
+              isSel ? 'ring-2 ring-blue-500' : '',
+            ].join(' ')}
+            style={{ background: `hsl(210 70% ${100 - intensity}%)` }}
+            aria-pressed={isSel}
+            title={`pref:${code} value:${v}`}
+          >
+            {code}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/components/palette/PresetsFilterBar.tsx
+++ b/web/components/palette/PresetsFilterBar.tsx
@@ -1,0 +1,50 @@
+'use client'
+import React from 'react'
+import { usePresetsFilter } from '@/store/presetsFilterStore'
+
+function Chip({ active, onClick, children, title }: { active?: boolean; onClick?: () => void; children: React.ReactNode; title?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={[
+        'h-7 px-2 rounded-full border text-xs',
+        active ? 'bg-primary text-primary-foreground border-primary' : 'bg-background hover:bg-accent',
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  )
+}
+
+export default function PresetsFilterBar() {
+  const { activeDomains, toggleDomain, setOnly, reset, alwaysShowCommon } = usePresetsFilter()
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-[11px] text-muted-foreground">表示</span>
+      <span className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded bg-muted" title="常に表示（common）">
+        📌 共通
+      </span>
+      <Chip active={activeDomains.travel} onClick={() => toggleDomain('travel')} title="旅系だけ表示/非表示">
+        旅
+      </Chip>
+      <Chip active={activeDomains.accounting} onClick={() => toggleDomain('accounting')} title="会計系だけ表示/非表示">
+        会計
+      </Chip>
+      <Chip onClick={() => setOnly('travel')} title="旅系のみ">
+        旅のみ
+      </Chip>
+      <Chip onClick={() => setOnly('accounting')} title="会計のみ">
+        会計のみ
+      </Chip>
+      <Chip onClick={reset} title="すべて表示（フィルタ無効）">
+        全表示
+      </Chip>
+      {!alwaysShowCommon && (
+        <span className="text-[11px] text-warning">※共通の常時表示が無効です</span>
+      )}
+    </div>
+  )
+}

--- a/web/components/palette/PresetsSection.tsx
+++ b/web/components/palette/PresetsSection.tsx
@@ -1,0 +1,44 @@
+'use client'
+import React, { useMemo } from 'react'
+import { PRESETS, type PresetDef } from '@/lib/presets'
+import { useBuilderStore } from '@/store/builderStore'
+import PresetsFilterBar from './PresetsFilterBar'
+import { usePresetsFilter } from '@/store/presetsFilterStore'
+
+export default function PresetsSection() {
+  const placePreset = useBuilderStore((s) => s.placePreset)
+  const { activeDomains, alwaysShowCommon } = usePresetsFilter()
+
+  const activeSet = useMemo(
+    () => new Set(Object.entries(activeDomains).filter(([, v]) => v).map(([k]) => k)),
+    [activeDomains],
+  )
+
+  const shouldShow = (p: PresetDef) => {
+    if (alwaysShowCommon && p.tags.includes('common')) return true
+    if (activeSet.size === 0) return true
+    return p.tags.some((t) => activeSet.has(t))
+  }
+
+  const list = PRESETS.filter(shouldShow)
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-xs font-semibold text-muted-foreground">Presets</h3>
+      <PresetsFilterBar />
+      <div className="grid grid-cols-2 gap-2">
+        {list.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => placePreset(p.id)}
+            className="border rounded-lg p-2 text-left hover:bg-accent"
+            title={p.tags.join(', ')}
+          >
+            <div className="text-sm font-medium">{p.displayName}</div>
+            <div className="text-[10px] text-muted-foreground">{p.id}</div>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web/lib/ids.ts
+++ b/web/lib/ids.ts
@@ -1,0 +1,1 @@
+export const newId = (p = 'n') => `${p}_${crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)}`

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -1,0 +1,64 @@
+import type { ComponentNode } from '@/types/editor'
+import { newId } from './ids'
+
+export type DomainTag = 'common' | 'travel' | 'accounting'
+export type PresetTag = DomainTag | 'card' | 'map' | 'chart' | 'analytics'
+
+export type PresetDef = {
+  id: string
+  displayName: string
+  icon?: string
+  tags: PresetTag[]
+  tree: ComponentNode
+}
+
+export const cloneSubtree = (node: ComponentNode): ComponentNode => {
+  return {
+    ...node,
+    id: newId('n'),
+    children: node.children?.map(cloneSubtree),
+  }
+}
+
+export const preset_japanMapCard_basic: PresetDef = {
+  id: 'preset.jpmap.card.basic',
+  displayName: 'JapanMap（カード/基本）',
+  tags: ['common', 'map', 'card', 'analytics'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: 'Japan Map', className: 'w-[520px] h-[360px]' } as any,
+    children: [
+      {
+        id: newId('n'),
+        type: 'JapanMap',
+        props: {
+          valuesByPref: {},
+          selected: null,
+        } as any,
+      },
+    ],
+  },
+}
+
+export const preset_travelTimeline: PresetDef = {
+  id: 'preset.travel.timeline',
+  displayName: '旅程タイムライン（カード）',
+  tags: ['travel', 'card'],
+  tree: { id: newId('n'), type: 'Card', props: { title: '旅程' } as any, children: [] },
+}
+
+export const preset_accountingJournal: PresetDef = {
+  id: 'preset.accounting.journal',
+  displayName: '仕訳一覧（カード）',
+  tags: ['accounting', 'card'],
+  tree: { id: newId('n'), type: 'Card', props: { title: '仕訳' } as any, children: [] },
+}
+
+export const PRESETS: PresetDef[] = [
+  preset_japanMapCard_basic,
+  preset_travelTimeline,
+  preset_accountingJournal,
+]
+
+export const getPresetById = (id: string) => PRESETS.find((p) => p.id === id)

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -1,4 +1,6 @@
 import type { ComponentMeta } from '@/types/builder';
+import Card from '@/components/Card';
+import JapanMap from '@/components/domain/JapanMap';
 
 export type RegistryItem = {
   meta: ComponentMeta;
@@ -50,4 +52,28 @@ DEFAULT_COMPONENTS.forEach((c) => {
     },
     Render: () => null,
   });
+});
+
+register({
+  meta: {
+    id: 'Card',
+    displayName: 'Card',
+    props: [],
+    allowChildren: true,
+    defaultW: 240,
+    defaultH: 160,
+  },
+  Render: Card,
+});
+
+register({
+  meta: {
+    id: 'JapanMap',
+    displayName: 'JapanMap',
+    props: [],
+    allowChildren: false,
+    defaultW: 520,
+    defaultH: 360,
+  },
+  Render: JapanMap,
 });

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -2,6 +2,7 @@
 import { create } from 'zustand'
 import { produce } from 'immer'
 import { getDef } from '@/lib/registry'
+import { getPresetById, cloneSubtree } from '@/lib/presets'
 import { useGridStore } from '@/store/gridStore'
 import { useHistoryStore } from './historyStore'
 import type { ActionMap } from '@/types/actions'
@@ -63,6 +64,7 @@ type BuilderState = {
 }
 
 type BuilderActions = {
+  placePreset: (presetId: string, pos?: { x: number; y: number }) => void
   addFromPalette: (type: string, at?: { x: number; y: number }, meta?: any) => void
   move: (id: string, to: { x: number; y: number }, snapGrid?: boolean) => void
   resize: (id: string, to: { w: number; h: number }, snapGrid?: boolean) => void
@@ -133,6 +135,49 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set, get) 
     selectedIds: [],
     ui: { guides: [] },
     historyBatchDepth: 0,
+
+  placePreset(presetId, pos) {
+    const preset = getPresetById(presetId)
+    if (!preset) return
+    const root = cloneSubtree(preset.tree)
+
+    const flatten = (node: any, parentId: string | null, acc: Elm[]): Elm => {
+      const id = node.id
+      const x = parentId ? 0 : Math.round(pos?.x ?? 40)
+      const y = parentId ? 0 : Math.round(pos?.y ?? 40)
+      const def = getDef(node.type)
+      const w = def?.meta?.defaultW ?? 160
+      const h = def?.meta?.defaultH ?? 40
+      const elm: Elm = {
+        id,
+        type: node.type,
+        x,
+        y,
+        w,
+        h,
+        visible: true,
+        locked: false,
+        parentId,
+        children: [],
+        props: node.props,
+      }
+      acc.push(elm)
+      node.children?.forEach((ch: any) => {
+        const child = flatten(ch, id, acc)
+        elm.children?.push(child.id)
+      })
+      return elm
+    }
+
+    const list: Elm[] = []
+    const rootElm = flatten(root, null, list)
+    set((s) => ({
+      elements: [...s.elements, ...list],
+      tree: [...s.tree, rootElm],
+      selectedId: rootElm.id,
+      selectedIds: [rootElm.id],
+    }))
+  },
 
   addFromPalette(type, pos, meta) {
     const s = get()

--- a/web/store/presetsFilterStore.ts
+++ b/web/store/presetsFilterStore.ts
@@ -1,0 +1,28 @@
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type Domain = 'travel' | 'accounting'
+
+type PresetsFilterState = {
+  activeDomains: Record<Domain, boolean>
+  alwaysShowCommon: boolean
+  toggleDomain: (d: Domain) => void
+  setOnly: (d: Domain) => void
+  reset: () => void
+}
+
+export const usePresetsFilter = create(
+  persist<PresetsFilterState>(
+    (set) => ({
+      activeDomains: { travel: false, accounting: false },
+      alwaysShowCommon: true,
+      toggleDomain: (d) =>
+        set((s) => ({ activeDomains: { ...s.activeDomains, [d]: !s.activeDomains[d] } })),
+      setOnly: (d) =>
+        set(() => ({ activeDomains: { travel: false, accounting: false, [d]: true } as Record<Domain, boolean> })),
+      reset: () => set(() => ({ activeDomains: { travel: false, accounting: false } })),
+    }),
+    { name: 'presets-filter-v1' },
+  ),
+)


### PR DESCRIPTION
## Summary
- add reusable Card and JapanMap components
- introduce preset registry with filtering and placement
- register new components in builder registry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b661f32b9c832cbc2a9d334ecff446