### PR TITLE
feat(builder): add "JapanMap + Share + Save" preset (travel)

### DIFF
--- a/web/components/travel/SaveMapBar.tsx
+++ b/web/components/travel/SaveMapBar.tsx
@@ -1,0 +1,39 @@
+'use client'
+import React, { useState } from 'react'
+import { usePrefPaint } from '@/store/prefPaintStore'
+
+export default function SaveMapBar() {
+  const exportB64 = usePrefPaint(s => s.exportB64)
+  const importB64 = usePrefPaint(s => s.importB64)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  const save = () => {
+    const b64 = exportB64()
+    localStorage.setItem('prefPaintB64', b64)
+    setMsg('保存したよ')
+    setTimeout(() => setMsg(null), 1000)
+  }
+
+  const load = () => {
+    const b64 = localStorage.getItem('prefPaintB64')
+    if (b64) {
+      importB64(b64)
+      setMsg('読み込んだよ')
+    } else {
+      setMsg('保存なし')
+    }
+    setTimeout(() => setMsg(null), 1000)
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <button className="px-2 py-1 border rounded" onClick={save}>
+        保存
+      </button>
+      <button className="px-2 py-1 border rounded" onClick={load}>
+        読み込み
+      </button>
+      {msg && <span className="text-muted-foreground">{msg}</span>}
+    </div>
+  )
+}

--- a/web/lib/presets.travel.ts
+++ b/web/lib/presets.travel.ts
@@ -1,0 +1,53 @@
+import { newId } from '@/lib/ids'
+import type { ComponentNode } from '@/types/editor'
+
+// タグ設計
+export type DomainTag = 'common' | 'travel' | 'accounting'
+export type PresetTag = DomainTag | 'card' | 'map' | 'share' | 'chart' | 'analytics'
+
+export type PresetDef = {
+  id: string
+  displayName: string
+  tags: PresetTag[]
+  tree: ComponentNode
+}
+
+// 共通のカード子要素
+const mapCardChildren = (useJapanMap: boolean): ComponentNode[] => ([
+  { id: newId('n'), type: 'PrefShareBar', props: {} },
+  { id: newId('n'), type: useJapanMap ? 'JapanMap' : 'PrefGridMap', props: {} },
+  { id: newId('n'), type: 'SaveMapBar', props: {} },
+  {
+    id: newId('n'),
+    type: 'DownloadPNG',
+    props: { targetId: 'mapCard', fileName: 'my-map.png' },
+  },
+])
+
+export const preset_travel_map_share_save_card_grid: PresetDef = {
+  id: 'preset.travel.map.share.save.card.grid',
+  displayName: 'JapanMap + Share + Save（Grid）',
+  tags: ['travel', 'card', 'map', 'share'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: '地図コレ', className: 'w-[640px] min-h-[420px]', id: 'mapCard' },
+    children: mapCardChildren(false),
+  },
+}
+
+// JapanMap が存在する場合のプリセット（SVG版）
+export const maybeJapanMapPreset = (hasJapanMap: boolean): PresetDef | null => {
+  if (!hasJapanMap) return null
+  return {
+    id: 'preset.travel.map.share.save.card.svg',
+    displayName: 'JapanMap + Share + Save（SVG）',
+    tags: ['travel', 'card', 'map', 'share'],
+    tree: {
+      id: newId('n'),
+      type: 'Card',
+      props: { title: '地図コレ（SVG）', className: 'w-[720px] min-h-[480px]', id: 'mapCard' },
+      children: mapCardChildren(true),
+    },
+  }
+}

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -1,16 +1,7 @@
 import type { ComponentNode } from '@/types/editor'
 import { newId } from './ids'
