### PR TITLE
feat: enable interactive actions runtime

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       immer:
         specifier: ^10.0.0
         version: 10.0.0
+      json-logic-js:
+        specifier: ^2.0.5
+        version: 2.0.5
       nanoid:
         specifier: ^5.0.2
         version: 5.1.5
@@ -1429,6 +1432,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-logic-js@2.0.5:
+    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -3317,6 +3323,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-logic-js@2.0.5: {}
 
   json-schema-traverse@0.4.1: {}
 

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -8,37 +8,24 @@ import { usePresetDraft } from '@/store/presetDraftStore'
 import { useBuilderStore } from '@/store/builderStore'
 
 export default function DevActionsPage(){
-  const name = usePresetDraft(s=>s.draft.name)
-  const setName = usePresetDraft(s=>s.setName)
-
-  // 既存の適用関数に接続（仮：ここではアラートorストアの関数呼び出し）
-  const replace = ()=>{/* TODO: draft -> 実際のノードへ適用 */}
-  const append  = ()=>{/* TODO */}
-  const remove  = ()=>{/* TODO */}
-  const replaceAll = ()=>{/* TODO */}
-  const appendAll  = ()=>{/* TODO */}
-  const removeAll  = ()=>{/* TODO */}
+  const draft = usePresetDraft(s=>s.draft)
+  const applySel = useBuilderStore(s=>s.applyInteractiveToSelection)
+  const applyAll = useBuilderStore(s=>s.applyInteractiveToAll)
 
   return (
     <div className="p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <input className="text-lg font-bold bg-transparent outline-none" value={name} onChange={e=>setName(e.target.value)}/>
-        <div className="text-[11px] opacity-70">updated: {new Date().toLocaleString()}</div>
-      </div>
-
       <div className="grid md:grid-cols-2 gap-3">
-        <div className="space-y-3">
-          <TriggersCard/>
-          <EffectsCard/>
-        </div>
-        <div className="space-y-3">
-          <ActionsCard/>{/* ← When がこの中に入っている */}
-        </div>
+        <div className="space-y-3"><TriggersCard/><EffectsCard/></div>
+        <div className="space-y-3"><ActionsCard/></div>
       </div>
 
       <ApplyBar
-        onReplace={replace} onAppend={append} onRemove={remove}
-        onReplaceAll={replaceAll} onAppendAll={appendAll} onRemoveAll={removeAll}
+        onReplace={()=>applySel(draft,'replace')}
+        onAppend={()=>applySel(draft,'append')}
+        onRemove={()=>applySel(draft,'remove')}
+        onReplaceAll={()=>applyAll(draft,'replace')}
+        onAppendAll={()=>applyAll(draft,'append')}
+        onRemoveAll={()=>applyAll(draft,'remove')}
       />
     </div>
   )

--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -1,0 +1,48 @@
+'use client'
+import React, { useEffect, useMemo, useRef } from 'react'
+import { buildInteractiveClass } from '@/lib/interactiveCSS'
+import { bindWhen, type RuntimeCtx } from '@/lib/interactiveActions'
+import type { PresetDraft } from '@/types/presets-ui'
+import { useRouter } from 'next/navigation'
+
+export default function InteractiveWrapper({ draft, children }:{ draft: PresetDraft; children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const router = useRouter()
+
+  // 1) Triggers → ユニーククラス作成
+  const cls = useMemo(()=>{
+    const id = Math.random().toString(36).slice(2,8)
+    const t = draft.triggers
+    const to = (eff?: any) => {
+      if (!eff) return undefined
+      const o:any = {}
+      if (eff.scale?.scale) o.scale = eff.scale.scale
+      if (eff.bgColor?.color) o.bg = eff.bgColor.color
+      if (eff.shadow?.level) o.shadow = eff.shadow.level
+      if (eff.opacity?.opacity != null) o.opacity = eff.opacity.opacity
+      return o
+    }
+    // draft.effects は汎用配列なので kind を寄せて取り出す（最小）
+    const pack = (kind:string) => draft.effects.find(e=>e.kind===kind)?.value
+    const base = {
+      transitionMs: t.transitionMs, easing: t.easing,
+      hover: t.hover ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
+      active: t.active ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
+      focus: t.focus ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
+      focusWithin: t.focusWithin ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
+      groupHover: t.groupHover ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
+    }
+    return buildInteractiveClass(id, base as any)
+  }, [draft])
+
+  // 2) When → Action バインド
+  useEffect(()=>{
+    const el = ref.current; if(!el) return
+    const cleaners = draft.actions.map(a => bindWhen(el, a, {
+      el, data:{}, emit:(ev,p)=>window.dispatchEvent(new CustomEvent(ev,{detail:p})), navigate:(u)=>router.push(u)
+    } as RuntimeCtx))
+    return () => cleaners.forEach(c=>c())
+  }, [draft])
+
+  return <div ref={ref} className={cls}>{children}</div>
+}

--- a/web/lib/interactiveActions.ts
+++ b/web/lib/interactiveActions.ts
@@ -1,0 +1,75 @@
+import type { ActionDef, WhenFlags } from '@/types/presets-ui'
+let jsonLogic: any = null
+export const ensureJsonLogic = async () => {
+  if (jsonLogic) return jsonLogic
+  try { jsonLogic = (await import('json-logic-js')).default } catch { jsonLogic = { apply: () => true } }
+  return jsonLogic
+}
+const truthy = async (rule: any, data: any) => {
+  if (!rule) return true
+  const jl = await ensureJsonLogic()
+  try { return !!jl.apply(rule, data) } catch { return false }
+}
+const withThrottle = <T extends (...a:any[])=>any>(fn:T, ms?:number|null) => {
+  if (!ms) return fn
+  let last = 0; return ((...args:any[]) => { const now=Date.now(); if(now-last>=ms){ last=now; fn(...args) } }) as T
+}
+const withDebounce = <T extends (...a:any[])=>any>(fn:T, ms?:number|null) => {
+  if (!ms) return fn
+  let t:any=null; return ((...args:any[]) => { clearTimeout(t); t=setTimeout(()=>fn(...args), ms) }) as T
+}
+
+export type RuntimeCtx = {
+  el: HTMLElement
+  data?: any // 必要なら将来データ注入
+  emit?: (event:string, payload?:any)=>void
+  navigate?: (url:string)=>void
+}
+
+export async function runAction(a: ActionDef, ctx: RuntimeCtx) {
+  if (!(await truthy(a.if, ctx.data))) return
+  const exec = async () => {
+    if (a.type === 'openUrl') {
+      const url = a.params?.url as string
+      if (url) window.open(url, '_blank', 'noopener')
+    } else if (a.type === 'copyToClipboard') {
+      const text = a.params?.text ?? ''
+      try { await navigator.clipboard?.writeText(String(text)) } catch {}
+    } else if (a.type === 'emit') {
+      ctx.emit?.(a.params?.event ?? 'event', a.params?.payload)
+    } else if (a.type === 'navigate') {
+      ctx.navigate?.(a.params?.to ?? '/')
+    } else if (a.type === 'toggleVar') {
+      // 将来: Zustandの外部ストアに橋渡し
+      (window as any).__vars = (window as any).__vars || {}
+      const k = a.params?.key ?? 'flag'
+      ;(window as any).__vars[k] = !(window as any).__vars[k]
+    }
+  }
+  const wrapped = withThrottle(withDebounce(exec, a.debounceMs), a.throttleMs)
+  await wrapped()
+}
+
+export function bindWhen(el: HTMLElement, a: ActionDef, ctx: RuntimeCtx) {
+  const w = a.when || {}
+  const subs: Array<() => void> = []
+  if (w.click) {
+    const h = () => runAction(a, ctx)
+    el.addEventListener('click', h); subs.push(()=>el.removeEventListener('click', h))
+  }
+  if (w.doubleClick) {
+    const h = () => runAction(a, ctx)
+    el.addEventListener('dblclick', h); subs.push(()=>el.removeEventListener('dblclick', h))
+  }
+  if (w.mount) {
+    let id = requestAnimationFrame(()=>runAction(a, ctx)); subs.push(()=>cancelAnimationFrame(id))
+  }
+  if (w.delayMs && w.delayMs > 0) {
+    const t = setTimeout(()=>runAction(a, ctx), w.delayMs); subs.push(()=>clearTimeout(t))
+  }
+  if (w.inView) {
+    const io = new IntersectionObserver(([e])=>{ if(e.isIntersecting) runAction(a, ctx) }, { rootMargin:'0px 0px -10% 0px' })
+    io.observe(el); subs.push(()=>io.disconnect())
+  }
+  return () => subs.forEach(f=>f())
+}

--- a/web/lib/interactiveCSS.ts
+++ b/web/lib/interactiveCSS.ts
@@ -1,0 +1,55 @@
+let styleEl: HTMLStyleElement | null = null
+const ensureSheet = () => {
+  if (typeof document === 'undefined') return null
+  if (!styleEl) {
+    styleEl = document.createElement('style')
+    styleEl.setAttribute('data-interactive', '1')
+    document.head.appendChild(styleEl)
+  }
+  return styleEl
+}
+
+/** ユニーククラス名を発行し、トリガに応じた CSS を返す */
+export function buildInteractiveClass(id: string, opts: {
+  transitionMs: number
+  easing: string
+  hover?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
+  active?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
+  focus?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
+  focusWithin?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
+  groupHover?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
+}) {
+  const cls = `ix-${id}`
+  const lines: string[] = []
+  const base = `.\\${cls}{transition:${opts.transitionMs}ms ${opts.easing};}`
+  lines.push(base)
+  const rule = (pseudo: string, v?: any) => {
+    if (!v) return
+    const t: string[] = []
+    if (v.scale != null) t.push(`transform:scale(${v.scale});`)
+    if (v.bg) t.push(`background:${v.bg};`)
+    if (v.shadow) t.push(`box-shadow:${shadow(v.shadow)};`)
+    if (v.opacity != null) t.push(`opacity:${v.opacity};`)
+    if (!t.length) return
+    lines.push(`${pseudo}{${t.join('')}}`)
+  }
+  const shadow = (lvl: string) => {
+    // 最小実装（Tailwind近似）
+    if (lvl === 'xl') return '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)'
+    if (lvl === 'lg') return '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
+    return '0 1px 2px 0 rgb(0 0 0 / 0.05)'
+  }
+  rule(`.\\${cls}:hover`, opts.hover)
+  rule(`.\\${cls}:active`, opts.active)
+  rule(`.\\${cls}:focus`, opts.focus)
+  rule(`.\\${cls}:focus-within`, opts.focusWithin)
+  rule(`.group:hover .\\${cls}`, opts.groupHover)
+
+  const sheet = ensureSheet()
+  if (sheet) sheet.textContent += '\n' + lines.join('\n')
+  return cls
+}
+
+export function removeInteractiveRules() {
+  if (styleEl) { styleEl.remove(); styleEl = null }
+}

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -20,6 +20,7 @@ import Hero from '@/components/typography/Hero';
 import { MapThemeProvider } from '@/contexts/MapThemeContext';
 import AnimeOnMount from '@/components/anim/AnimeOnMount';
 import AnimeOnView from '@/components/anim/AnimeOnView';
+import InteractiveWrapper from '@/components/interactive/InteractiveWrapper';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -345,5 +346,6 @@ export const REGISTRY = {
   MapThemeProvider: { component: MapThemeProvider, displayName: 'MapThemeProvider' },
   AnimeOnMount: { component: AnimeOnMount, displayName: 'AnimeOnMount' },
   AnimeOnView: { component: AnimeOnView, displayName: 'AnimeOnView' },
+  InteractiveWrapper: { component: InteractiveWrapper, displayName: 'InteractiveWrapper' },
   ...(JapanMap ? { JapanMap: { component: JapanMap, displayName: 'JapanMap' } } : {}),
 } as const;

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "framer-motion": "^12.23.12",
     "html-to-image": "^1.11.13",
     "immer": "^10.0.0",
+    "json-logic-js": "^2.0.5",
     "nanoid": "^5.0.2",
     "next": "14.2.5",
     "octokit": "^5.0.3",

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -136,9 +136,11 @@ type BuilderActions = {
   beginBatch: () => void;
   endBatch: () => void;
   updateMany: (patches: ElmPatch[], recordHistory?: boolean) => void;
-  wrapSelectedWith: (type: 'AnimeOnMount' | 'AnimeOnView', props?: Record<string, any>) => void;
-  unwrapSelectedIf: (type?: 'AnimeOnMount' | 'AnimeOnView') => void;
+  wrapSelectedWith: (type: 'AnimeOnMount' | 'AnimeOnView' | 'InteractiveWrapper', props?: Record<string, any>) => void;
+  unwrapSelectedIf: (type?: 'AnimeOnMount' | 'AnimeOnView' | 'InteractiveWrapper') => void;
   replayAnimationOnSelected: () => void;
+  applyInteractiveToSelection: (draft: any, mode: 'replace' | 'append' | 'remove') => void;
+  applyInteractiveToAll: (draft: any, mode: 'replace' | 'append' | 'remove') => void;
 };
 
 function snapToGrid(n: number) {
@@ -909,7 +911,8 @@ export const useBuilderStore = create<BuilderState & BuilderActions>(
             if (
               !(
                 wrapper.type === "AnimeOnMount" ||
-                wrapper.type === "AnimeOnView"
+                wrapper.type === "AnimeOnView" ||
+                wrapper.type === "InteractiveWrapper"
               )
             )
               return;
@@ -974,6 +977,25 @@ export const useBuilderStore = create<BuilderState & BuilderActions>(
           const tree = state.tree.map((r) => map.get(r.id) || r);
           return { elements, tree };
         });
+      },
+
+      applyInteractiveToSelection(draft, mode) {
+        if (mode === 'remove') {
+          get().unwrapSelectedIf('InteractiveWrapper');
+        } else if (mode === 'replace') {
+          get().unwrapSelectedIf('InteractiveWrapper');
+          get().wrapSelectedWith('InteractiveWrapper', { draft });
+        } else {
+          get().wrapSelectedWith('InteractiveWrapper', { draft });
+        }
+      },
+
+      applyInteractiveToAll(draft, mode) {
+        const prev = get().selectedIds;
+        const allIds = get().elements.map((e) => e.id);
+        set({ selectedIds: allIds, selectedId: allIds[allIds.length - 1] ?? null });
+        get().applyInteractiveToSelection(draft, mode);
+        set({ selectedIds: prev, selectedId: prev[prev.length - 1] ?? null });
       },
 
       setElements(els) {


### PR DESCRIPTION
## Summary
- add interactive CSS builder and action runtime for /dev/actions
- add InteractiveWrapper component and registry entry
- allow applying interactive wrappers via builder store

## Testing
- `pnpm test` *(fails: ReferenceError TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a7938ea8832ca0b52f2cfad4b91f