### PR TITLE
feat: add travel gallery, map and cost split presets

### DIFF
--- a/web/components/travel/CostSplit.tsx
+++ b/web/components/travel/CostSplit.tsx
@@ -1,0 +1,33 @@
+'use client'
+import React from 'react'
+
+export type CostItem = { name: string; amount: number }
+export type CostSplitProps = {
+  items?: CostItem[]
+}
+
+export default function CostSplit({ items = [] }: CostSplitProps) {
+  const total = items.reduce((sum, i) => sum + (i.amount || 0), 0)
+  return (
+    <table className="w-full text-xs">
+      <thead>
+        <tr>
+          <th className="text-left">Item</th>
+          <th className="text-right">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((it, i) => (
+          <tr key={i}>
+            <td>{it.name}</td>
+            <td className="text-right">{it.amount.toLocaleString()}</td>
+          </tr>
+        ))}
+        <tr className="font-medium">
+          <td>Total</td>
+          <td className="text-right">{total.toLocaleString()}</td>
+        </tr>
+      </tbody>
+    </table>
+  )
+}

--- a/web/components/travel/POIMap.tsx
+++ b/web/components/travel/POIMap.tsx
@@ -1,0 +1,27 @@
+'use client'
+import React from 'react'
+
+export type POIMarker = { id: string; x: number; y: number; label?: string }
+export type POIMapProps = {
+  markers?: POIMarker[]
+}
+
+export default function POIMap({ markers = [] }: POIMapProps) {
+  return (
+    <div className="relative w-full h-full bg-muted">
+      {markers.length === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+          No markers
+        </div>
+      )}
+      {markers.map((m) => (
+        <div
+          key={m.id}
+          className="absolute w-2 h-2 rounded-full bg-primary"
+          style={{ left: m.x, top: m.y }}
+          title={m.label}
+        />
+      ))}
+    </div>
+  )
+}

--- a/web/components/travel/PlaceGallery.tsx
+++ b/web/components/travel/PlaceGallery.tsx
@@ -1,0 +1,24 @@
+'use client'
+import React from 'react'
+
+export type PlaceGalleryProps = {
+  images?: string[]
+}
+
+export default function PlaceGallery({ images = [] }: PlaceGalleryProps) {
+  if (images.length === 0) {
+    return <div className="text-xs text-muted-foreground">No images</div>
+  }
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {images.map((src, i) => (
+        <img
+          key={i}
+          src={src}
+          alt=""
+          className="w-full h-24 object-cover rounded-md border"
+        />
+      ))}
+    </div>
+  )
+}

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -77,11 +77,56 @@ export const preset_travelPrefPaintCard: PresetDef = {
   },
 }
 
+export const preset_placeGalleryCard: PresetDef = {
+  id: 'preset.travel.gallery.card',
+  displayName: 'Place Gallery（カード）',
+  tags: ['travel', 'card'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: 'スポット写真', className: 'w-[560px] h-[360px]' } as any,
+    children: [
+      { id: newId('n'), type: 'PlaceGallery', props: { images: [] } as any },
+    ],
+  },
+}
+
+export const preset_poiMapCard: PresetDef = {
+  id: 'preset.travel.poi.card',
+  displayName: 'POI Map（カード）',
+  tags: ['travel', 'card'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: 'スポット地図', className: 'w-[560px] h-[360px]' } as any,
+    children: [
+      { id: newId('n'), type: 'POIMap', props: { markers: [] } as any },
+    ],
+  },
+}
+
+export const preset_costSplitCard: PresetDef = {
+  id: 'preset.travel.costsplit.card',
+  displayName: 'Cost Split（カード）',
+  tags: ['travel', 'card'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: '費用分担', className: 'w-[420px] h-[240px]' } as any,
+    children: [
+      { id: newId('n'), type: 'CostSplit', props: { items: [] } as any },
+    ],
+  },
+}
+
 export const PRESETS: PresetDef[] = [
   preset_japanMapCard_basic,
   preset_tripHeaderCard,
   preset_itineraryTimelineCard,
   preset_travelPrefPaintCard,
+  preset_placeGalleryCard,
+  preset_poiMapCard,
+  preset_costSplitCard,
   preset_travel_map_share_save_card_grid,
   preset_travel_map_enum_card,
   // JapanMap（SVG版）があるなら追加

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -10,6 +10,9 @@ import PrefEnumLegend from '@/components/travel/PrefEnumLegend';
 import PrefEnumGridMap from '@/components/travel/PrefEnumGridMap';
 import PrefEnumShareBar from '@/components/travel/PrefEnumShareBar';
 import SaveMapBarEnum from '@/components/travel/SaveMapBarEnum';
+import PlaceGallery from '@/components/travel/PlaceGallery';
+import POIMap from '@/components/travel/POIMap';
+import CostSplit from '@/components/travel/CostSplit';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -219,6 +222,42 @@ register({
   Render: SaveMapBarEnum,
 });
 
+register({
+  meta: {
+    id: 'PlaceGallery',
+    displayName: 'PlaceGallery',
+    props: [],
+    allowChildren: false,
+    defaultW: 560,
+    defaultH: 360,
+  },
+  Render: PlaceGallery,
+});
+
+register({
+  meta: {
+    id: 'POIMap',
+    displayName: 'POIMap',
+    props: [],
+    allowChildren: false,
+    defaultW: 560,
+    defaultH: 360,
+  },
+  Render: POIMap,
+});
+
+register({
+  meta: {
+    id: 'CostSplit',
+    displayName: 'CostSplit',
+    props: [],
+    allowChildren: false,
+    defaultW: 420,
+    defaultH: 240,
+  },
+  Render: CostSplit,
+});
+
 export const REGISTRY = {
   Card: { component: Card, displayName: 'Card' },
   PrefShareBar: { component: PrefShareBar, displayName: 'PrefShareBar' },
@@ -229,5 +268,8 @@ export const REGISTRY = {
   PrefEnumGridMap: { component: PrefEnumGridMap, displayName: 'PrefEnumGridMap' },
   PrefEnumShareBar: { component: PrefEnumShareBar, displayName: 'PrefEnumShareBar' },
   SaveMapBarEnum: { component: SaveMapBarEnum, displayName: 'SaveMapBarEnum' },
+  PlaceGallery: { component: PlaceGallery, displayName: 'PlaceGallery' },
+  POIMap: { component: POIMap, displayName: 'POIMap' },
+  CostSplit: { component: CostSplit, displayName: 'CostSplit' },
   ...(JapanMap ? { JapanMap: { component: JapanMap, displayName: 'JapanMap' } } : {}),
 } as const;


### PR DESCRIPTION
## Summary
- add placeholder components for travel gallery, POI map and cost split table
- register new components and expose card presets for each

## Testing
- `pnpm test` *(fails: Cannot find module 'firebase/auth' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b693391410832c9992ff2fc3f8a60b