### PR TITLE
refactor: restore dev actions layout

### DIFF
--- a/web/app/dev/actions/ActionsCard.tsx
+++ b/web/app/dev/actions/ActionsCard.tsx
@@ -16,7 +16,7 @@ export default function ActionsCard(){
     <CardFieldset title="Actions (run on events)">
       <div className="space-y-2">
         {actions.map((a,i)=>(
-          <div key={i} className="rounded border p-2">
+          <div key={i} className="border rounded p-2">
             <div className="flex items-center gap-2">
               <select className="border rounded px-2 py-1 text-xs"
                 value={a.type} onChange={e=>update(i,{ type:e.target.value as any })}>
@@ -44,7 +44,7 @@ export default function ActionsCard(){
                 value={a.debounceMs ?? ''} onChange={e=>update(i,{ debounceMs:e.target.value? +e.target.value : null })}/>
             </div>
 
-            {/* Run when（枠内末尾） */}
+            {/* ★ Run when：Actionsの“枠内”の末尾に固定 */}
             <div className="mt-2 pt-2 border-t">
               <div className="text-xs font-medium opacity-80 mb-1">Run when</div>
               <div className="flex flex-wrap gap-2">

--- a/web/app/dev/actions/EffectsCard.tsx
+++ b/web/app/dev/actions/EffectsCard.tsx
@@ -1,36 +1,125 @@
 'use client'
-import { useState } from 'react'
 import { usePresetDraft } from '@/store/presetDraftStore'
 import { CardFieldset } from './_ui/Field'
+import React, { useState } from 'react'
+
+const ALL_EFFECTS = ['scale','bgColor','shadow','opacity','cursor','translate','rotate'] as const
+type Kind = typeof ALL_EFFECTS[number]
 
 export default function EffectsCard(){
-  const effects = usePresetDraft(s=>s.draft.effects)
-  const [open, setOpen] = useState(false)
+  const draft = usePresetDraft(s=>s.draft)
+  const addEffect = usePresetDraft(s=>s.addEffect)
+  const update = usePresetDraft(s=>s.updateEffect)
+  const remove = usePresetDraft(s=>s.removeEffect)
+  const [kind, setKind] = useState<Kind>('scale')
+
+  const onAdd = () => addEffect({ kind, value: defaultValue(kind) })
 
   return (
     <CardFieldset title="Effects (visual)">
-      {/* ピル表示（一覧） */}
-      <div className="flex flex-wrap gap-2 mb-2">
-        {effects.map((e,i)=>(
-          <span key={i} className="text-[11px] px-2 py-1 rounded-full border">{e.kind}</span>
-        ))}
-        <button className="text-[11px] px-2 py-1 rounded border" onClick={()=>setOpen(v=>!v)}>
-          {open ? 'Hide details' : 'Edit details'}
-        </button>
+      {/* 上：セレクト + Add（元のUI構成） */}
+      <div className="flex items-center gap-2 mb-2">
+        <select className="border rounded px-2 py-1 text-xs" value={kind} onChange={e=>setKind(e.target.value as Kind)}>
+          {ALL_EFFECTS.map(k => <option key={k} value={k}>{k}</option>)}
+        </select>
+        <button className="px-2 py-1 border rounded text-xs" onClick={onAdd}>+ Add</button>
       </div>
 
-      {/* 詳細は必要時のみ展開（元よりあっさり） */}
-      {open && (
-        <div className="space-y-2 text-xs">
-          {effects.map((e,i)=>(
-            <div key={i} className="border rounded px-2 py-1">
-              <div className="font-medium">{e.kind}</div>
-              <div className="opacity-70">（詳細エディタは従来のまま or 後続で追加）</div>
+      {/* 下：各エフェクトの詳細行（削除しない！） */}
+      <div className="space-y-2">
+        {draft.effects.map((e,i)=>(
+          <div key={i} className="border rounded p-2">
+            <div className="flex items-center justify-between">
+              <div className="text-xs font-medium">{e.kind}</div>
+              <button className="text-xs opacity-70 hover:opacity-100" onClick={()=>remove(i)}>remove</button>
             </div>
-          ))}
-        </div>
-      )}
+
+            {/* 各詳細エディタ（元の項目を維持） */}
+            {e.kind==='scale' && (
+              <div className="mt-2 flex items-center gap-2 text-xs">
+                <label>scale <input className="border rounded px-2 py-1 w-20 ml-1"
+                  type="number" step="0.01"
+                  value={e.value?.scale ?? 1}
+                  onChange={ev=>update(i,{ value:{ ...e.value, scale:+ev.target.value }})}/></label>
+              </div>
+            )}
+
+            {e.kind==='bgColor' && (
+              <div className="mt-2 flex items-center gap-2 text-xs">
+                <label>bg <input className="border rounded px-2 py-1 w-28 ml-1"
+                  type="text"
+                  value={e.value?.color ?? '#4440ff'}
+                  onChange={ev=>update(i,{ value:{ ...e.value, color:ev.target.value }})}/></label>
+              </div>
+            )}
+
+            {e.kind==='shadow' && (
+              <div className="mt-2 flex items-center gap-2 text-xs">
+                <label>shadow
+                  <select className="border rounded px-2 py-1 w-24 ml-1"
+                    value={e.value?.level ?? 'xl'}
+                    onChange={ev=>update(i,{ value:{ ...e.value, level:ev.target.value }})}>
+                    <option value="sm">sm</option><option value="md">md</option><option value="lg">lg</option><option value="xl">xl</option>
+                  </select>
+                </label>
+              </div>
+            )}
+
+            {e.kind==='opacity' && (
+              <div className="mt-2 flex items-center gap-2 text-xs">
+                <label>opacity <input className="border rounded px-2 py-1 w-20 ml-1"
+                  type="number" step="0.05" min="0" max="1"
+                  value={e.value?.opacity ?? 0.9}
+                  onChange={ev=>update(i,{ value:{ ...e.value, opacity:+ev.target.value }})}/></label>
+              </div>
+            )}
+
+            {e.kind==='cursor' && (
+              <div className="mt-2 flex items-center gap-2 text-xs">
+                <label>cursor
+                  <select className="border rounded px-2 py-1 w-28 ml-1"
+                    value={e.value?.cursor ?? 'pointer'}
+                    onChange={ev=>update(i,{ value:{ ...e.value, cursor:ev.target.value }})}>
+                    <option>pointer</option><option>default</option><option>crosshair</option><option>move</option>
+                  </select>
+                </label>
+              </div>
+            )}
+
+            {e.kind==='translate' && (
+              <div className="mt-2 flex items-center gap-3 text-xs">
+                <label>x(px) <input className="border rounded px-2 py-1 w-20 ml-1" type="number"
+                  value={e.value?.x ?? 0}
+                  onChange={ev=>update(i,{ value:{ ...e.value, x:+ev.target.value }})}/></label>
+                <label>y(px) <input className="border rounded px-2 py-1 w-20 ml-1" type="number"
+                  value={e.value?.y ?? 0}
+                  onChange={ev=>update(i,{ value:{ ...e.value, y:+ev.target.value }})}/></label>
+              </div>
+            )}
+
+            {e.kind==='rotate' && (
+              <div className="mt-2 flex items-center gap-2 text-xs">
+                <label>deg <input className="border rounded px-2 py-1 w-20 ml-1" type="number"
+                  value={e.value?.deg ?? 0}
+                  onChange={ev=>update(i,{ value:{ ...e.value, deg:+ev.target.value }})}/></label>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
     </CardFieldset>
   )
+}
+
+function defaultValue(kind:Kind){
+  switch(kind){
+    case 'scale': return { scale:1 }
+    case 'bgColor': return { color:'#4440ff' }
+    case 'shadow': return { level:'xl' }
+    case 'opacity': return { opacity:0.9 }
+    case 'cursor': return { cursor:'pointer' }
+    case 'translate': return { x:0, y:0 }
+    case 'rotate': return { deg:0 }
+  }
 }
 

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -14,9 +14,9 @@ export default function DevActionsPage(){
   const applyAll = useBuilderStore(s=>s.applyInteractiveToAll)
 
   return (
-    <div className="p-4">
-      <div className="grid grid-cols-[200px,1fr,320px] gap-4">
-        {/* 左：プリセット一覧（元の雰囲気） */}
+    <div className="p-3">
+      <div className="grid grid-cols-[220px,1fr,320px] gap-4">
+        {/* 左：プリセット一覧（元の密度） */}
         <aside className="space-y-2">
           <div className="flex items-center justify-between">
             <div className="text-xs font-semibold">Presets</div>
@@ -25,41 +25,42 @@ export default function DevActionsPage(){
             {PRESETS.map(p=>(
               <button key={p.id} onClick={()=>placePreset(p.id)}
                 className="w-full text-left px-2 py-1 rounded border hover:bg-accent text-xs">
-                <div className="font-medium">{p.displayName}</div>
-                <div className="opacity-60">{p.tags?.join(', ')}</div>
+                <div className="font-medium truncate">{p.displayName}</div>
+                <div className="opacity-60 truncate">{(p as any).tags?.join(', ')}</div>
               </button>
             ))}
           </div>
         </aside>
 
-        {/* 中央：エディタ（上部にApply列） */}
+        {/* 中央：編集フォーム */}
         <main className="space-y-3">
-          {/* Apply 行（上部） */}
+          {/* Apply（上部に戻す） */}
           <div className="flex flex-wrap gap-2">
             <button className="px-3 py-1 border rounded bg-primary text-primary-foreground"
-              onClick={()=>applySel(draft,'replace')}>Apply to Selection (Replace)</button>
-            <button className="px-3 py-1 border rounded" onClick={()=>applySel(draft,'append')}>Append to Selection</button>
-            <button className="px-3 py-1 border rounded" onClick={()=>applySel(draft,'remove')}>Remove from Selection</button>
+              onClick={()=>applySel(draft,'replace')}>Replace Selection</button>
+            <button className="px-3 py-1 border rounded" onClick={()=>applySel(draft,'append')}>Append Selection</button>
+            <button className="px-3 py-1 border rounded" onClick={()=>applySel(draft,'remove')}>Remove Selection</button>
             <span className="opacity-50">|</span>
             <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'replace')}>Replace All</button>
             <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'append')}>Append All</button>
             <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'remove')}>Remove All</button>
           </div>
 
-          <section className="grid md:grid-cols-2 gap-3">
+          <div className="grid md:grid-cols-2 gap-3">
             <TriggersCard/>
-            <ActionsCard/>{/* ← Run when を“枠内末尾”に保持 */}
-          </section>
+            {/* ★ When は Actions 枠の中に表示（下のActionsCardで対応） */}
+            <ActionsCard/>
+          </div>
 
-          <EffectsCard/>{/* ← ピル表示＋必要時展開 */}
+          {/* 詳細エディタは削らない（EffectsCardの中に残す） */}
+          <EffectsCard/>
         </main>
 
-        {/* 右：プレビュー（元の感じ） */}
+        {/* 右：プレビュー */}
         <aside>
-          <div className="text-xs font-semibold mb-2">Preview</div>
+          <div className="text-xs font-semibold mb-2">Preview（必要なら .group を付けて Group Hover も確認）</div>
           <div className="rounded-xl border p-6 bg-muted/10">
-            <div className="h-32 rounded-lg border flex items-center justify-center">Hover me</div>
-            <p className="mt-2 text-[11px] opacity-70">必要なら .group を付けて Group Hover も確認</p>
+            <div className="h-32 rounded-lg border flex items-center justify-center text-sm">Hover me</div>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- restore three-column dev actions page with preset list, apply bar on top, and preview pane
- compact actions editor, appending Run when toggles inside each action card
- keep full effects editor with selectable effect types and detailed controls

## Testing
- `npm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7d8073c832cb3699864da2a8f07