### PR TITLE
feat(builder): SVG JapanMap (enum) + page presets + import

### DIFF
--- a/docs/japanmap_porting_decision.md
+++ b/docs/japanmap_porting_decision.md
@@ -1,0 +1,8 @@
+# Japan Map Porting Decision
+
+- **Strategy chosen:** A – shared import.
+- The SVG map lives in the workspace package `@repo/comp-maps-jp` under `packages/comp-maps-jp`.
+- The `web` app already depends on this package via `package.json` and Next.js `transpilePackages` option.
+- Therefore, we can import `JapanMap` directly from `@repo/comp-maps-jp` without copying files.
+- No `tsconfig.json` path mapping is required beyond the existing workspace setup.
+- This keeps the source of truth in one place and avoids duplication.

--- a/docs/japanmap_porting_scan.md
+++ b/docs/japanmap_porting_scan.md
@@ -1,0 +1,22 @@
+# Japan Map Porting Scan
+
+- Source components located in `packages/comp-maps-jp/src/`.
+  - `JapanMap.tsx`: renders `<svg>` with prefecture paths.
+    - Props: `values`, `showLabels`, `palette`, `strokeWidth`, `labelKind`, `onChange`, `onHover`.
+    - Iterates `PrefShape` for each `PrefCode` using `PREF_PATHS` data.
+    - Uses `colorOf` utility to derive fill color from `values` + `palette`.
+    - Click handling: `PrefShape` receives `onClick` calling local `handleClick` which cycles status via `onChange` callback.
+  - `components/PrefShape.tsx`: simple wrapper for `<path>` element.
+    - Props: `{ code, d, fill, stroke, strokeWidth, onClick, onEnter, onLeave }`.
+    - Emits `onClick(code)`, `onEnter(code)`, `onLeave()`.
+    - Currently no `data-code` attribute; accessible interaction limited to mouse.
+  - `data/prefPaths.ts`: mapping from `PrefCode` to SVG path strings.
+    - Placeholder data for now (only a couple of prefectures defined).
+
+- Prefecture codes handled by TypeScript `PrefCode` union types. No DOM `data-code` attributes.
+- Lacks keyboard accessibility; paths are not focusable.
+- To integrate with builder enum store:
+  - Need adapter to convert numeric enum states (0–3) to `VisitStatus` strings used in map.
+  - May patch map to accept `getFill(code)` and `onPrefClick(code)` for direct store linkage.
+  - Consider adding `tabIndex` and keyboard handlers for accessibility.
+

--- a/packages/comp-maps-jp/package.json
+++ b/packages/comp-maps-jp/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "type": "module",
   "sideEffects": false,
-  "exports": { ".": "./src/register.ts" },
+  "exports": {
+    ".": "./src/register.ts",
+    "./JapanMap": "./src/JapanMap.tsx",
+    "./types": "./src/types.ts"
+  },
   "dependencies": { "@repo/types": "workspace:*" }
 }

