### PR TITLE
feat(web): visibility/follow/photo (travel services reuse)

### DIFF
--- a/web/app/u/[uid]/m/[mapId]/page.tsx
+++ b/web/app/u/[uid]/m/[mapId]/page.tsx
@@ -1,22 +1,49 @@
 'use client'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import PrefGridMap from '@/components/travel/PrefGridMap'
+import FollowButton from '@/components/travel/FollowButton'
+import VisibilityToggle from '@/components/travel/VisibilityToggle'
+import PhotoUploader from '@/components/travel/PhotoUploader'
+import ApproveFollower from '@/components/travel/ApproveFollower'
 import { usePrefPaint } from '@/store/prefPaintStore'
-import { getMap } from '@/services/travel'
+import { getMap, onUser } from '@/services/travel'
 
 export default function MapPage({ params }: { params: { uid: string; mapId: string } }) {
   const importB64 = usePrefPaint(s => s.importB64)
+  const [allowed, setAllowed] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+  const [user, setUser] = useState<any>(null)
+
+  useEffect(() => onUser(setUser), [])
 
   useEffect(() => {
     getMap(params.uid, params.mapId).then(b64 => {
-      if (b64) importB64(b64)
+      if (b64) {
+        importB64(b64)
+        setAllowed(true)
+      }
+      setLoaded(true)
     })
   }, [params.uid, params.mapId, importB64])
+
+  const isOwner = user?.uid === params.uid
 
   return (
     <div className="p-6 max-w-3xl mx-auto space-y-4">
       <h1 className="text-xl font-bold">塗り地図</h1>
-      <PrefGridMap />
+      {!isOwner && <FollowButton ownerUid={params.uid} />}
+      {allowed ? (
+        <div className="space-y-2">
+          {isOwner && (
+            <VisibilityToggle uid={params.uid} mapId={params.mapId} />
+          )}
+          <PrefGridMap />
+          <PhotoUploader uid={params.uid} mapId={params.mapId} />
+          {isOwner && <ApproveFollower ownerUid={params.uid} />}
+        </div>
+      ) : (
+        loaded && <p className="text-sm">閲覧できません</p>
+      )}
     </div>
   )
 }

