### PR TITLE
feat: unify map themes with palettes

### DIFF
--- a/web/app/api/og/[pe]/route.tsx
+++ b/web/app/api/og/[pe]/route.tsx
@@ -1,17 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from 'next/server'
 import { PREFS } from '@/lib/japanPrefs'
+import { getMapPalette } from '@/lib/mapPalette'
 
 // Edgeで動かす
 export const runtime = 'edge'
-
-// 列挙：0=なし,1=行きたい,2=行った,3=住んだ
-const COLORS = {
-  0: '#F7F7F7',
-  1: '#f59e0b', // want
-  2: '#3b82f6', // visited
-  3: '#ef4444', // lived
-} as const
 
 const decodeEnum = (b64: string): number[] => {
   try {
@@ -31,7 +24,10 @@ const decodeEnum = (b64: string): number[] => {
   }
 }
 
-export async function GET(_: Request, { params }: { params: { pe: string } }) {
+export async function GET(req: Request, { params }: { params: { pe: string } }) {
+  const t = new URL(req.url).searchParams.get('t') ?? 'default'
+  const pal = getMapPalette(t)
+  const COLORS = { 0: pal.none, 1: pal.want, 2: pal.visited, 3: pal.lived } as const
   const vals = decodeEnum(params.pe)
 
   return new ImageResponse(
@@ -43,7 +39,7 @@ export async function GET(_: Request, { params }: { params: { pe: string } }) {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
-          background: 'linear-gradient(180deg,#ffffff,#f4f6f8)',
+          background: `linear-gradient(180deg,${pal.bgFrom},${pal.bgTo})`,
           padding: 48,
           fontFamily: 'sans-serif',
         }}
@@ -75,7 +71,7 @@ export async function GET(_: Request, { params }: { params: { pe: string } }) {
               style={{
                 height: 70,
                 borderRadius: 10,
-                border: '2px solid #e5e7eb',
+                border: `2px solid ${pal.stroke}`,
                 background: COLORS[vals[i] as 0 | 1 | 2 | 3],
                 display: 'flex',
                 alignItems: 'center',

--- a/web/app/api/og/p/[p]/route.ts
+++ b/web/app/api/og/p/[p]/route.ts
@@ -17,10 +17,12 @@ const decodeBool = (b64: string): number[] => {
   }
 }
 
-export async function GET(_: Request, { params }: { params: { p: string } }) {
+export async function GET(req: Request, { params }: { params: { p: string } }) {
   const vals = decodeBool(params.p)
+  const t = new URL(req.url).searchParams.get('t')
   // 再利用：列挙APIに合わせた描画
   const url = new URL('/api/og/' + btoa(String.fromCharCode(...pack2bit(vals))), 'http://x')
+  if (t) url.searchParams.set('t', t)
   return fetch(url) // 2bitへ変換して転送
 }
 

--- a/web/app/s/[pe]/page.tsx
+++ b/web/app/s/[pe]/page.tsx
@@ -3,9 +3,9 @@ import type { Metadata } from 'next'
 export const runtime = 'edge'
 export const dynamic = 'force-static' // キャッシュしてOK（パラメータベース）
 
-export async function generateMetadata({ params }: { params: { pe: string } }): Promise<Metadata> {
+export async function generateMetadata({ params, searchParams }: { params: { pe: string }; searchParams: { t?: string } }): Promise<Metadata> {
   const pe = params.pe
-  const img = `/api/og/${pe}`
+  const img = `/api/og/${pe}${searchParams?.t ? `?t=${searchParams.t}` : ''}`
   return {
     title: '地図コレ – 私の日本地図',
     description: '行きたい・行った・住んだを色でシェア！',
@@ -23,12 +23,13 @@ export async function generateMetadata({ params }: { params: { pe: string } }): 
   }
 }
 
-export default function ShareEnumPage({ params }: { params: { pe: string } }) {
+export default function ShareEnumPage({ params, searchParams }: { params: { pe: string }; searchParams: { t?: string } }) {
   const pe = params.pe
+  const img = `/api/og/${pe}${searchParams?.t ? `?t=${searchParams.t}` : ''}`
   return (
     <div className="min-h-screen flex flex-col items-center justify-center gap-6 p-6 text-center">
       <h1 className="text-2xl font-bold">共有ページ（列挙）</h1>
-      <img src={`/api/og/${pe}`} alt="OG Preview" className="w-[600px] rounded-xl border shadow" />
+      <img src={img} alt="OG Preview" className="w-[600px] rounded-xl border shadow" />
       <a href={`/travel/demo?pe=${pe}`} className="px-4 py-2 border rounded">アプリで開く</a>
     </div>
   )

--- a/web/components/travel/JapanMapEnumSVG.tsx
+++ b/web/components/travel/JapanMapEnumSVG.tsx
@@ -3,45 +3,46 @@ import React from 'react'
 import { JapanMap } from '@repo/comp-maps-jp/JapanMap'
 import type { PrefCode } from '@repo/comp-maps-jp/types'
 import { usePrefPaintEnum } from '@/store/prefPaintEnumStore'
+import { getMapPalette } from '@/lib/mapPalette'
 
 export type Enum = 0 | 1 | 2 | 3
-export type Palette = { none: string; want: string; visited: string; lived: string; stroke?: string }
 export type Props = {
   clickable?: boolean
-  palette?: Partial<Palette>
+  paletteId?: string
+  palette?: Partial<{ none: string; want: string; visited: string; lived: string; stroke: string }>
   showLabels?: boolean
   className?: string
 }
 
-const DEFAULT_PALETTE: Required<Palette> = {
-  none: 'hsl(0 0% 98%)',
-  want: 'hsl(38 92% 55%)',
-  visited: 'hsl(217 91% 60%)',
-  lived: 'hsl(0 84% 60%)',
-  stroke: '#0b1020',
-}
-
 export default function JapanMapEnumSVG({
   clickable = true,
+  paletteId,
   palette,
   showLabels = false,
   className,
 }: Props) {
   const painted = usePrefPaintEnum((s) => s.painted)
   const cycle = usePrefPaintEnum((s) => s.cycle)
-  const pal = { ...DEFAULT_PALETTE, ...palette }
+  const pal = getMapPalette(paletteId)
+  const colors = {
+    none: palette?.none ?? pal.none,
+    want: palette?.want ?? pal.want,
+    visited: palette?.visited ?? pal.visited,
+    lived: palette?.lived ?? pal.lived,
+    stroke: palette?.stroke ?? pal.stroke,
+  }
 
   const getFill = (code: PrefCode) => {
     const v = painted[code] ?? 0
     switch (v) {
       case 1:
-        return pal.want
+        return colors.want
       case 2:
-        return pal.visited
+        return colors.visited
       case 3:
-        return pal.lived
+        return colors.lived
       default:
-        return pal.none
+        return colors.none
     }
   }
 
@@ -54,7 +55,7 @@ export default function JapanMapEnumSVG({
     <JapanMap
       values={{}}
       showLabels={showLabels}
-      palette={{ visited: pal.visited, lived: pal.lived, passed: pal.want, none: pal.none, stroke: pal.stroke }}
+      palette={{ visited: colors.visited, lived: colors.lived, passed: colors.want, none: colors.none, stroke: colors.stroke }}
       strokeWidth={1}
       labelKind={showLabels ? 'pref' : 'none'}
       getFill={getFill}

--- a/web/components/travel/SaveMapBarEnum.tsx
+++ b/web/components/travel/SaveMapBarEnum.tsx
@@ -2,11 +2,13 @@
 import React, { useEffect, useState } from 'react'
 import { usePrefPaintEnum } from '@/store/prefPaintEnumStore'
 import { onUser, createMap } from '@/services/travel'
+import { useMapTheme } from '@/contexts/MapThemeContext'
 
 export default function SaveMapBarEnum() {
   const exportEnumB64 = usePrefPaintEnum(s => s.exportEnumB64)
   const [uid, setUid] = useState<string | undefined>()
   const [link, setLink] = useState<string>('')
+  const { paletteId = 'default' } = useMapTheme()
 
   useEffect(() => onUser(u => setUid(u?.uid)), [])
 
@@ -18,7 +20,7 @@ export default function SaveMapBarEnum() {
       visibility: 'public',
     })
     const pe = exportEnumB64()
-    const share = `${location.origin}/s/${pe}`                    // ← 共有は /s/[pe]
+    const share = `${location.origin}/s/${pe}?t=${paletteId}`                    // ← 共有は /s/[pe]?t=...
     const doc = `${location.origin}/u/${uid}/m/${id}`            // ← 詳細ページも保持
     setLink(share)
     await navigator.clipboard?.writeText(share)

--- a/web/contexts/MapThemeContext.tsx
+++ b/web/contexts/MapThemeContext.tsx
@@ -1,0 +1,24 @@
+'use client'
+import React, { createContext, useContext, useMemo } from 'react'
+import { getMapPalette } from '@/lib/mapPalette'
+
+const Ctx = createContext<{paletteId: string; vars: React.CSSProperties}>({ paletteId: 'default', vars: {} })
+
+export const MapThemeProvider = ({ id = 'default', children }: { id?: string; children: React.ReactNode }) => {
+  const pal = getMapPalette(id)
+  const vars = useMemo(() => ({
+    // @ts-ignore
+    ['--map-none']: pal.none,
+    ['--map-want']: pal.want,
+    ['--map-visited']: pal.visited,
+    ['--map-lived']: pal.lived,
+    ['--map-stroke']: pal.stroke,
+  }), [id])
+  return (
+    <Ctx.Provider value={{ paletteId: id, vars }}>
+      <div style={vars}>{children}</div>
+    </Ctx.Provider>
+  )
+}
+
+export const useMapTheme = () => useContext(Ctx)

--- a/web/lib/mapPalette.ts
+++ b/web/lib/mapPalette.ts
@@ -1,0 +1,21 @@
+export type MapPalette = {
+  id: string; name: string;
+  none: string; want: string; visited: string; lived: string; stroke: string;
+  bgFrom: string; bgTo: string;
+}
+export const MAP_PALETTES: Record<string, MapPalette> = {
+  default: { id:'default', name:'Default',
+    none:'#F7F7F7', want:'#f59e0b', visited:'#3b82f6', lived:'#ef4444', stroke:'#e5e7eb',
+    bgFrom:'#ffffff', bgTo:'#f4f6f8',
+  },
+  ocean: { id:'ocean', name:'Ocean',
+    none:'#F6FAFF', want:'#0ea5e9', visited:'#2563eb', lived:'#0f766e', stroke:'#dbeafe',
+    bgFrom:'#eef6ff', bgTo:'#eaf2fb',
+  },
+  sakura: { id:'sakura', name:'Sakura',
+    none:'#FFF7FA', want:'#fb7185', visited:'#f472b6', lived:'#db2777', stroke:'#fecdd3',
+    bgFrom:'#fff1f2', bgTo:'#ffe4e6',
+  },
+}
+export const getMapPalette = (id?: string) =>
+  MAP_PALETTES[id ?? 'default'] ?? MAP_PALETTES.default

--- a/web/lib/presets.travel.ts
+++ b/web/lib/presets.travel.ts
@@ -129,3 +129,17 @@ export const preset_travel_landing_svg: PresetDef = {
     ],
   },
 }
+
+export const preset_theme_ocean: PresetDef = {
+  id: 'preset.theme.ocean',
+  displayName: 'Theme (Ocean)',
+  tags: ['common'],
+  tree: { id: newId('n'), type: 'MapThemeProvider', props: { id: 'ocean' }, children: [] },
+}
+
+export const preset_theme_sakura: PresetDef = {
+  id: 'preset.theme.sakura',
+  displayName: 'Theme (Sakura)',
+  tags: ['common'],
+  tree: { id: newId('n'), type: 'MapThemeProvider', props: { id: 'sakura' }, children: [] },
+}

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -1,6 +1,6 @@
 import type { ComponentNode } from '@/types/editor'
 import { newId } from './ids'
-import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, preset_travel_map_enum_card, preset_travel_map_enum_svg_card, preset_travel_landing_svg, type PresetDef } from './presets.travel'
+import { preset_travel_map_share_save_card_grid, maybeJapanMapPreset, preset_travel_map_enum_card, preset_travel_map_enum_svg_card, preset_travel_landing_svg, preset_theme_ocean, preset_theme_sakura, type PresetDef } from './presets.travel'
 export type { DomainTag, PresetTag, PresetDef } from './presets.travel'
 
 export const cloneSubtree = (node: ComponentNode): ComponentNode => {
@@ -131,6 +131,8 @@ export const PRESETS: PresetDef[] = [
   preset_travel_map_enum_card,
   preset_travel_map_enum_svg_card,
   preset_travel_landing_svg,
+  preset_theme_ocean,
+  preset_theme_sakura,
   // JapanMap（SVG版）があるなら追加
   ...(() => {
     try {

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -17,6 +17,7 @@ import JapanMapEnumSVG from '@/components/travel/JapanMapEnumSVG';
 import BackgroundGradient from '@/components/design/BackgroundGradient';
 import Section from '@/components/design/Section';
 import Hero from '@/components/typography/Hero';
+import { MapThemeProvider } from '@/contexts/MapThemeContext';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -310,6 +311,18 @@ register({
   Render: CostSplit,
 });
 
+register({
+  meta: {
+    id: 'MapThemeProvider',
+    displayName: 'MapThemeProvider',
+    props: [],
+    allowChildren: true,
+    defaultW: 100,
+    defaultH: 100,
+  },
+  Render: MapThemeProvider,
+});
+
 export const REGISTRY = {
   Card: { component: Card, displayName: 'Card' },
   PrefShareBar: { component: PrefShareBar, displayName: 'PrefShareBar' },
@@ -327,5 +340,6 @@ export const REGISTRY = {
   PlaceGallery: { component: PlaceGallery, displayName: 'PlaceGallery' },
   POIMap: { component: POIMap, displayName: 'POIMap' },
   CostSplit: { component: CostSplit, displayName: 'CostSplit' },
+  MapThemeProvider: { component: MapThemeProvider, displayName: 'MapThemeProvider' },
   ...(JapanMap ? { JapanMap: { component: JapanMap, displayName: 'JapanMap' } } : {}),
 } as const;


### PR DESCRIPTION
## Summary
- add shared map palettes and hookable MapThemeProvider
- theme-aware Japan map SVG and OG image rendering
- include palette id in share links and presets

## Testing
- `npm test` *(fails: Cannot find module 'firebase/auth')*
- `npm install firebase` *(fails: Cannot read properties of null (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_68b699cc6488832cb9dd339d592d9167