### PR TITLE
feat(travel): JapanMap enum (want/visited/lived) + legend + preset

### DIFF
--- a/web/app/u/[uid]/m/[mapId]/page.tsx
+++ b/web/app/u/[uid]/m/[mapId]/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-import PrefGridMap from '@/components/travel/PrefGridMap'
+import PrefEnumGridMap from '@/components/travel/PrefEnumGridMap'
 import { FollowButton } from '@/components/travel/FollowControls'
 import VisibilityToggle from '@/components/travel/VisibilityToggle'
 import PhotoUploader from '@/components/travel/PhotoUploader'
 import { usePrefPaint } from '@/store/prefPaintStore'
+import { usePrefPaintEnum } from '@/store/prefPaintEnumStore'
 import { getMap, onUser } from '@/services/travel'
 import DownloadPNG from '@/components/util/DownloadPNG'
 
@@ -13,7 +14,8 @@ export default function MapPage({
 }: {
   params: { uid: string; mapId: string }
 }) {
-  const importB64 = usePrefPaint(s => s.importB64)
+  const importBool = usePrefPaint(s => s.importB64)
+  const importEnum = usePrefPaintEnum(s => s.importEnumB64)
   const [allowed, setAllowed] = useState(false)
   const [loaded, setLoaded] = useState(false)
   const [user, setUser] = useState<any>(null)
@@ -25,14 +27,27 @@ export default function MapPage({
     getMap(params.uid, params.mapId)
       .then(doc => {
         if (doc) {
-          importB64(doc.paintB64)
-          setVisibility(doc.visibility)
-          setAllowed(true)
+          if (doc.paintB64) {
+            importEnum(doc.paintB64)
+            setTimeout(() => {
+              const st = usePrefPaintEnum.getState().painted
+              const has = Object.values(st).some(v => v && v > 0)
+              if (!has) importBool(doc.paintB64)
+              setAllowed(true)
+              setVisibility(doc.visibility)
+              setLoaded(true)
+            }, 0)
+          } else {
+            setVisibility(doc.visibility)
+            setAllowed(true)
+            setLoaded(true)
+          }
+        } else {
+          setLoaded(true)
         }
-        setLoaded(true)
       })
       .catch(() => setLoaded(true))
-  }, [params.uid, params.mapId, importB64])
+  }, [params.uid, params.mapId, importBool, importEnum])
 
   const isOwner = user?.uid === params.uid
 
@@ -49,7 +64,7 @@ export default function MapPage({
               value={visibility}
             />
           )}
-          <PrefGridMap />
+          <PrefEnumGridMap />
           {isOwner && <PhotoUploader uid={params.uid} mapId={params.mapId} />}
           <div className="flex items-center gap-2">
             <DownloadPNG targetId="mapCard" fileName={`${params.uid}-${params.mapId}.png`} />

