### PR TITLE
Add prefecture paint share components

### DIFF
--- a/web/components/travel/PrefGridMap.tsx
+++ b/web/components/travel/PrefGridMap.tsx
@@ -1,0 +1,32 @@
+'use client'
+import React from 'react'
+import { PREFS } from '@/lib/japanPrefs'
+import { usePrefPaint } from '@/store/prefPaintStore'
+
+export default function PrefGridMap() {
+  const painted = usePrefPaint(s => s.painted)
+  const toggle = usePrefPaint(s => s.toggle)
+
+  return (
+    <div className="grid grid-cols-6 gap-1 text-xs select-none">
+      {PREFS.map(({ code, name }) => {
+        const on = !!painted[code]
+        return (
+          <button
+            key={code}
+            onClick={() => toggle(code)}
+            className={[
+              'h-9 rounded-md border flex items-center justify-center px-2',
+              on ? 'ring-1 ring-blue-500' : '',
+            ].join(' ')}
+            style={{ background: on ? 'hsl(210 80% 60%)' : 'hsl(0 0% 98%)' }}
+            title={`${name} (${code})`}
+            aria-pressed={on}
+          >
+            <span className="truncate">{name}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/components/travel/PrefShareBar.tsx
+++ b/web/components/travel/PrefShareBar.tsx
@@ -1,0 +1,32 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { usePrefPaint } from '@/store/prefPaintStore'
+
+export default function PrefShareBar() {
+  const exportB64 = usePrefPaint(s => s.exportB64)
+  const importB64 = usePrefPaint(s => s.importB64)
+  const [copied, setCopied] = useState(false)
+
+  const copyLink = () => {
+    const b64 = exportB64()
+    const url = new URL(location.href)
+    url.searchParams.set('p', b64)
+    navigator.clipboard?.writeText(url.toString())
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1200)
+  }
+
+  useEffect(() => {
+    const p = new URLSearchParams(location.search).get('p')
+    if (p) importB64(p)
+  }, [importB64])
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <button className="px-2 py-1 border rounded" onClick={copyLink}>
+        {copied ? 'コピーした！' : 'シェアリンクをコピー'}
+      </button>
+      <span className="text-muted-foreground">リンクを送れば同じ塗りが再現されるよ</span>
+    </div>
+  )
+}

--- a/web/lib/japanPrefs.ts
+++ b/web/lib/japanPrefs.ts
@@ -1,0 +1,20 @@
+export type Pref = { code: string; name: string }
+export const PREFS: Pref[] = [
+  { code: '01', name: '北海道' }, { code: '02', name: '青森' }, { code: '03', name: '岩手' },
+  { code: '04', name: '宮城' }, { code: '05', name: '秋田' }, { code: '06', name: '山形' },
+  { code: '07', name: '福島' }, { code: '08', name: '茨城' }, { code: '09', name: '栃木' },
+  { code: '10', name: '群馬' }, { code: '11', name: '埼玉' }, { code: '12', name: '千葉' },
+  { code: '13', name: '東京' }, { code: '14', name: '神奈川' }, { code: '15', name: '新潟' },
+  { code: '16', name: '富山' }, { code: '17', name: '石川' }, { code: '18', name: '福井' },
+  { code: '19', name: '山梨' }, { code: '20', name: '長野' }, { code: '21', name: '岐阜' },
+  { code: '22', name: '静岡' }, { code: '23', name: '愛知' }, { code: '24', name: '三重' },
+  { code: '25', name: '滋賀' }, { code: '26', name: '京都' }, { code: '27', name: '大阪' },
+  { code: '28', name: '兵庫' }, { code: '29', name: '奈良' }, { code: '30', name: '和歌山' },
+  { code: '31', name: '鳥取' }, { code: '32', name: '島根' }, { code: '33', name: '岡山' },
+  { code: '34', name: '広島' }, { code: '35', name: '山口' }, { code: '36', name: '徳島' },
+  { code: '37', name: '香川' }, { code: '38', name: '愛媛' }, { code: '39', name: '高知' },
+  { code: '40', name: '福岡' }, { code: '41', name: '佐賀' }, { code: '42', name: '長崎' },
+  { code: '43', name: '熊本' }, { code: '44', name: '大分' }, { code: '45', name: '宮崎' },
+  { code: '46', name: '鹿児島' }, { code: '47', name: '沖縄' },
+]
+export const CODES = PREFS.map(p => p.code)

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -71,10 +71,26 @@ export const preset_itineraryTimelineCard: PresetDef = {
   },
 }
 
+export const preset_travelPrefPaintCard: PresetDef = {
+  id: 'preset.travel.prefpaint.card',
+  displayName: '都道府県ぬりえ（カード）',
+  tags: ['travel', 'card'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: '地図コレ・ぬりえ', className: 'w-[560px] h-[420px]' } as any,
+    children: [
+      { id: newId('n'), type: 'PrefShareBar', props: {} as any },
+      { id: newId('n'), type: 'PrefGridMap', props: {} as any },
+    ],
+  },
+}
+
 export const PRESETS: PresetDef[] = [
   preset_japanMapCard_basic,
   preset_tripHeaderCard,
   preset_itineraryTimelineCard,
+  preset_travelPrefPaintCard,
 ]
 
 export const getPresetById = (id: string) => PRESETS.find((p) => p.id === id)

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -3,6 +3,8 @@ import Card from '@/components/Card';
 import TripHeader from '@/components/travel/TripHeader';
 import ItineraryTimeline from '@/components/travel/ItineraryTimeline';
 import JapanMap from '@/components/domain/JapanMap';
+import PrefShareBar from '@/components/travel/PrefShareBar';
+import PrefGridMap from '@/components/travel/PrefGridMap';
 
 export type RegistryItem = {
   meta: ComponentMeta;
@@ -102,4 +104,28 @@ register({
     defaultH: 360,
   },
   Render: JapanMap,
+});
+
+register({
+  meta: {
+    id: 'PrefShareBar',
+    displayName: 'PrefShareBar',
+    props: [],
+    allowChildren: false,
+    defaultW: 320,
+    defaultH: 40,
+  },
+  Render: PrefShareBar,
+});
+
+register({
+  meta: {
+    id: 'PrefGridMap',
+    displayName: 'PrefGridMap',
+    props: [],
+    allowChildren: false,
+    defaultW: 560,
+    defaultH: 360,
+  },
+  Render: PrefGridMap,
 });

--- a/web/store/prefPaintStore.ts
+++ b/web/store/prefPaintStore.ts
@@ -1,0 +1,61 @@
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { CODES } from '@/lib/japanPrefs'
+
+type PaintState = Record<string, boolean>
+
+const pack = (state: PaintState) => {
+  // 47bitをバイト配列に
+  const bits = CODES.map(c => (state[c] ? 1 : 0))
+  const bytes: number[] = []
+  for (let i = 0; i < bits.length; i += 8) {
+    let b = 0
+    for (let j = 0; j < 8 && i + j < bits.length; j++) b |= bits[i + j] << (7 - j)
+    bytes.push(b)
+  }
+  const bin = String.fromCharCode(...bytes)
+  return btoa(bin) // Base64
+}
+
+const unpack = (b64: string): PaintState => {
+  try {
+    const bin = atob(b64)
+    const bytes = Array.from(bin, ch => ch.charCodeAt(0))
+    const res: PaintState = {}
+    let idx = 0
+    for (let i = 0; i < bytes.length && idx < CODES.length; i++) {
+      const byte = bytes[i]
+      for (let bit = 7; bit >= 0 && idx < CODES.length; bit--) {
+        res[CODES[idx]] = ((byte >> bit) & 1) === 1
+        idx++
+      }
+    }
+    return res
+  } catch { return {} }
+}
+
+type Store = {
+  painted: PaintState
+  toggle: (code: string) => void
+  set: (code: string, v: boolean) => void
+  clearAll: () => void
+  fillAll: () => void
+  exportB64: () => string
+  importB64: (b64: string) => void
+}
+
+export const usePrefPaint = create(
+  persist<Store>(
+    (set, get) => ({
+      painted: {},
+      toggle: (code) => set(s => ({ painted: { ...s.painted, [code]: !s.painted[code] } })),
+      set: (code, v) => set(s => ({ painted: { ...s.painted, [code]: v } })),
+      clearAll: () => set({ painted: {} }),
+      fillAll: () => set({ painted: Object.fromEntries(CODES.map(c => [c, true])) }),
+      exportB64: () => pack(get().painted),
+      importB64: (b64: string) => set({ painted: unpack(b64) }),
+    }),
+    { name: 'pref-paint-v1' }
+  )
+)


### PR DESCRIPTION
## Summary
- add Japan prefecture list and paint store with Base64 sharing
- add grid map and share bar components
- register components and preset for quick placement

## Testing
- `pnpm test`
- `pnpm build` *(fails: Module not found: Can't resolve '@core/action-bus')*


------
https://chatgpt.com/codex/tasks/task_e_68b6677721cc832cb22be837efd9e521