### PR TITLE
feat: add anime.js animation presets

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.85.5
         version: 5.85.5(@tanstack/react-query@5.85.5(react@18.3.1))(react@18.3.1)
+      animejs:
+        specifier: ^4.1.3
+        version: 4.1.3
       dexie:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1010,6 +1013,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  animejs@4.1.3:
+    resolution: {integrity: sha512-4XzlIsQsku1ycSPzchxxT0N+ohEMZObG71nOSBBkZoV4sgQvtXa/qAANkFpTE6pegdV8JnIBZiB0LfdxNoRNMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2869,6 +2875,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  animejs@4.1.3: {}
 
   ansi-regex@5.0.1: {}
 

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -18,6 +18,103 @@ const buildSubtree = (elements: any[], id: string): ComponentNode | null => {
   } as ComponentNode;
 };
 
+function AnimationPresets() {
+  const wrap = useBuilderStore((s) => s.wrapSelectedWith);
+  const unwrap = useBuilderStore((s) => s.unwrapSelectedIf);
+  const replay = useBuilderStore((s) => s.replayAnimationOnSelected);
+
+  const [preset, setPreset] = useState<'pop' | 'fadeUp' | 'cascade'>("pop");
+  const [mode, setMode] = useState<'mount' | 'view'>("mount");
+  const [duration, setDuration] = useState(700);
+  const [delay, setDelay] = useState(0);
+  const [stagger, setStagger] = useState(60);
+  const [easing, setEasing] = useState("easeOutQuad");
+  const [selector, setSelector] = useState(">*");
+
+  const apply = () => {
+    const props: any = { preset, duration, delay, easing };
+    if (preset === "cascade")
+      (props.selector = selector), (props.stagger = stagger);
+    wrap(mode === "mount" ? "AnimeOnMount" : "AnimeOnView", props);
+  };
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold">Animation Presets</h2>
+      <div className="flex flex-wrap gap-2 items-center">
+        <select
+          className="border rounded px-2 py-1"
+          value={preset}
+          onChange={(e) => setPreset(e.target.value as any)}
+        >
+          <option value="pop">pop（scale+fade）</option>
+          <option value="fadeUp">fadeUp（下から）</option>
+          <option value="cascade">cascade（子を順番に）</option>
+        </select>
+        <select
+          className="border rounded px-2 py-1"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as any)}
+        >
+          <option value="mount">on mount</option>
+          <option value="view">on view (scroll in)</option>
+        </select>
+        <label className="text-xs">
+          duration
+          <input
+            className="border rounded px-1 w-20 ml-1"
+            type="number"
+            value={duration}
+            onChange={(e) => setDuration(+e.target.value)}
+          />
+        </label>
+        <label className="text-xs">
+          delay
+          <input
+            className="border rounded px-1 w-16 ml-1"
+            type="number"
+            value={delay}
+            onChange={(e) => setDelay(+e.target.value)}
+          />
+        </label>
+        {preset === "cascade" && (
+          <>
+            <label className="text-xs">
+              stagger
+              <input
+                className="border rounded px-1 w-16 ml-1"
+                type="number"
+                value={stagger}
+                onChange={(e) => setStagger(+e.target.value)}
+              />
+            </label>
+            <label className="text-xs">
+              selector
+              <input
+                className="border rounded px-1 w-40 ml-1"
+                value={selector}
+                onChange={(e) => setSelector(e.target.value)}
+              />
+            </label>
+          </>
+        )}
+        <button className="px-3 py-1 border rounded" onClick={apply}>
+          Apply to selection
+        </button>
+        <button className="px-3 py-1 border rounded" onClick={() => unwrap()}>
+          Unwrap
+        </button>
+        <button className="px-3 py-1 border rounded" onClick={replay}>
+          Replay
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        ※ まず Canvas で対象ノードを選択してから適用してください
+      </p>
+    </section>
+  );
+}
+
 export default function DevActionsPage() {
   const placePreset = useBuilderStore((s) => s.placePreset);
   const addSubtree = useBuilderStore((s) => s.addSubtree);
@@ -54,8 +151,8 @@ export default function DevActionsPage() {
   }, [addSubtree]);
 
   return (
-    <div className="p-4 space-y-3">
-      <h1 className="text-lg font-bold">Dev / Actions / Presets & Share</h1>
+    <div className="p-4 space-y-6">
+      <h1 className="text-lg font-bold">Dev / Actions</h1>
 
       {PRESETS.map((p) => (
         <button
@@ -88,6 +185,8 @@ export default function DevActionsPage() {
           Import
         </button>
       </div>
+
+      <AnimationPresets />
     </div>
   );
 }

--- a/web/components/anim/AnimeOnMount.tsx
+++ b/web/components/anim/AnimeOnMount.tsx
@@ -1,0 +1,59 @@
+'use client'
+import React, { useEffect, useRef } from 'react'
+
+export type Preset = 'pop' | 'fadeUp' | 'cascade'
+
+export default function AnimeOnMount({
+  preset = 'pop',
+  duration = 700,
+  delay = 0,
+  stagger = 60,
+  easing = 'easeOutQuad',
+  selector = '>*',
+  playKey = 0,
+  children,
+  className,
+  style,
+}: {
+  preset?: Preset
+  duration?: number
+  delay?: number
+  stagger?: number
+  easing?: string
+  selector?: string          // cascade のターゲットセレクタ
+  playKey?: number           // 変わると再生し直す
+  children: React.ReactNode
+  className?: string
+  style?: React.CSSProperties
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const mod = await import('animejs')
+      if (cancelled) return
+      const anime = (mod.default ?? (mod as any)) as any
+      const base = { duration, delay, easing }
+      const el = ref.current
+      if (!el) return
+      if (preset === 'cascade') {
+        const targets = el.querySelectorAll(selector)
+        anime({ targets, opacity: [0, 1], translateY: [8, 0], delay: anime.stagger(stagger), ...base })
+      } else if (preset === 'fadeUp') {
+        anime({ targets: el, opacity: [0, 1], translateY: [12, 0], ...base })
+      } else {
+        anime({ targets: el, opacity: [0, 1], scale: [0.96, 1], ...base })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [preset, duration, delay, stagger, easing, selector, playKey])
+
+  return (
+    <div ref={ref} className={className} style={style}>
+      {children}
+    </div>
+  )
+}

--- a/web/components/anim/AnimeOnView.tsx
+++ b/web/components/anim/AnimeOnView.tsx
@@ -1,0 +1,42 @@
+'use client'
+import React, { useEffect, useRef, useState } from 'react'
+import AnimeOnMount, { type Preset } from './AnimeOnMount'
+
+export default function AnimeOnView({
+  preset = 'fadeUp',
+  rootMargin = '0px 0px -10% 0px',
+  once = true,
+  ...rest
+}: {
+  preset?: Preset
+  rootMargin?: string
+  once?: boolean
+  duration?: number
+  delay?: number
+  stagger?: number
+  easing?: string
+  selector?: string
+  playKey?: number
+  className?: string
+  children: React.ReactNode
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const io = new IntersectionObserver(([e]) => {
+      if (e.isIntersecting) {
+        setVisible(true)
+        if (once) io.disconnect()
+      }
+    }, { rootMargin })
+    io.observe(el)
+    return () => io.disconnect()
+  }, [rootMargin, once])
+  return (
+    <div ref={ref}>
+      {visible ? <AnimeOnMount preset={preset} {...rest} /> : rest.children}
+    </div>
+  )
+}

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -18,6 +18,8 @@ import BackgroundGradient from '@/components/design/BackgroundGradient';
 import Section from '@/components/design/Section';
 import Hero from '@/components/typography/Hero';
 import { MapThemeProvider } from '@/contexts/MapThemeContext';
+import AnimeOnMount from '@/components/anim/AnimeOnMount';
+import AnimeOnView from '@/components/anim/AnimeOnView';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -341,5 +343,7 @@ export const REGISTRY = {
   POIMap: { component: POIMap, displayName: 'POIMap' },
   CostSplit: { component: CostSplit, displayName: 'CostSplit' },
   MapThemeProvider: { component: MapThemeProvider, displayName: 'MapThemeProvider' },
+  AnimeOnMount: { component: AnimeOnMount, displayName: 'AnimeOnMount' },
+  AnimeOnView: { component: AnimeOnView, displayName: 'AnimeOnView' },
   ...(JapanMap ? { JapanMap: { component: JapanMap, displayName: 'JapanMap' } } : {}),
 } as const;

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "@schemas": "workspace:*",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",
+    "animejs": "^4.1.3",
     "dexie": "^4.2.0",
     "firebase": "^10.12.2",
     "framer-motion": "^12.23.12",

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -136,6 +136,9 @@ type BuilderActions = {
   beginBatch: () => void;
   endBatch: () => void;
   updateMany: (patches: ElmPatch[], recordHistory?: boolean) => void;
+  wrapSelectedWith: (type: 'AnimeOnMount' | 'AnimeOnView', props?: Record<string, any>) => void;
+  unwrapSelectedIf: (type?: 'AnimeOnMount' | 'AnimeOnView') => void;
+  replayAnimationOnSelected: () => void;
 };
 
 function snapToGrid(n: number) {
@@ -839,6 +842,138 @@ export const useBuilderStore = create<BuilderState & BuilderActions>(
             });
           }),
         );
