### PR TITLE
refactor: streamline dev actions layout

### DIFF
--- a/web/app/dev/actions/ActionsCard.tsx
+++ b/web/app/dev/actions/ActionsCard.tsx
@@ -9,70 +9,62 @@ export default function ActionsCard(){
   const remove = usePresetDraft(s=>s.removeAction)
   const add = usePresetDraft(s=>s.addAction)
 
-  const addOpenUrl = () => add({
-    type:'openUrl',
-    params:{ url:'' },
-    if:null, throttleMs:null, debounceMs:null,
-    when:{ click:false, doubleClick:false, mount:false, inView:false, delayMs:null }
-  })
+  const addOpenUrl = () => add({ type:'openUrl', params:{ url:'' }, if:null, throttleMs:null, debounceMs:null,
+    when:{ click:true, doubleClick:false, mount:false, inView:false, delayMs:null } })
 
   return (
     <CardFieldset title="Actions (run on events)">
-      <div className="space-y-3">
+      <div className="space-y-2">
         {actions.map((a,i)=>(
-          <div key={i} className="border rounded p-2">
-            <div className="flex items-center justify-between">
+          <div key={i} className="rounded border p-2">
+            <div className="flex items-center gap-2">
               <select className="border rounded px-2 py-1 text-xs"
-                      value={a.type}
-                      onChange={e=>update(i,{ type:e.target.value as any })}>
+                value={a.type} onChange={e=>update(i,{ type:e.target.value as any })}>
                 <option value="openUrl">openUrl</option>
                 <option value="emit">emit</option>
                 <option value="toggleVar">toggleVar</option>
                 <option value="copyToClipboard">copyToClipboard</option>
                 <option value="navigate">navigate</option>
               </select>
-              <button className="text-xs text-muted-foreground" onClick={()=>remove(i)}>Del</button>
+              <button className="ml-auto text-xs opacity-70 hover:opacity-100" onClick={()=>remove(i)}>Del</button>
             </div>
 
-            {/* params（最小：URLのみUI） */}
             {a.type==='openUrl' && (
               <input className="mt-2 w-full border rounded px-2 py-1 text-xs"
-                     placeholder="url"
-                     value={a.params?.url ?? ''}
-                     onChange={e=>update(i,{ params:{ ...a.params, url:e.target.value }})}/>
+                placeholder="url" value={a.params?.url ?? ''}
+                onChange={e=>update(i,{ params:{ ...a.params, url:e.target.value }})}/>
             )}
 
-            {/* If / throttle / debounce（最小） */}
             <div className="grid grid-cols-3 gap-2 mt-2">
               <textarea className="border rounded px-2 py-1 text-xs col-span-1" placeholder="If (JSON logic)"
-                        value={a.if ? JSON.stringify(a.if) : ''}
-                        onChange={e=>update(i,{ if:e.target.value ? JSON.parse(e.target.value) : null })}/>
+                value={a.if ? JSON.stringify(a.if) : ''} onChange={e=>update(i,{ if:e.target.value ? JSON.parse(e.target.value) : null })}/>
               <input className="border rounded px-2 py-1 text-xs" placeholder="Throttle (ms)"
-                     value={a.throttleMs ?? ''} onChange={e=>update(i,{ throttleMs:e.target.value? +e.target.value : null })}/>
+                value={a.throttleMs ?? ''} onChange={e=>update(i,{ throttleMs:e.target.value? +e.target.value : null })}/>
               <input className="border rounded px-2 py-1 text-xs" placeholder="Debounce (ms)"
-                     value={a.debounceMs ?? ''} onChange={e=>update(i,{ debounceMs:e.target.value? +e.target.value : null })}/>
+                value={a.debounceMs ?? ''} onChange={e=>update(i,{ debounceMs:e.target.value? +e.target.value : null })}/>
             </div>
 
-            {/* === Run when（★ 枠内末尾に移動） === */}
-            <div className="mt-3 pt-3 border-t">
-              <div className="text-xs font-medium text-muted-foreground mb-1">Run when</div>
+            {/* Run when（枠内末尾） */}
+            <div className="mt-2 pt-2 border-t">
+              <div className="text-xs font-medium opacity-80 mb-1">Run when</div>
               <div className="flex flex-wrap gap-2">
-                <Toggle label="click"        checked={!!a.when?.click} onChange={v=>update(i,{ when:{ ...a.when, click:v }})}/>
-                <Toggle label="doubleClick"  checked={!!a.when?.doubleClick} onChange={v=>update(i,{ when:{ ...a.when, doubleClick:v }})}/>
-                <Toggle label="mount"        checked={!!a.when?.mount} onChange={v=>update(i,{ when:{ ...a.when, mount:v }})}/>
-                <Toggle label="inView"       checked={!!a.when?.inView} onChange={v=>update(i,{ when:{ ...a.when, inView:v }})}/>
+                <Toggle label="click"       checked={!!a.when?.click} onChange={v=>update(i,{ when:{ ...a.when, click:v }})}/>
+                <Toggle label="doubleClick" checked={!!a.when?.doubleClick} onChange={v=>update(i,{ when:{ ...a.when, doubleClick:v }})}/>
+                <Toggle label="mount"       checked={!!a.when?.mount} onChange={v=>update(i,{ when:{ ...a.when, mount:v }})}/>
+                <Toggle label="inView"      checked={!!a.when?.inView} onChange={v=>update(i,{ when:{ ...a.when, inView:v }})}/>
                 <div className="flex items-center gap-1 text-xs">
-                  <Toggle label="delay" checked={!!a.when?.delayMs} onChange={v=>update(i,{ when:{ ...a.when, delayMs: v ? (a.when?.delayMs ?? 300) : null }})}/>
-                  <input className="border rounded px-1 w-20" type="number" value={a.when?.delayMs ?? ''} placeholder="ms"
-                         onChange={e=>update(i,{ when:{ ...a.when, delayMs: e.target.value? +e.target.value : null }})}/>
+                  <Toggle label="delay" checked={!!a.when?.delayMs}
+                    onChange={v=>update(i,{ when:{ ...a.when, delayMs: v ? (a.when?.delayMs ?? 300) : null }})}/>
+                  <input className="border rounded px-1 w-16" type="number" value={a.when?.delayMs ?? ''} placeholder="ms"
+                    onChange={e=>update(i,{ when:{ ...a.when, delayMs: e.target.value? +e.target.value : null }})}/>
                 </div>
               </div>
             </div>
           </div>
         ))}
-
         <button className="px-2 py-1 border rounded text-xs" onClick={addOpenUrl}>Add action</button>
       </div>
     </CardFieldset>
   )
 }