-
-export type DomainTag = 'common' | 'travel' | 'accounting'
-export type PresetTag = DomainTag | 'card' | 'map' | 'chart' | 'analytics'
-
-export type PresetDef = {
-  id: string
-  displayName: string
-  icon?: string
-  tags: PresetTag[] // tags are mandatory
-  tree: ComponentNode
-}
+import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, type PresetDef } from './presets.travel'
+export type { DomainTag, PresetTag, PresetDef } from './presets.travel'
 
 export const cloneSubtree = (node: ComponentNode): ComponentNode => {
   return {
@@ -91,6 +82,17 @@ export const PRESETS: PresetDef[] = [
   preset_tripHeaderCard,
   preset_itineraryTimelineCard,
   preset_travelPrefPaintCard,
+  preset_travel_map_share_save_card_grid,
+  // JapanMap（SVG版）があるなら追加
+  ...(() => {
+    try {
+      require('@/components/domain/maps/JapanMap')
+      const p = maybeJapanMapPreset(true)
+      return p ? [p] : []
+    } catch {
+      return []
+    }
+  })(),
 ]
 
 export const getPresetById = (id: string) => PRESETS.find((p) => p.id === id)

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -2,9 +2,20 @@ import type { ComponentMeta } from '@/types/builder';
 import Card from '@/components/Card';
 import TripHeader from '@/components/travel/TripHeader';
 import ItineraryTimeline from '@/components/travel/ItineraryTimeline';
-import JapanMap from '@/components/domain/JapanMap';
 import PrefShareBar from '@/components/travel/PrefShareBar';
 import PrefGridMap from '@/components/travel/PrefGridMap';
+import SaveMapBar from '@/components/travel/SaveMapBar';
+import DownloadPNG from '@/components/util/DownloadPNG';
+
+// JapanMap is optional (SVG variant lives in components/domain/maps)
+let JapanMap: any = null;
+try {
+  JapanMap = require('@/components/domain/maps/JapanMap').default;
+} catch {
+  try {
+    JapanMap = require('@/components/domain/JapanMap').default;
+  } catch {}
+}
 
 export type RegistryItem = {
   meta: ComponentMeta;
@@ -94,17 +105,19 @@ register({
   Render: ItineraryTimeline,
 });
 
-register({
-  meta: {
-    id: 'JapanMap',
-    displayName: 'JapanMap',
-    props: [],
-    allowChildren: false,
-    defaultW: 520,
-    defaultH: 360,
-  },
-  Render: JapanMap,
-});
+if (JapanMap) {
+  register({
+    meta: {
+      id: 'JapanMap',
+      displayName: 'JapanMap',
+      props: [],
+      allowChildren: false,
+      defaultW: 520,
+      defaultH: 360,
+    },
+    Render: JapanMap,
+  });
+}
 
 register({
   meta: {
@@ -129,3 +142,36 @@ register({
   },
   Render: PrefGridMap,
 });
+
+register({
+  meta: {
+    id: 'SaveMapBar',
+    displayName: 'SaveMapBar',
+    props: [],
+    allowChildren: false,
+    defaultW: 320,
+    defaultH: 40,
+  },
+  Render: SaveMapBar,
+});
+
+register({
+  meta: {
+    id: 'DownloadPNG',
+    displayName: 'DownloadPNG',
+    props: [],
+    allowChildren: false,
+    defaultW: 160,
+    defaultH: 40,
+  },
+  Render: DownloadPNG,
+});
+
+export const REGISTRY = {
+  Card: { component: Card, displayName: 'Card' },
+  PrefShareBar: { component: PrefShareBar, displayName: 'PrefShareBar' },
+  PrefGridMap: { component: PrefGridMap, displayName: 'PrefGridMap' },
+  SaveMapBar: { component: SaveMapBar, displayName: 'SaveMapBar' },
+  DownloadPNG: { component: DownloadPNG, displayName: 'DownloadPNG' },
+  ...(JapanMap ? { JapanMap: { component: JapanMap, displayName: 'JapanMap' } } : {}),
+} as const;


### PR DESCRIPTION
## Summary
- add SaveMapBar component for local map persistence
- extend preset registry and add travel share+save presets with optional SVG JapanMap variant
- register SaveMapBar and DownloadPNG components in builder registry

## Testing
- `npm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b689ea2344832c96efa461f83dc876