+      },
+
+      wrapSelectedWith(type, props = {}) {
+        const { selectedIds } = get();
+        if (!selectedIds.length) return;
+        set((state) => {
+          const ids = new Set(selectedIds);
+          const replacements = new Map<string, Elm>();
+          const newElements: Elm[] = [];
+          state.elements.forEach((el) => {
+            if (!ids.has(el.id)) {
+              newElements.push(el);
+              return;
+            }
+            const wrapperId = newId("n");
+            const child: Elm = { ...el, x: 0, y: 0, parentId: wrapperId };
+            const wrapper: Elm = {
+              id: wrapperId,
+              type,
+              x: el.x,
+              y: el.y,
+              w: el.w,
+              h: el.h,
+              visible: el.visible,
+              locked: el.locked,
+              parentId: el.parentId ?? null,
+              children: [child.id],
+              props: { ...(props || {}) },
+            };
+            replacements.set(el.id, wrapper);
+            newElements.push(wrapper, child);
+          });
+          newElements.forEach((el) => {
+            if (el.children) {
+              el.children = el.children.map((cid) => {
+                const rep = replacements.get(cid);
+                return rep ? rep.id : cid;
+              });
+            }
+          });
+          const newTree = state.tree.map((root) => {
+            const rep = replacements.get(root.id);
+            return rep ? rep : root;
+          });
+          const newSelected = selectedIds.map(
+            (id) => replacements.get(id)?.id || id,
+          );
+          return {
+            elements: newElements,
+            tree: newTree,
+            selectedIds: newSelected,
+            selectedId: newSelected[newSelected.length - 1] ?? null,
+          };
+        });
+      },
+
+      unwrapSelectedIf(type) {
+        const { selectedIds } = get();
+        if (!selectedIds.length) return;
+        set((state) => {
+          const toRemove = new Set<string>();
+          const newSelected: string[] = [];
+          state.elements.forEach((wrapper) => {
+            if (!selectedIds.includes(wrapper.id)) return;
+            if (
+              !(
+                wrapper.type === "AnimeOnMount" ||
+                wrapper.type === "AnimeOnView"
+              )
+            )
+              return;
+            if (type && wrapper.type !== type) return;
+            if (!wrapper.children?.length) return;
+            const childId = wrapper.children[0];
+            const child = state.elements.find((e) => e.id === childId);
+            if (!child) return;
+            child.parentId = wrapper.parentId ?? null;
+            child.x = (child.x ?? 0) + (wrapper.x ?? 0);
+            child.y = (child.y ?? 0) + (wrapper.y ?? 0);
+            if (wrapper.parentId) {
+              const parent = state.elements.find((e) => e.id === wrapper.parentId);
+              if (parent && parent.children) {
+                parent.children = parent.children.map((cid) =>
+                  cid === wrapper.id ? childId : cid,
+                );
+              }
+            }
+            newSelected.push(childId);
+            toRemove.add(wrapper.id);
+          });
+          const elements = state.elements.filter((e) => !toRemove.has(e.id));
+          const map = new Map(elements.map((e) => [e.id, e]));
+          const tree = state.tree.reduce<Elm[]>((acc, root) => {
+            if (toRemove.has(root.id)) {
+              const child = map.get(root.children?.[0] || "");
+              if (child) acc.push(child);
+            } else {
+              acc.push(map.get(root.id) || root);
+            }
+            return acc;
+          }, []);
+          return {
+            elements,
+            tree,
+            selectedIds: newSelected,
+            selectedId: newSelected[newSelected.length - 1] ?? null,
+          };
+        });
+      },
+
+      replayAnimationOnSelected() {
+        const { selectedIds } = get();
+        if (!selectedIds.length) return;
+        set((state) => {
+          const idSet = new Set(selectedIds);
+          const elements = state.elements.map((el) => {
+            if (
+              idSet.has(el.id) &&
+              (el.type === "AnimeOnMount" || el.type === "AnimeOnView")
+            ) {
+              const pk = Number((el.props as any)?.playKey ?? 0);
+              return {
+                ...el,
+                props: { ...(el.props || {}), playKey: pk + 1 },
+              };
+            }
+            return el;
+          });
+          const map = new Map(elements.map((e) => [e.id, e]));
+          const tree = state.tree.map((r) => map.get(r.id) || r);
+          return { elements, tree };
+        });
       },
 
       setElements(els) {


### PR DESCRIPTION
## Summary
- add AnimeOnMount and AnimeOnView wrappers powered by anime.js
- enable builder actions to wrap, unwrap and replay animations
- expose Animation Presets UI on /dev/actions

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b69d40d6b4832c85a4604d1a9a4b0e