### PR TITLE
feat: add followers feed

### DIFF
--- a/web/app/feed/page.tsx
+++ b/web/app/feed/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { onUser } from '@/services/travel'
+import { listFollowingFeed, getUserProfile, type MapDoc } from '@/services/travel'
+
+type CardItem = MapDoc & { ownerName?: string; ownerIcon?: string }
+
+export default function FeedPage() {
+  const [me, setMe] = useState<string | null>(null)
+  const [items, setItems] = useState<CardItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => onUser(u => setMe(u?.uid ?? null)), [])
+  useEffect(() => {
+    if (!me) { setItems([]); setLoading(false); return }
+    ;(async () => {
+      setLoading(true)
+      const maps = await listFollowingFeed(me, 5)
+      const withNames = await Promise.all(maps.map(async m => {
+        const prof = await getUserProfile(m._owner!)
+        return { ...m, ownerName: prof?.displayName ?? m._owner, ownerIcon: prof?.photoURL }
+      }))
+      setItems(withNames)
+      setLoading(false)
+    })()
+  }, [me])
+
+  if (!me) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto">
+        <h1 className="text-xl font-bold mb-2">フォロー中の新着</h1>
+        <p className="text-sm text-muted-foreground">ログインすると、承認されたユーザーの新着マップが表示されます。</p>
+        <p className="mt-4"><a className="underline" href="/discover">Discover を見る</a></p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <h1 className="text-xl font-bold">フォロー中の新着</h1>
+      {loading ? <p>読み込み中…</p> : items.length ? (
+        <div className="grid md:grid-cols-2 gap-3">
+          {items.map(it => (
+            <div key={`${it._owner}/${it._id}`} className="border rounded-xl p-3">
+              <div className="flex items-center gap-2 mb-2">
+                {it.ownerIcon && <img src={it.ownerIcon} className="w-6 h-6 rounded-full" alt="" />}
+                <span className="text-sm">{it.ownerName}</span>
+              </div>
+              <div className="font-medium">{it.title ?? 'Untitled Map'}</div>
+              <div className="text-xs text-muted-foreground mb-2">visibility: {it.visibility}</div>
+              <Link className="text-sm underline" href={`/u/${it._owner}/m/${it._id}`}>開く</Link>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-sm text-muted-foreground">
+          まだフィードに表示できるマップがありません。<br />
+          <a className="underline" href="/discover">Discover</a> から公開ユーザーを見つけてフォロー申請→承認してもらってね。
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/app/travel/demo/page.tsx
+++ b/web/app/travel/demo/page.tsx
@@ -26,6 +26,11 @@ export default function TravelDemoPage() {
       <p className="text-sm text-muted-foreground">
         カード右下の「PNGで保存」で、今の塗りを画像にできます。
       </p>
+
+      <p className="text-sm">
+        <a className="underline" href="/discover">Discover</a> /
+        <a className="underline ml-2" href="/feed">フォロー中の新着</a>
+      </p>
     </div>
   )
 }

--- a/web/services/travel.ts
+++ b/web/services/travel.ts
@@ -140,6 +140,53 @@ export async function listUserMaps(uid: string, max = 50): Promise<MapDoc[]> {
   return snap.docs.map(d => ({ ...(d.data() as any), _id: d.id, _owner: uid }) as MapDoc)
 }
 
+export async function listApprovedOwnersFor(meUid: string): Promise<string[]> {
+  const qy = query(
+    collectionGroup(db, 'followers'),
+    where('__name__', '==', meUid),
+    where('status', '==', 'approved'),
+  )
+  const snap = await getDocs(qy)
+  const owners = new Set<string>()
+  snap.forEach(d => {
+    const parts = d.ref.path.split('/')
+    if (parts.length >= 4) owners.add(parts[1])
+  })
+  return [...owners]
+}
+
+export async function listOwnerMapsForFeed(
+  ownerUid: string,
+  maxPerOwner = 10,
+): Promise<MapDoc[]> {
+  const qy = query(
+    collection(db, 'users', ownerUid, 'maps'),
+    where('visibility', 'in', ['public', 'followers']),
+    orderBy('updatedAt', 'desc'),
+    limit(maxPerOwner),
+  )
+  const snap = await getDocs(qy)
+  return snap.docs.map(d => ({ ...(d.data() as any), _id: d.id, _owner: ownerUid }))
+}
+
+export async function listFollowingFeed(
+  meUid: string,
+  maxPerOwner = 5,
+): Promise<MapDoc[]> {
+  const owners = await listApprovedOwnersFor(meUid)
+  if (!owners.length) return []
+  const chunks = await Promise.all(
+    owners.map(uid => listOwnerMapsForFeed(uid, maxPerOwner)),
+  )
+  const all = chunks.flat()
+  all.sort((a, b) => {
+    const ta = a.updatedAt?.toMillis?.() ?? 0
+    const tb = b.updatedAt?.toMillis?.() ?? 0
+    return tb - ta
+  })
+  return all
+}
+
 export async function getUserProfile(
   uid: string,
 ): Promise<{ displayName?: string; photoURL?: string } | null> {


### PR DESCRIPTION
## Summary
- support fetching follower-only maps and assembling feed
- add /feed page to show newly updated maps from approved owners
- link travel demo to feed

## Testing
- `npm install --no-save --prefix .tmp jest ts-jest @testing-library/react @testing-library/jest-dom react-test-renderer @types/jest jest-environment-jsdom firebase`
- `NODE_PATH="$(pwd)/.tmp/node_modules" node .tmp/node_modules/jest/bin/jest.js --config jest.config.cjs --coverage` *(fails: Cannot find module 'firebase/auth')*

------
https://chatgpt.com/codex/tasks/task_e_68b6907fb9f8832ca7b4bcb356562b23