### PR TITLE
feat(web): paint & save via travel services (MVP path)

### DIFF
--- a/docs/porting_decision.md
+++ b/docs/porting_decision.md
@@ -6,7 +6,7 @@ Chosen: **C — minimal copy/stub**.
 The repository lacks a standalone `travel/` app, so shared path imports (`@travel/*`) cannot resolve. A TypeScript compile test failed with `Cannot find module '@travel/anything'`, demonstrating that aliasing to a non-existent package breaks the build.
 
 ## Impact
-- Added stub Firebase wiring and service layer under `web/` (approx. 30 lines total).
-- No changes to existing modules; `travel/` remains untouched.
+- Expanded stub Firebase/service layer under `web/` to simulate auth and map storage via `localStorage`.
+- Added demo login and map-saving pages; `travel/` source still absent.
 
-Further implementation requires the original `travel/` source to replace stubs.
+Further implementation requires the original `travel/` source to replace mocks.

--- a/docs/porting_scan.md
+++ b/docs/porting_scan.md
@@ -8,4 +8,5 @@
 - `app/travel/demo/page.tsx` present as demo page; no `/app/u/[uid]/m/[mapId]` route detected.
 - `.env.local` located at `web/.env.local`; no other env files.
 - `tsconfig.json` defines path aliases (`@core/*`, `@domain-components`, `@data`, `@/*`); none unresolved.
-- 47-prefecture map store found in `components/domain/maps/mapStore.ts` (hover state only).
+- `useMapUIStore` hover state in `components/domain/maps/mapStore.ts`.
+- Persistent 47-prefecture paint store with bit-pack/unpack in `web/store/prefPaintStore.ts`.

--- a/web/app/travel/demo/page.tsx
+++ b/web/app/travel/demo/page.tsx
@@ -2,18 +2,20 @@
 import React from 'react'
 import PrefShareBar from '@/components/travel/PrefShareBar'
 import PrefGridMap from '@/components/travel/PrefGridMap'
+import LoginButton from '@/components/travel/LoginButton'
 
 export default function TravelDemoPage() {
   return (
     <div className="p-6 max-w-3xl mx-auto space-y-4">
       <h1 className="text-xl font-bold">地図コレ・ぬりえ（デモ）</h1>
       <div className="rounded-2xl border shadow-sm p-4 space-y-3 bg-background">
+        <div className="flex justify-end"><LoginButton /></div>
         <PrefShareBar />
         <PrefGridMap />
       </div>
       <p className="text-sm text-muted-foreground">
         47都道府県をクリックで塗り／外し。<br />
-        「シェアリンクをコピー」でURL（?p=Base64）を共有すると、開いた先で自動復元されます。
+        「保存してリンクをコピー」でURL（/u/uid/m/id）を共有すると、開いた先で自動復元されます。
       </p>
     </div>
   )

--- a/web/app/u/[uid]/m/[mapId]/page.tsx
+++ b/web/app/u/[uid]/m/[mapId]/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+import React, { useEffect } from 'react'
+import PrefGridMap from '@/components/travel/PrefGridMap'
+import { usePrefPaint } from '@/store/prefPaintStore'
+import { getMap } from '@/services/travel'
+
+export default function MapPage({ params }: { params: { uid: string; mapId: string } }) {
+  const importB64 = usePrefPaint(s => s.importB64)
+
+  useEffect(() => {
+    getMap(params.uid, params.mapId).then(b64 => {
+      if (b64) importB64(b64)
+    })
+  }, [params.uid, params.mapId, importB64])
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-xl font-bold">塗り地図</h1>
+      <PrefGridMap />
+    </div>
+  )
+}
+

--- a/web/components/travel/LoginButton.tsx
+++ b/web/components/travel/LoginButton.tsx
@@ -1,0 +1,21 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { signInWithGoogle, signOutNow, onUser } from '@/services/travel'
+
+export default function LoginButton() {
+  const [user, setUser] = useState<unknown>(null)
+
+  useEffect(() => onUser(setUser), [])
+
+  const handle = () => {
+    if (user) signOutNow()
+    else signInWithGoogle()
+  }
+
+  return (
+    <button className="px-2 py-1 border rounded" onClick={handle}>
+      {user ? 'ログアウト' : 'Googleでログイン'}
+    </button>
+  )
+}
+

--- a/web/components/travel/PrefShareBar.tsx
+++ b/web/components/travel/PrefShareBar.tsx
@@ -1,19 +1,28 @@
 'use client'
 import React, { useEffect, useState } from 'react'
 import { usePrefPaint } from '@/store/prefPaintStore'
