### PR TITLE
docs: add porting audit and decision

### DIFF
--- a/docs/env_status.md
+++ b/docs/env_status.md
@@ -1,0 +1,4 @@
+# Environment Status
+
+No `.env` or `.env.local` files with Firebase configuration exist in the repository. Firebase environment variables are currently undefined.
+

--- a/docs/porting_audit.md
+++ b/docs/porting_audit.md
@@ -1,0 +1,12 @@
+# Porting Audit
+
+## travel/
+- No `travel/` directory or Firebase setup found in repository. Initial search for `travel` at root returned no results.
+
+## web/
+- `web/app/travel/demo/page.tsx` renders demo page using travel components.
+- `web/components/travel/PrefGridMap.tsx` and `PrefShareBar.tsx` provide simple local painting and sharing via Base64.
+- `web/store/prefPaintStore.ts` stores painted prefectures locally with import/export helpers.
+- No Firebase initialization or services exist in `web/` yet.
+- No `.env` files containing `NEXT_PUBLIC_FIREBASE_*` were found.
+

--- a/docs/porting_decision.md
+++ b/docs/porting_decision.md
@@ -1,0 +1,4 @@
+# Porting Decision
+
+No `travel/` implementation is present in this repository, so Firebase logic and service layers cannot be reused or ported. Implementation is blocked until the `travel/` source is available.
+


### PR DESCRIPTION
## Summary
- document initial audit of missing travel Firebase code
- note decision blocked until travel source available
- record environment status (no Firebase env vars)

## Testing
- `pnpm -C web build`

------
https://chatgpt.com/codex/tasks/task_e_68b67e062b2c832cb5af748c2c4e6e9d