### PR TITLE
chore(web): wire Firebase via travel code + path aliases (no UI changes)

### DIFF
--- a/docs/porting_decision.md
+++ b/docs/porting_decision.md
@@ -1,4 +1,12 @@
 # Porting Decision
 
-No `travel/` implementation is present in this repository, so Firebase logic and service layers cannot be reused or ported. Implementation is blocked until the `travel/` source is available.
+## Strategy
+Chosen: **C — minimal copy/stub**.
 
+The repository lacks a standalone `travel/` app, so shared path imports (`@travel/*`) cannot resolve. A TypeScript compile test failed with `Cannot find module '@travel/anything'`, demonstrating that aliasing to a non-existent package breaks the build.
+
+## Impact
+- Added stub Firebase wiring and service layer under `web/` (approx. 30 lines total).
+- No changes to existing modules; `travel/` remains untouched.
+
+Further implementation requires the original `travel/` source to replace stubs.

--- a/docs/porting_scan.md
+++ b/docs/porting_scan.md
@@ -1,0 +1,11 @@
+# Porting Scan
+
+## travel/
+- (directory missing) Existing Firebase setup, services, Firestore rules, and env files not found.
+
+## web/
+- `components/domain/maps/JapanMap.tsx`: `Visit` union (`'none'|'passed'|'visited'|'lived'`) cycles on click via `CYCLE` array; uses `useMapUIStore` for hover.
+- `app/travel/demo/page.tsx` present as demo page; no `/app/u/[uid]/m/[mapId]` route detected.
+- `.env.local` located at `web/.env.local`; no other env files.
+- `tsconfig.json` defines path aliases (`@core/*`, `@domain-components`, `@data`, `@/*`); none unresolved.
+- 47-prefecture map store found in `components/domain/maps/mapStore.ts` (hover state only).

--- a/web/lib/firebase.ts
+++ b/web/lib/firebase.ts
@@ -1,0 +1,10 @@
+/**
+ * Firebase stubs for web.
+ * The real implementation lives in the missing travel app.
+ * Replace these placeholders once the shared module becomes available.
+ */
+
+export const auth: unknown = {};
+export const db: unknown = {};
+export const storage: unknown = {};
+export const googleProvider: unknown = {};

--- a/web/services/travel.ts
+++ b/web/services/travel.ts
@@ -1,0 +1,36 @@
+/**
+ * Placeholder travel service implementations.
+ * Real logic will be copied from the travel app once available.
+ */
+
+export async function signInWithGoogle(): Promise<void> {
+  throw new Error('signInWithGoogle not implemented');
+}
+
+export function onUser(_cb: (user: unknown) => void): () => void {
+  // immediately emit null user; return unsubscribe noop
+  _cb(null);
+  return () => void 0;
+}
+
+export async function signOutNow(): Promise<void> {
+  // no-op
+}
+
+export async function createMap(): Promise<{ id: string }> {
+  return { id: 'stub' };
+}
+
+export async function getMap(): Promise<unknown> {
+  return null;
+}
+
+export async function uploadMapPhoto(): Promise<null> {
+  return null;
+}
+
+export async function requestFollow(): Promise<void> {}
+
+export async function approveFollower(): Promise<void> {}
+
+export async function setVisibility(): Promise<void> {}


### PR DESCRIPTION
## Summary
- document scan of travel vs web code base
- record decision to use minimal stubs because travel app is missing
- add stub firebase and travel service modules under web

## Testing
- `pnpm -C web build`


------
https://chatgpt.com/codex/tasks/task_e_68b67f924520832c80c55f14511b4a8f