+import { createMap, onUser } from '@/services/travel'
 
 export default function PrefShareBar() {
   const exportB64 = usePrefPaint(s => s.exportB64)
   const importB64 = usePrefPaint(s => s.importB64)
-  const [copied, setCopied] = useState(false)
+  const [user, setUser] = useState<any>(null)
+  const [msg, setMsg] = useState<string | null>(null)
 
-  const copyLink = () => {
+  useEffect(() => onUser(setUser), [])
+
+  const saveLink = async () => {
     const b64 = exportB64()
-    const url = new URL(location.href)
-    url.searchParams.set('p', b64)
-    navigator.clipboard?.writeText(url.toString())
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1000)
+    if (!user) {
+      setMsg('ログインしてね')
+      setTimeout(() => setMsg(null), 1000)
+      return
+    }
+    const { id } = await createMap(b64)
+    const url = `${location.origin}/u/${user.uid}/m/${id}`
+    await navigator.clipboard?.writeText(url)
+    setMsg('コピーした！')
+    setTimeout(() => setMsg(null), 1000)
   }
 
   useEffect(() => {
@@ -23,8 +32,8 @@ export default function PrefShareBar() {
 
   return (
     <div className="flex items-center gap-2 text-xs">
-      <button className="px-2 py-1 border rounded" onClick={copyLink}>
-        {copied ? 'コピーした！' : 'シェアリンクをコピー'}
+      <button className="px-2 py-1 border rounded" onClick={saveLink}>
+        {msg ? msg : '保存してリンクをコピー'}
       </button>
       <span className="text-muted-foreground">リンクを送れば同じ塗りが再現されるよ</span>
     </div>

--- a/web/services/travel.ts
+++ b/web/services/travel.ts
@@ -1,32 +1,55 @@
 /**
- * Placeholder travel service implementations.
- * Real logic will be copied from the travel app once available.
+ * Mock travel service implementations using `localStorage`.
+ * Replace with real Firebase logic once the travel app becomes available.
  */
 
-export async function signInWithGoogle(): Promise<void> {
-  throw new Error('signInWithGoogle not implemented');
+type User = { uid: string }
+
+let currentUser: User | null = null
+const listeners = new Set<(u: User | null) => void>()
+
+// load persisted user on module init in browser
+if (typeof window !== 'undefined') {
+  const raw = localStorage.getItem('demo-user')
+  if (raw) currentUser = JSON.parse(raw)
 }
 
-export function onUser(_cb: (user: unknown) => void): () => void {
-  // immediately emit null user; return unsubscribe noop
-  _cb(null);
-  return () => void 0;
+const notify = () => listeners.forEach(cb => cb(currentUser))
+
+export async function signInWithGoogle(): Promise<void> {
+  currentUser = { uid: 'demo' }
+  if (typeof window !== 'undefined')
+    localStorage.setItem('demo-user', JSON.stringify(currentUser))
+  notify()
+}
+
+export function onUser(cb: (user: User | null) => void): () => void {
+  listeners.add(cb)
+  cb(currentUser)
+  return () => listeners.delete(cb)
 }
 
 export async function signOutNow(): Promise<void> {
-  // no-op
+  currentUser = null
+  if (typeof window !== 'undefined') localStorage.removeItem('demo-user')
+  notify()
 }
 
-export async function createMap(): Promise<{ id: string }> {
-  return { id: 'stub' };
+export async function createMap(b64: string): Promise<{ id: string }> {
+  if (!currentUser) throw new Error('no user')
+  const id = Math.random().toString(36).slice(2, 10)
+  if (typeof window !== 'undefined')
+    localStorage.setItem(`map:${currentUser.uid}:${id}`, b64)
+  return { id }
 }
 
-export async function getMap(): Promise<unknown> {
-  return null;
+export async function getMap(uid: string, mapId: string): Promise<string | null> {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(`map:${uid}:${mapId}`)
 }
 
 export async function uploadMapPhoto(): Promise<null> {
-  return null;
+  return null
 }
 
 export async function requestFollow(): Promise<void> {}
@@ -34,3 +57,4 @@ export async function requestFollow(): Promise<void> {}
 export async function approveFollower(): Promise<void> {}
 
 export async function setVisibility(): Promise<void> {}
+


### PR DESCRIPTION
## Summary
- document scan and strategy for missing travel app
- add localStorage-based travel service with login and map save
- demo login, save, and view routes for painted maps

## Testing
- `pnpm -C web build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b680d0abfc832cae78e9b48931dbc8