--- a/web/components/travel/PrefEnumGridMap.tsx
+++ b/web/components/travel/PrefEnumGridMap.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React from 'react'
+import { PREFS } from '@/lib/japanPrefs'
+import { usePrefPaintEnum, STATES } from '@/store/prefPaintEnumStore'
+import { STATE_META } from './PrefEnumLegend'
+
+const COLOR = {
+  0: 'hsl(0 0% 98%)',
+  1: STATE_META[0].color,
+  2: STATE_META[1].color,
+  3: STATE_META[2].color,
+} as const
+
+export default function PrefEnumGridMap() {
+  const painted = usePrefPaintEnum(s => s.painted)
+  const cycle = usePrefPaintEnum(s => s.cycle)
+
+  return (
+    <div className="grid grid-cols-6 gap-1 text-xs select-none">
+      {PREFS.map(({ code, name }) => {
+        const v = painted[code] ?? 0
+        return (
+          <button
+            key={code}
+            onClick={() => cycle(code)}
+            className={[
+              'h-9 rounded-md border flex items-center justify-center px-2',
+              v ? 'ring-1 ring-foreground/30' : '',
+            ].join(' ')}
+            style={{ background: COLOR[v as keyof typeof COLOR] }}
+            title={`${name} (${code})`}
+            aria-pressed={v !== STATES.none}
+          >
+            <span className="truncate">{name}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/components/travel/PrefEnumLegend.tsx
+++ b/web/components/travel/PrefEnumLegend.tsx
@@ -1,0 +1,20 @@
+'use client'
+import React from 'react'
+export const STATE_META = [
+  { v: 1, label: '行きたい', color: 'hsl(38 92% 55%)' },   // amber-ish
+  { v: 2, label: '行った',   color: 'hsl(217 91% 60%)' },  // blue-ish
+  { v: 3, label: '住んだ',   color: 'hsl(0 84% 60%)' },    // red-ish
+] as const
+
+export default function PrefEnumLegend() {
+  return (
+    <div className="flex gap-3 text-xs">
+      {STATE_META.map(s => (
+        <div key={s.v} className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-sm border" style={{ background: s.color }} />
+          <span className="text-muted-foreground">{s.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/components/travel/PrefEnumShareBar.tsx
+++ b/web/components/travel/PrefEnumShareBar.tsx
@@ -1,0 +1,32 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { usePrefPaintEnum } from '@/store/prefPaintEnumStore'
+
+export default function PrefEnumShareBar() {
+  const exportEnumB64 = usePrefPaintEnum(s => s.exportEnumB64)
+  const importEnumB64 = usePrefPaintEnum(s => s.importEnumB64)
+  const [copied, setCopied] = useState(false)
+
+  const copyLink = () => {
+    const b64 = exportEnumB64()
+    const url = new URL(location.href)
+    url.searchParams.set('pe', b64) // enum: paint enum
+    navigator.clipboard?.writeText(url.toString())
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1000)
+  }
+
+  useEffect(() => {
+    const pe = new URLSearchParams(location.search).get('pe')
+    if (pe) importEnumB64(pe)
+  }, [importEnumB64])
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <button className="px-2 py-1 border rounded" onClick={copyLink}>
+        {copied ? 'コピーした！' : 'シェア（enum）'}
+      </button>
+      <span className="text-muted-foreground">?pe= を使って列挙塗りを共有</span>
+    </div>
+  )
+}

--- a/web/components/travel/SaveMapBarEnum.tsx
+++ b/web/components/travel/SaveMapBarEnum.tsx
@@ -1,0 +1,34 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { usePrefPaintEnum } from '@/store/prefPaintEnumStore'
+import { onUser, createMap } from '@/services/travel'
+
+export default function SaveMapBarEnum() {
+  const exportEnumB64 = usePrefPaintEnum(s => s.exportEnumB64)
+  const [uid, setUid] = useState<string | undefined>()
+  const [link, setLink] = useState<string>('')
+
+  useEffect(() => onUser(u => setUid(u?.uid)), [])
+
+  const save = async () => {
+    if (!uid) return alert('ログインしてください')
+    const id = await createMap(uid, {
+      title: '列挙ぬりマップ',
+      paintB64: exportEnumB64(), // ← 既存フィールドにそのまま保存（互換読み込みは後述）
+      visibility: 'public',
+    })
+    const url = `${location.origin}/u/${uid}/m/${id}`
+    setLink(url)
+    await navigator.clipboard?.writeText(url)
+    alert('保存してリンクをコピーしました')
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <button className="px-2 py-1 border rounded" onClick={save}>
+        保存してリンクコピー
+      </button>
+      {link && <a className="underline" href={link}>開く</a>}
+    </div>
+  )
+}

--- a/web/lib/presets.travel.ts
+++ b/web/lib/presets.travel.ts
@@ -51,3 +51,21 @@ export const maybeJapanMapPreset = (hasJapanMap: boolean): PresetDef | null => {
     },
   }
 }
+
+export const preset_travel_map_enum_card: PresetDef = {
+  id: 'preset.travel.map.enum.card',
+  displayName: 'JapanMap（行きたい/行った/住んだ）',
+  tags: ['travel', 'card', 'map', 'share'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: '地図コレ（列挙）', className: 'w-[720px] min-h-[500px]', id: 'mapCard' },
+    children: [
+      { id: newId('n'), type: 'PrefEnumLegend', props: {} },
+      { id: newId('n'), type: 'PrefEnumShareBar', props: {} },
+      { id: newId('n'), type: 'PrefEnumGridMap', props: {} },
+      { id: newId('n'), type: 'SaveMapBarEnum', props: {} },
+      { id: newId('n'), type: 'DownloadPNG', props: { targetId: 'mapCard', fileName: 'my-map.png' } },
+    ],
+  },
+}

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -1,6 +1,6 @@
 import type { ComponentNode } from '@/types/editor'
 import { newId } from './ids'
-import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, type PresetDef } from './presets.travel'
+import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, preset_travel_map_enum_card, type PresetDef } from './presets.travel'
 export type { DomainTag, PresetTag, PresetDef } from './presets.travel'
 
 export const cloneSubtree = (node: ComponentNode): ComponentNode => {
@@ -83,6 +83,7 @@ export const PRESETS: PresetDef[] = [
   preset_itineraryTimelineCard,
   preset_travelPrefPaintCard,
   preset_travel_map_share_save_card_grid,
+  preset_travel_map_enum_card,
   // JapanMap（SVG版）があるなら追加
   ...(() => {
     try {

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -6,6 +6,10 @@ import PrefShareBar from '@/components/travel/PrefShareBar';
 import PrefGridMap from '@/components/travel/PrefGridMap';
 import SaveMapBar from '@/components/travel/SaveMapBar';
 import DownloadPNG from '@/components/util/DownloadPNG';
+import PrefEnumLegend from '@/components/travel/PrefEnumLegend';
+import PrefEnumGridMap from '@/components/travel/PrefEnumGridMap';
+import PrefEnumShareBar from '@/components/travel/PrefEnumShareBar';
+import SaveMapBarEnum from '@/components/travel/SaveMapBarEnum';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -167,11 +171,63 @@ register({
   Render: DownloadPNG,
 });
 
+register({
+  meta: {
+    id: 'PrefEnumLegend',
+    displayName: 'PrefEnumLegend',
+    props: [],
+    allowChildren: false,
+    defaultW: 320,
+    defaultH: 40,
+  },
+  Render: PrefEnumLegend,
+});
+
+register({
+  meta: {
+    id: 'PrefEnumGridMap',
+    displayName: 'PrefEnumGridMap',
+    props: [],
+    allowChildren: false,
+    defaultW: 560,
+    defaultH: 360,
+  },
+  Render: PrefEnumGridMap,
+});
+
+register({
+  meta: {
+    id: 'PrefEnumShareBar',
+    displayName: 'PrefEnumShareBar',
+    props: [],
+    allowChildren: false,
+    defaultW: 320,
+    defaultH: 40,
+  },
+  Render: PrefEnumShareBar,
+});
+
+register({
+  meta: {
+    id: 'SaveMapBarEnum',
+    displayName: 'SaveMapBarEnum',
+    props: [],
+    allowChildren: false,
+    defaultW: 320,
+    defaultH: 40,
+  },
+  Render: SaveMapBarEnum,
+});
+
 export const REGISTRY = {
   Card: { component: Card, displayName: 'Card' },
   PrefShareBar: { component: PrefShareBar, displayName: 'PrefShareBar' },
   PrefGridMap: { component: PrefGridMap, displayName: 'PrefGridMap' },
   SaveMapBar: { component: SaveMapBar, displayName: 'SaveMapBar' },
   DownloadPNG: { component: DownloadPNG, displayName: 'DownloadPNG' },
+  PrefEnumLegend: { component: PrefEnumLegend, displayName: 'PrefEnumLegend' },
+  PrefEnumGridMap: { component: PrefEnumGridMap, displayName: 'PrefEnumGridMap' },
+  PrefEnumShareBar: { component: PrefEnumShareBar, displayName: 'PrefEnumShareBar' },
+  SaveMapBarEnum: { component: SaveMapBarEnum, displayName: 'SaveMapBarEnum' },
   ...(JapanMap ? { JapanMap: { component: JapanMap, displayName: 'JapanMap' } } : {}),
 } as const;

--- a/web/store/prefPaintEnumStore.ts
+++ b/web/store/prefPaintEnumStore.ts
@@ -1,0 +1,76 @@
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { CODES } from '@/lib/japanPrefs'
+
+/** 0:なし / 1:行きたい / 2:行った / 3:住んだ */
+export type PrefState = 0 | 1 | 2 | 3
+export const STATES = { none: 0, want: 1, visited: 2, lived: 3 } as const
+
+export type EnumState = Record<string, PrefState>
+
+const packEnum = (s: EnumState) => {
+  // 2bit×47 = 94bit → 12byte（96bit）に詰める
+  const vals = CODES.map(c => s[c] ?? 0)
+  const bytes: number[] = []
+  for (let i = 0; i < vals.length; i += 4) {
+    const a = vals[i] ?? 0
+    const b = vals[i + 1] ?? 0
+    const c = vals[i + 2] ?? 0
+    const d = vals[i + 3] ?? 0
+    bytes.push((a << 6) | (b << 4) | (c << 2) | d)
+  }
+  const bin = String.fromCharCode(...bytes)
+  return btoa(bin) // Base64
+}
+
+const unpackEnum = (b64: string): EnumState => {
+  try {
+    const bin = atob(b64)
+    const bytes = Array.from(bin, ch => ch.charCodeAt(0))
+    const res: EnumState = {}
+    let idx = 0
+    for (const byte of bytes) {
+      for (let shift = 6; shift >= 0 && idx < CODES.length; shift -= 2) {
+        const v = (byte >> shift) & 0b11
+        res[CODES[idx]] = v as PrefState
+        idx++
+      }
+      if (idx >= CODES.length) break
+    }
+    return res
+  } catch {
+    return {}
+  }
+}
+
+type Store = {
+  painted: EnumState
+  cycle: (code: string) => void
+  setState: (code: string, v: PrefState) => void
+  clearAll: () => void
+  fillAll: (v?: PrefState) => void
+  exportEnumB64: () => string
+  importEnumB64: (b64: string) => void
+}
+
+export const usePrefPaintEnum = create(
+  persist<Store>(
+    (set, get) => ({
+      painted: {},
+      cycle: (code) =>
+        set(s => {
+          const cur = s.painted[code] ?? 0
+          const next = ((cur + 1) % 4) as PrefState // 0→1→2→3→0
+          return { painted: { ...s.painted, [code]: next } }
+        }),
+      setState: (code, v) => set(s => ({ painted: { ...s.painted, [code]: v } })),
+      clearAll: () => set({ painted: {} }),
+      fillAll: (v = 2) =>
+        set({ painted: Object.fromEntries(CODES.map(c => [c, v])) as EnumState }),
+      exportEnumB64: () => packEnum(get().painted),
+      importEnumB64: (b64: string) => set({ painted: unpackEnum(b64) }),
+    }),
+    { name: 'pref-paint-enum-v1' }
+  )
+)


### PR DESCRIPTION
## Summary
- add persistent 2-bit-pref store for want/visited/lived states
- introduce grid-based enum map with legend, share bar, and save bar
- wire map page/presets/registry to new enum map components

## Testing
- `pnpm test` *(fails: Cannot find module 'firebase/auth')*

------
https://chatgpt.com/codex/tasks/task_e_68b68c1dce74832cab1f5446a2266c6f