+

--- a/web/app/dev/actions/EffectsCard.tsx
+++ b/web/app/dev/actions/EffectsCard.tsx
@@ -1,20 +1,36 @@
 'use client'
+import { useState } from 'react'
 import { usePresetDraft } from '@/store/presetDraftStore'
 import { CardFieldset } from './_ui/Field'
 
 export default function EffectsCard(){
   const effects = usePresetDraft(s=>s.draft.effects)
-  // 本実装では各 Effect の編集UIを詳細化、ここでは読み取り表示と remove のみ（最小差分）
+  const [open, setOpen] = useState(false)
+
   return (
     <CardFieldset title="Effects (visual)">
-      <div className="space-y-2 text-xs">
-        {effects.map((e, i)=>(
-          <div key={i} className="flex items-center justify-between border rounded px-2 py-1">
-            <span>{e.kind}</span>
-            {/* 値編集は後続。今は一覧だけ */}
-          </div>
+      {/* ピル表示（一覧） */}
+      <div className="flex flex-wrap gap-2 mb-2">
+        {effects.map((e,i)=>(
+          <span key={i} className="text-[11px] px-2 py-1 rounded-full border">{e.kind}</span>
         ))}
+        <button className="text-[11px] px-2 py-1 rounded border" onClick={()=>setOpen(v=>!v)}>
+          {open ? 'Hide details' : 'Edit details'}
+        </button>
       </div>
+
+      {/* 詳細は必要時のみ展開（元よりあっさり） */}
+      {open && (
+        <div className="space-y-2 text-xs">
+          {effects.map((e,i)=>(
+            <div key={i} className="border rounded px-2 py-1">
+              <div className="font-medium">{e.kind}</div>
+              <div className="opacity-70">（詳細エディタは従来のまま or 後続で追加）</div>
+            </div>
+          ))}
+        </div>
+      )}
     </CardFieldset>
   )
 }
+

--- a/web/app/dev/actions/_ui/Toggle.tsx
+++ b/web/app/dev/actions/_ui/Toggle.tsx
@@ -1,9 +1,10 @@
 'use client'
 export default function Toggle({checked,onChange,label,id}:{checked:boolean;onChange:(v:boolean)=>void;label:string;id?:string}) {
   return (
-    <label className="inline-flex items-center gap-2 text-xs border rounded px-2 py-1 cursor-pointer select-none">
+    <label className="inline-flex items-center gap-1 text-xs px-2 py-1 border rounded cursor-pointer select-none">
       <input type="checkbox" className="accent-primary" checked={checked} onChange={e=>onChange(e.target.checked)} id={id}/>
       <span>{label}</span>
     </label>
   )
 }
+

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -3,30 +3,67 @@ import React from 'react'
 import TriggersCard from './TriggersCard'
 import EffectsCard from './EffectsCard'
 import ActionsCard from './ActionsCard'
-import ApplyBar from './ApplyBar'
-import { usePresetDraft } from '@/store/presetDraftStore'
+import { PRESETS } from '@/lib/presets'
 import { useBuilderStore } from '@/store/builderStore'
+import { usePresetDraft } from '@/store/presetDraftStore'
 
 export default function DevActionsPage(){
+  const placePreset = useBuilderStore(s=>s.placePreset)
   const draft = usePresetDraft(s=>s.draft)
   const applySel = useBuilderStore(s=>s.applyInteractiveToSelection)
   const applyAll = useBuilderStore(s=>s.applyInteractiveToAll)
 
   return (
-    <div className="p-4 space-y-3">
-      <div className="grid md:grid-cols-2 gap-3">
-        <div className="space-y-3"><TriggersCard/><EffectsCard/></div>
-        <div className="space-y-3"><ActionsCard/></div>
-      </div>
+    <div className="p-4">
+      <div className="grid grid-cols-[200px,1fr,320px] gap-4">
+        {/* 左：プリセット一覧（元の雰囲気） */}
+        <aside className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="text-xs font-semibold">Presets</div>
+          </div>
+          <div className="space-y-1">
+            {PRESETS.map(p=>(
+              <button key={p.id} onClick={()=>placePreset(p.id)}
+                className="w-full text-left px-2 py-1 rounded border hover:bg-accent text-xs">
+                <div className="font-medium">{p.displayName}</div>
+                <div className="opacity-60">{p.tags?.join(', ')}</div>
+              </button>
+            ))}
+          </div>
+        </aside>
 
-      <ApplyBar
-        onReplace={()=>applySel(draft,'replace')}
-        onAppend={()=>applySel(draft,'append')}
-        onRemove={()=>applySel(draft,'remove')}
-        onReplaceAll={()=>applyAll(draft,'replace')}
-        onAppendAll={()=>applyAll(draft,'append')}
-        onRemoveAll={()=>applyAll(draft,'remove')}
-      />
+        {/* 中央：エディタ（上部にApply列） */}
+        <main className="space-y-3">
+          {/* Apply 行（上部） */}
+          <div className="flex flex-wrap gap-2">
+            <button className="px-3 py-1 border rounded bg-primary text-primary-foreground"
+              onClick={()=>applySel(draft,'replace')}>Apply to Selection (Replace)</button>
+            <button className="px-3 py-1 border rounded" onClick={()=>applySel(draft,'append')}>Append to Selection</button>
+            <button className="px-3 py-1 border rounded" onClick={()=>applySel(draft,'remove')}>Remove from Selection</button>
+            <span className="opacity-50">|</span>
+            <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'replace')}>Replace All</button>
+            <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'append')}>Append All</button>
+            <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'remove')}>Remove All</button>
+          </div>
+
+          <section className="grid md:grid-cols-2 gap-3">
+            <TriggersCard/>
+            <ActionsCard/>{/* ← Run when を“枠内末尾”に保持 */}
+          </section>
+
+          <EffectsCard/>{/* ← ピル表示＋必要時展開 */}
+        </main>
+
+        {/* 右：プレビュー（元の感じ） */}
+        <aside>
+          <div className="text-xs font-semibold mb-2">Preview</div>
+          <div className="rounded-xl border p-6 bg-muted/10">
+            <div className="h-32 rounded-lg border flex items-center justify-center">Hover me</div>
+            <p className="mt-2 text-[11px] opacity-70">必要なら .group を付けて Group Hover も確認</p>
+          </div>
+        </aside>
+      </div>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- Restore three-column Dev Actions layout with preset list and preview panel
- Reintroduce apply controls at top and simplify action editor density
- Show effects as pills with optional detail view and compact toggle styling

## Testing
- `pnpm test` *(fails: ReferenceError: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b2db11f8832ca011aa08e20743f8