--- a/web/components/travel/ApproveFollower.tsx
+++ b/web/components/travel/ApproveFollower.tsx
@@ -1,0 +1,35 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { getFollowRequests, approveFollower } from '@/services/travel'
+
+type Props = { ownerUid: string }
+
+export default function ApproveFollower({ ownerUid }: Props) {
+  const [reqs, setReqs] = useState<string[]>([])
+
+  const load = () => {
+    getFollowRequests(ownerUid).then(setReqs)
+  }
+
+  useEffect(load, [ownerUid])
+
+  const approve = async (uid: string) => {
+    await approveFollower(ownerUid, uid)
+    load()
+  }
+
+  if (reqs.length === 0) return null
+
+  return (
+    <div className="space-y-1 text-xs">
+      {reqs.map(r => (
+        <div key={r} className="flex items-center gap-2">
+          <span>{r}</span>
+          <button className="px-1 border rounded" onClick={() => approve(r)}>
+            承認
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/components/travel/FollowButton.tsx
+++ b/web/components/travel/FollowButton.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { onUser, requestFollow, isFollower, hasPendingFollow } from '@/services/travel'
+
+type Props = { ownerUid: string }
+
+export default function FollowButton({ ownerUid }: Props) {
+  const [user, setUser] = useState<any>(null)
+  const [status, setStatus] = useState<'none' | 'pending' | 'follow'>('none')
+
+  useEffect(() => onUser(setUser), [])
+
+  useEffect(() => {
+    if (user) {
+      if (isFollower(ownerUid, user.uid)) setStatus('follow')
+      else if (hasPendingFollow(ownerUid, user.uid)) setStatus('pending')
+    }
+  }, [user, ownerUid])
+
+  const req = async () => {
+    await requestFollow(ownerUid)
+    setStatus('pending')
+  }
+
+  if (!user || user.uid === ownerUid) return null
+
+  return (
+    <button
+      className="px-2 py-1 border rounded text-xs"
+      onClick={req}
+      disabled={status !== 'none'}
+    >
+      {status === 'pending'
+        ? '申請中'
+        : status === 'follow'
+        ? 'フォロー中'
+        : 'フォロー申請'}
+    </button>
+  )
+}

--- a/web/components/travel/PhotoUploader.tsx
+++ b/web/components/travel/PhotoUploader.tsx
@@ -1,0 +1,35 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { uploadMapPhoto, getMapPhotos, onUser } from '@/services/travel'
+
+type Props = { uid: string; mapId: string }
+
+export default function PhotoUploader({ uid, mapId }: Props) {
+  const [photos, setPhotos] = useState<string[]>([])
+  const [isOwner, setIsOwner] = useState(false)
+
+  useEffect(() => {
+    getMapPhotos(uid, mapId).then(setPhotos)
+    return onUser(u => setIsOwner(u?.uid === uid))
+  }, [uid, mapId])
+
+  const upload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      const url = await uploadMapPhoto(uid, mapId, file)
+      setPhotos(p => [...p, url])
+      e.target.value = ''
+    }
+  }
+
+  return (
+    <div className="space-y-2 text-xs">
+      {isOwner && <input type="file" accept="image/*" onChange={upload} />}
+      <div className="flex gap-2 flex-wrap">
+        {photos.map((p, i) => (
+          <img key={i} src={p} className="w-24 h-24 object-cover" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/components/travel/VisibilityToggle.tsx
+++ b/web/components/travel/VisibilityToggle.tsx
@@ -1,0 +1,27 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { getVisibility, setVisibility } from '@/services/travel'
+
+type Props = { uid: string; mapId: string }
+
+export default function VisibilityToggle({ uid, mapId }: Props) {
+  const [vis, setVis] = useState<'public' | 'followers' | 'private'>('public')
+
+  useEffect(() => {
+    getVisibility(uid, mapId).then(v => setVis(v))
+  }, [uid, mapId])
+
+  const change = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value as 'public' | 'followers' | 'private'
+    setVis(v)
+    setVisibility(uid, mapId, v)
+  }
+
+  return (
+    <select value={vis} onChange={change} className="border rounded p-1 text-xs">
+      <option value="public">public</option>
+      <option value="followers">followers</option>
+      <option value="private">private</option>
+    </select>
+  )
+}

--- a/web/services/travel.ts
+++ b/web/services/travel.ts
@@ -4,6 +4,7 @@
  */
 
 type User = { uid: string }
+type Visibility = 'public' | 'followers' | 'private'
 
 let currentUser: User | null = null
 const listeners = new Set<(u: User | null) => void>()
@@ -38,23 +39,101 @@ export async function signOutNow(): Promise<void> {
 export async function createMap(b64: string): Promise<{ id: string }> {
   if (!currentUser) throw new Error('no user')
   const id = Math.random().toString(36).slice(2, 10)
-  if (typeof window !== 'undefined')
+  if (typeof window !== 'undefined') {
     localStorage.setItem(`map:${currentUser.uid}:${id}`, b64)
+    localStorage.setItem(`visibility:${currentUser.uid}:${id}`, 'public')
+  }
   return { id }
 }
 
 export async function getMap(uid: string, mapId: string): Promise<string | null> {
   if (typeof window === 'undefined') return null
+  const vis =
+    (localStorage.getItem(`visibility:${uid}:${mapId}`) as Visibility | null) ||
+    'public'
+  if (vis === 'private' && currentUser?.uid !== uid) return null
+  if (vis === 'followers' && currentUser?.uid !== uid) {
+    const key = `follow:${uid}:${currentUser?.uid}`
+    if (!localStorage.getItem(key)) return null
+  }
   return localStorage.getItem(`map:${uid}:${mapId}`)
 }
 
-export async function uploadMapPhoto(): Promise<null> {
-  return null
+export async function setVisibility(
+  uid: string,
+  mapId: string,
+  v: Visibility,
+): Promise<void> {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(`visibility:${uid}:${mapId}`, v)
 }
 
-export async function requestFollow(): Promise<void> {}
+export async function uploadMapPhoto(
+  uid: string,
+  mapId: string,
+  file: File,
+): Promise<string> {
+  if (typeof window === 'undefined') return ''
+  const url = URL.createObjectURL(file)
+  const key = `photos:${uid}:${mapId}`
+  const arr = JSON.parse(localStorage.getItem(key) || '[]') as string[]
+  arr.push(url)
+  localStorage.setItem(key, JSON.stringify(arr))
+  return url
+}
 
-export async function approveFollower(): Promise<void> {}
+export async function getMapPhotos(
+  uid: string,
+  mapId: string,
+): Promise<string[]> {
+  if (typeof window === 'undefined') return []
+  const key = `photos:${uid}:${mapId}`
+  return JSON.parse(localStorage.getItem(key) || '[]') as string[]
+}
 
-export async function setVisibility(): Promise<void> {}
+export async function requestFollow(ownerUid: string): Promise<void> {
+  if (!currentUser || currentUser.uid === ownerUid) return
+  if (typeof window === 'undefined') return
+  localStorage.setItem(`request:${ownerUid}:${currentUser.uid}`, '1')
+}
+
+export async function getFollowRequests(ownerUid: string): Promise<string[]> {
+  if (typeof window === 'undefined') return []
+  return Object.keys(localStorage)
+    .filter(k => k.startsWith(`request:${ownerUid}:`))
+    .map(k => k.split(':')[2])
+}
+
+export async function approveFollower(
+  ownerUid: string,
+  followerUid: string,
+): Promise<void> {
+  if (typeof window === 'undefined') return
+  localStorage.removeItem(`request:${ownerUid}:${followerUid}`)
+  localStorage.setItem(`follow:${ownerUid}:${followerUid}`, '1')
+}
+
+export function isFollower(ownerUid: string, followerUid: string): boolean {
+  if (typeof window === 'undefined') return false
+  return localStorage.getItem(`follow:${ownerUid}:${followerUid}`) === '1'
+}
+
+export function hasPendingFollow(
+  ownerUid: string,
+  followerUid: string,
+): boolean {
+  if (typeof window === 'undefined') return false
+  return localStorage.getItem(`request:${ownerUid}:${followerUid}`) === '1'
+}
+
+export async function getVisibility(
+  uid: string,
+  mapId: string,
+): Promise<Visibility> {
+  if (typeof window === 'undefined') return 'public'
+  return (
+    (localStorage.getItem(`visibility:${uid}:${mapId}`) as Visibility | null) ||
+    'public'
+  )
+}
 


### PR DESCRIPTION
## Summary
- add localStorage-backed visibility, follow, and photo helpers in travel service
- expose minimal UI components: VisibilityToggle, FollowButton, ApproveFollower, PhotoUploader
- integrate components into map page for basic sharing workflow

## Testing
- `pnpm -C web build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6829966cc832cbbc42b1f1d0a6999