--- a/packages/comp-maps-jp/src/JapanMap.tsx
+++ b/packages/comp-maps-jp/src/JapanMap.tsx
@@ -9,7 +9,7 @@ import type { PrefCode, VisitStatus, JapanMapProps } from './types';
 const CYCLE: VisitStatus[] = ['none','passed','visited','lived'];
 
 export function JapanMap(props: JapanMapProps) {
-  const { values, showLabels, palette, strokeWidth, labelKind, onChange, onHover } = props;
+  const { values, showLabels, palette, strokeWidth, labelKind, onChange, onHover, getFill, onPrefClick, className, svgProps } = props
   const [hover, setHover] = useState<PrefCode | null>(null);
   const nextOf = (v?: VisitStatus) => CYCLE[(CYCLE.indexOf(v ?? 'none') + 1) % CYCLE.length];
 
@@ -22,11 +22,15 @@ export function JapanMap(props: JapanMapProps) {
   const labels = labelKind === 'capital' ? CAPITAL_LABELS : PREF_LABELS;
 
   return (
-    <svg viewBox="0 0 480 480" className="w-full h-auto select-none">
+    <svg
+      viewBox="0 0 480 480"
+      className={["w-full h-auto select-none", className].filter(Boolean).join(' ')}
+      {...svgProps}
+    >
       <g>
         {(Object.keys(PREF_PATHS) as PrefCode[]).map((code) => {
           const d = PREF_PATHS[code];
-          const fill = colorOf(values[code], palette);
+          const fill = getFill ? getFill(code) : colorOf(values[code], palette)
           return (
             <PrefShape
               key={code}
@@ -35,7 +39,7 @@ export function JapanMap(props: JapanMapProps) {
               fill={fill}
               stroke={palette.stroke}
               strokeWidth={strokeWidth}
-              onClick={handleClick}
+              onClick={onPrefClick ?? handleClick}
               onEnter={(c) => { setHover(c); onHover?.(c); }}
               onLeave={() => { setHover(null); onHover?.(null); }}
             />

--- a/packages/comp-maps-jp/src/components/PrefShape.tsx
+++ b/packages/comp-maps-jp/src/components/PrefShape.tsx
@@ -13,7 +13,15 @@ export function PrefShape({
       fill={fill}
       stroke={stroke}
       strokeWidth={strokeWidth}
+      data-code={code}
+      tabIndex={0}
       onClick={() => onClick?.(code)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick?.(code);
+        }
+      }}
       onMouseEnter={() => onEnter?.(code)}
       onMouseLeave={() => onLeave?.()}
       className="transition-colors duration-100"

--- a/packages/comp-maps-jp/src/types.ts
+++ b/packages/comp-maps-jp/src/types.ts
@@ -1,15 +1,23 @@
+import type { SVGProps } from 'react'
+
 export type PrefCode =
  '01'|'02'|'03'|'04'|'05'|'06'|'07'|'08'|'09'|'10'|'11'|'12'|'13'|'14'|'15'|'16'|'17'|'18'|'19'|'20'|
  '21'|'22'|'23'|'24'|'25'|'26'|'27'|'28'|'29'|'30'|'31'|'32'|'33'|'34'|'35'|'36'|'37'|'38'|'39'|'40'|
- '41'|'42'|'43'|'44'|'45'|'46'|'47';
-export type VisitStatus = 'none'|'passed'|'visited'|'lived';
+ '41'|'42'|'43'|'44'|'45'|'46'|'47'
+export type VisitStatus = 'none'|'passed'|'visited'|'lived'
 
 export type JapanMapProps = {
-  values: Partial<Record<PrefCode, VisitStatus>>;
-  showLabels: boolean;
-  palette: { visited: string; lived: string; passed: string; none: string; stroke: string; };
-  strokeWidth: number;
-  labelKind: 'pref'|'capital'|'none';
-  onChange?: (next: JapanMapProps['values']) => void;
-  onHover?: (code: PrefCode | null) => void;
-};
+  values: Partial<Record<PrefCode, VisitStatus>>
+  showLabels: boolean
+  palette: { visited: string; lived: string; passed: string; none: string; stroke: string }
+  strokeWidth: number
+  labelKind: 'pref'|'capital'|'none'
+  onChange?: (next: JapanMapProps['values']) => void
+  onHover?: (code: PrefCode | null) => void
+  /** optional fill resolver */
+  getFill?: (code: PrefCode) => string
+  /** optional click handler per prefecture */
+  onPrefClick?: (code: PrefCode) => void
+  className?: string
+  svgProps?: SVGProps<SVGSVGElement>
+}

--- a/web/app/u/[uid]/m/[mapId]/page.tsx
+++ b/web/app/u/[uid]/m/[mapId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-import PrefEnumGridMap from '@/components/travel/PrefEnumGridMap'
+import PrefEnumLegend from '@/components/travel/PrefEnumLegend'
+import JapanMapEnumSVG from '@/components/travel/JapanMapEnumSVG'
 import { FollowButton } from '@/components/travel/FollowControls'
 import VisibilityToggle from '@/components/travel/VisibilityToggle'
 import PhotoUploader from '@/components/travel/PhotoUploader'
@@ -64,7 +65,8 @@ export default function MapPage({
               value={visibility}
             />
           )}
-          <PrefEnumGridMap />
+          <PrefEnumLegend />
+          <JapanMapEnumSVG />
           {isOwner && <PhotoUploader uid={params.uid} mapId={params.mapId} />}
           <div className="flex items-center gap-2">
             <DownloadPNG targetId="mapCard" fileName={`${params.uid}-${params.mapId}.png`} />

--- a/web/components/design/BackgroundGradient.tsx
+++ b/web/components/design/BackgroundGradient.tsx
@@ -1,0 +1,27 @@
+'use client'
+import React, { PropsWithChildren } from 'react'
+
+type Pattern = 'grid' | 'dots' | 'none'
+
+type Props = PropsWithChildren<{ from: string; to: string; angle: number; pattern?: Pattern; className?: string }>
+
+export default function BackgroundGradient({ from, to, angle, pattern = 'none', className, children }: Props) {
+  const base = `linear-gradient(${angle}deg, ${from}, ${to})`
+  let style: React.CSSProperties = { backgroundImage: base }
+  if (pattern === 'grid') {
+    style = {
+      backgroundImage: `${base},linear-gradient(#ffffff22 1px,transparent 1px),linear-gradient(90deg,#ffffff22 1px,transparent 1px)` ,
+      backgroundSize: '100% 100%,20px 20px,20px 20px',
+    }
+  } else if (pattern === 'dots') {
+    style = {
+      backgroundImage: `${base},radial-gradient(#ffffff22 1px,transparent 1px)` ,
+      backgroundSize: '100% 100%,10px 10px',
+    }
+  }
+  return (
+    <div className={["w-full h-full", className].filter(Boolean).join(' ')} style={style}>
+      {children}
+    </div>
+  )
+}

--- a/web/components/design/Section.tsx
+++ b/web/components/design/Section.tsx
@@ -1,0 +1,16 @@
+'use client'
+import React, { PropsWithChildren } from 'react'
+
+type Props = PropsWithChildren<{ max?: 'sm' | 'md' | 'lg' | 'xl'; pad?: 'sm' | 'md' | 'lg'; align?: 'left' | 'center'; className?: string }>
+
+export default function Section({ max = 'lg', pad = 'md', align = 'left', className, children }: Props) {
+  const maxClass = { sm: 'max-w-screen-sm', md: 'max-w-screen-md', lg: 'max-w-screen-lg', xl: 'max-w-screen-xl' }[max]
+  const padClass = { sm: 'p-4', md: 'p-8', lg: 'p-12' }[pad]
+  const alignClass = align === 'center' ? 'text-center' : ''
+  const wrapperAlign = align === 'center' ? 'mx-auto' : ''
+  return (
+    <section className={[padClass, className].filter(Boolean).join(' ')}>
+      <div className={[maxClass, wrapperAlign, alignClass].filter(Boolean).join(' ')}>{children}</div>
+    </section>
+  )
+}

--- a/web/components/travel/JapanMapEnumSVG.tsx
+++ b/web/components/travel/JapanMapEnumSVG.tsx
@@ -1,0 +1,66 @@
+'use client'
+import React from 'react'
+import { JapanMap } from '@repo/comp-maps-jp/JapanMap'
+import type { PrefCode } from '@repo/comp-maps-jp/types'
+import { usePrefPaintEnum } from '@/store/prefPaintEnumStore'
+
+export type Enum = 0 | 1 | 2 | 3
+export type Palette = { none: string; want: string; visited: string; lived: string; stroke?: string }
+export type Props = {
+  clickable?: boolean
+  palette?: Partial<Palette>
+  showLabels?: boolean
+  className?: string
+}
+
+const DEFAULT_PALETTE: Required<Palette> = {
+  none: 'hsl(0 0% 98%)',
+  want: 'hsl(38 92% 55%)',
+  visited: 'hsl(217 91% 60%)',
+  lived: 'hsl(0 84% 60%)',
+  stroke: '#0b1020',
+}
+
+export default function JapanMapEnumSVG({
+  clickable = true,
+  palette,
+  showLabels = false,
+  className,
+}: Props) {
+  const painted = usePrefPaintEnum((s) => s.painted)
+  const cycle = usePrefPaintEnum((s) => s.cycle)
+  const pal = { ...DEFAULT_PALETTE, ...palette }
+
+  const getFill = (code: PrefCode) => {
+    const v = painted[code] ?? 0
+    switch (v) {
+      case 1:
+        return pal.want
+      case 2:
+        return pal.visited
+      case 3:
+        return pal.lived
+      default:
+        return pal.none
+    }
+  }
+
+  const handleClick = (code: PrefCode) => {
+    if (!clickable) return
+    cycle(code)
+  }
+
+  return (
+    <JapanMap
+      values={{}}
+      showLabels={showLabels}
+      palette={{ visited: pal.visited, lived: pal.lived, passed: pal.want, none: pal.none, stroke: pal.stroke }}
+      strokeWidth={1}
+      labelKind={showLabels ? 'pref' : 'none'}
+      getFill={getFill}
+      onPrefClick={handleClick}
+      className={className}
+      svgProps={{ role: 'img', 'aria-label': 'Japan prefectures map' }}
+    />
+  )
+}

--- a/web/components/travel/PrefEnumLegend.tsx
+++ b/web/components/travel/PrefEnumLegend.tsx
@@ -1,15 +1,29 @@
 'use client'
 import React from 'react'
+
 export const STATE_META = [
-  { v: 1, label: '行きたい', color: 'hsl(38 92% 55%)' },   // amber-ish
-  { v: 2, label: '行った',   color: 'hsl(217 91% 60%)' },  // blue-ish
-  { v: 3, label: '住んだ',   color: 'hsl(0 84% 60%)' },    // red-ish
+  { v: 1, label: '行きたい', color: 'hsl(38 92% 55%)' },
+  { v: 2, label: '行った', color: 'hsl(217 91% 60%)' },
+  { v: 3, label: '住んだ', color: 'hsl(0 84% 60%)' },
 ] as const
 
-export default function PrefEnumLegend() {
+export type Palette = { want: string; visited: string; lived: string }
+
+export default function PrefEnumLegend({ palette }: { palette?: Partial<Palette> }) {
+  const pal: Palette = {
+    want: STATE_META[0].color,
+    visited: STATE_META[1].color,
+    lived: STATE_META[2].color,
+    ...palette,
+  }
+  const items = [
+    { v: 1, label: '行きたい', color: pal.want },
+    { v: 2, label: '行った', color: pal.visited },
+    { v: 3, label: '住んだ', color: pal.lived },
+  ]
   return (
     <div className="flex gap-3 text-xs">
-      {STATE_META.map(s => (
+      {items.map((s) => (
         <div key={s.v} className="flex items-center gap-1">
           <span className="inline-block w-3 h-3 rounded-sm border" style={{ background: s.color }} />
           <span className="text-muted-foreground">{s.label}</span>

--- a/web/components/typography/Hero.tsx
+++ b/web/components/typography/Hero.tsx
@@ -1,0 +1,18 @@
+'use client'
+import React from 'react'
+
+type Props = { title: string; subtitle?: string; ctaText?: string; ctaHref?: string }
+
+export default function Hero({ title, subtitle, ctaText, ctaHref }: Props) {
+  return (
+    <div className="text-center py-12 space-y-4">
+      <h1 className="text-4xl font-bold">{title}</h1>
+      {subtitle && <p className="text-muted-foreground">{subtitle}</p>}
+      {ctaText && ctaHref && (
+        <a href={ctaHref} className="inline-block px-4 py-2 rounded bg-primary text-primary-foreground">
+          {ctaText}
+        </a>
+      )}
+    </div>
+  )
+}

--- a/web/lib/presets.travel.ts
+++ b/web/lib/presets.travel.ts
@@ -69,3 +69,63 @@ export const preset_travel_map_enum_card: PresetDef = {
     ],
   },
 }
+
+export const preset_travel_map_enum_svg_card: PresetDef = {
+  id: 'preset.travel.map.enum.svg.card',
+  displayName: 'JapanMap（SVG列挙）カード',
+  tags: ['travel', 'card', 'map', 'share'],
+  tree: {
+    id: newId('n'),
+    type: 'Card',
+    props: { title: '地図コレ（SVG）', className: 'w-[720px] min-h-[520px]', id: 'mapCard' },
+    children: [
+      { id: newId('n'), type: 'PrefEnumLegend', props: {} },
+      { id: newId('n'), type: 'PrefEnumShareBar', props: {} },
+      { id: newId('n'), type: 'JapanMapEnumSVG', props: {} },
+      { id: newId('n'), type: 'SaveMapBarEnum', props: {} },
+      { id: newId('n'), type: 'DownloadPNG', props: { targetId: 'mapCard', fileName: 'my-map.png' } },
+    ],
+  },
+}
+
+export const preset_travel_landing_svg: PresetDef = {
+  id: 'preset.travel.landing.svg',
+  displayName: 'Travel Landing（SVG）',
+  tags: ['travel', 'page', 'landing', 'common'],
+  tree: {
+    id: newId('n'),
+    type: 'BackgroundGradient',
+    props: { from: '#0ea5e9', to: '#22c55e', angle: 135, pattern: 'none' },
+    children: [
+      {
+        id: newId('n'),
+        type: 'Section',
+        props: { max: 'xl', pad: 'lg', align: 'center' },
+        children: [
+          {
+            id: newId('n'),
+            type: 'Hero',
+            props: {
+              title: '旅の地図',
+              subtitle: '行きたい・行った・住んだ',
+              ctaText: '地図を作る',
+              ctaHref: '/travel/demo',
+            },
+          },
+          {
+            id: newId('n'),
+            type: 'Card',
+            props: { title: '地図コレ（SVG）', className: 'w-[720px] min-h-[520px]', id: 'mapCard' },
+            children: [
+              { id: newId('n'), type: 'PrefEnumLegend', props: {} },
+              { id: newId('n'), type: 'PrefEnumShareBar', props: {} },
+              { id: newId('n'), type: 'JapanMapEnumSVG', props: {} },
+              { id: newId('n'), type: 'SaveMapBarEnum', props: {} },
+              { id: newId('n'), type: 'DownloadPNG', props: { targetId: 'mapCard', fileName: 'my-map.png' } },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -1,6 +1,6 @@
 import type { ComponentNode } from '@/types/editor'
 import { newId } from './ids'
-import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, preset_travel_map_enum_card, type PresetDef } from './presets.travel'
+import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, preset_travel_map_enum_card, preset_travel_map_enum_svg_card, preset_travel_landing_svg, type PresetDef } from './presets.travel'
 export type { DomainTag, PresetTag, PresetDef } from './presets.travel'
 
 export const cloneSubtree = (node: ComponentNode): ComponentNode => {
@@ -129,6 +129,8 @@ export const PRESETS: PresetDef[] = [
   preset_costSplitCard,
   preset_travel_map_share_save_card_grid,
   preset_travel_map_enum_card,
+  preset_travel_map_enum_svg_card,
+  preset_travel_landing_svg,
   // JapanMap（SVG版）があるなら追加
   ...(() => {
     try {

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -13,6 +13,10 @@ import SaveMapBarEnum from '@/components/travel/SaveMapBarEnum';
 import PlaceGallery from '@/components/travel/PlaceGallery';
 import POIMap from '@/components/travel/POIMap';
 import CostSplit from '@/components/travel/CostSplit';
+import JapanMapEnumSVG from '@/components/travel/JapanMapEnumSVG';
+import BackgroundGradient from '@/components/design/BackgroundGradient';
+import Section from '@/components/design/Section';
+import Hero from '@/components/typography/Hero';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -200,6 +204,54 @@ register({
 
 register({
   meta: {
+    id: 'JapanMapEnumSVG',
+    displayName: 'JapanMapEnumSVG',
+    props: [],
+    allowChildren: false,
+    defaultW: 560,
+    defaultH: 360,
+  },
+  Render: JapanMapEnumSVG,
+});
+
+register({
+  meta: {
+    id: 'BackgroundGradient',
+    displayName: 'BackgroundGradient',
+    props: [],
+    allowChildren: true,
+    defaultW: 720,
+    defaultH: 480,
+  },
+  Render: BackgroundGradient,
+});
+
+register({
+  meta: {
+    id: 'Section',
+    displayName: 'Section',
+    props: [],
+    allowChildren: true,
+    defaultW: 720,
+    defaultH: 480,
+  },
+  Render: Section,
+});
+
+register({
+  meta: {
+    id: 'Hero',
+    displayName: 'Hero',
+    props: [],
+    allowChildren: false,
+    defaultW: 560,
+    defaultH: 200,
+  },
+  Render: Hero,
+});
+
+register({
+  meta: {
     id: 'PrefEnumShareBar',
     displayName: 'PrefEnumShareBar',
     props: [],
@@ -266,6 +318,10 @@ export const REGISTRY = {
   DownloadPNG: { component: DownloadPNG, displayName: 'DownloadPNG' },
   PrefEnumLegend: { component: PrefEnumLegend, displayName: 'PrefEnumLegend' },
   PrefEnumGridMap: { component: PrefEnumGridMap, displayName: 'PrefEnumGridMap' },
+  JapanMapEnumSVG: { component: JapanMapEnumSVG, displayName: 'JapanMapEnumSVG' },
+  BackgroundGradient: { component: BackgroundGradient, displayName: 'BackgroundGradient' },
+  Section: { component: Section, displayName: 'Section' },
+  Hero: { component: Hero, displayName: 'Hero' },
   PrefEnumShareBar: { component: PrefEnumShareBar, displayName: 'PrefEnumShareBar' },
   SaveMapBarEnum: { component: SaveMapBarEnum, displayName: 'SaveMapBarEnum' },
   PlaceGallery: { component: PlaceGallery, displayName: 'PlaceGallery' },

--- a/web/store/presetsFilterStore.ts
+++ b/web/store/presetsFilterStore.ts
@@ -15,13 +15,13 @@ type PresetsFilterState = {
 export const usePresetsFilter = create(
   persist<PresetsFilterState>(
     (set) => ({
-      activeDomains: { travel: false, accounting: false },
+      activeDomains: { travel: true, accounting: false },
       alwaysShowCommon: true,
       toggleDomain: (d) =>
         set((s) => ({ activeDomains: { ...s.activeDomains, [d]: !s.activeDomains[d] } })),
       setOnly: (d) =>
         set(() => ({ activeDomains: { travel: false, accounting: false, [d]: true } as Record<Domain, boolean> })),
-      reset: () => set(() => ({ activeDomains: { travel: false, accounting: false } })),
+      reset: () => set(() => ({ activeDomains: { travel: true, accounting: false } })),
     }),
     { name: 'presets-filter-v1' },
   ),


### PR DESCRIPTION
## Summary
- document travel Japan map components and shared import strategy
- add enum-aware SVG Japan map and legend palette support
- expose design primitives and presets including landing page
- render SVG enum map on user map page and show travel presets by default

## Testing
- `pnpm -C web build` *(fails: FirebaseError auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68b694a48768832ca703e0b8abedd46c