### PR TITLE
feat(travel): minimal paint & share demo (no Firebase)

### DIFF
--- a/web/app/travel/demo/page.tsx
+++ b/web/app/travel/demo/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+import React from 'react'
+import PrefShareBar from '@/components/travel/PrefShareBar'
+import PrefGridMap from '@/components/travel/PrefGridMap'
+
+export default function TravelDemoPage() {
+  return (
+    <div className="p-6 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-xl font-bold">地図コレ・ぬりえ（デモ）</h1>
+      <div className="rounded-2xl border shadow-sm p-4 space-y-3 bg-background">
+        <PrefShareBar />
+        <PrefGridMap />
+      </div>
+      <p className="text-sm text-muted-foreground">
+        47都道府県をクリックで塗り／外し。<br />
+        「シェアリンクをコピー」でURL（?p=Base64）を共有すると、開いた先で自動復元されます。
+      </p>
+    </div>
+  )
+}

--- a/web/components/travel/PrefShareBar.tsx
+++ b/web/components/travel/PrefShareBar.tsx
@@ -13,7 +13,7 @@ export default function PrefShareBar() {
     url.searchParams.set('p', b64)
     navigator.clipboard?.writeText(url.toString())
     setCopied(true)
-    setTimeout(() => setCopied(false), 1200)
+    setTimeout(() => setCopied(false), 1000)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add demo page that showcases prefecture painting with share links
- tweak share bar copy timeout

## Testing
- `pnpm -C web build`
- `pnpm -C web dev`

------
https://chatgpt.com/codex/tasks/task_e_68b67b249a50832c9c85fbd1bea86412