### PR TITLE
Default click behavior for undefined when flags

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -66,7 +66,8 @@ export default function DevActionsPage(){
                 <button
                   type="button"
                   tabIndex={0}
-                  className="h-32 w-full rounded-lg border flex items-center justify-center text-sm bg-background text-foreground cursor-pointer select-none"
+                  className="h-32 w-full rounded-lg border flex items-center justify-center
+                             text-sm bg-transparent text-foreground cursor-pointer select-none"
                   title="Hover me"
                 >
                   Hover me

--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -38,9 +38,13 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
   // 2) When → Action バインド
   useEffect(()=>{
     const el = ref.current; if(!el) return
-    const cleaners = draft.actions.map(a => bindWhen(el, a, {
-      el, data:{}, emit:(ev,p)=>window.dispatchEvent(new CustomEvent(ev,{detail:p})), navigate:(u)=>router.push(u)
-    } as RuntimeCtx))
+    const cleaners = draft.actions.map(a => bindWhen(
+      el,
+      a,
+      { el, data:{}, emit:(ev,p)=>window.dispatchEvent(new CustomEvent(ev,{detail:p})), navigate:(u)=>router.push(u) } as RuntimeCtx,
+      // 後方互換：もし a.when が空なら draft.when を使う
+      (draft as any).when
+    ))
     return () => cleaners.forEach(c=>c())
   }, [draft])
 

--- a/web/lib/interactiveActions.ts
+++ b/web/lib/interactiveActions.ts
@@ -1,4 +1,11 @@
 import type { ActionDef, WhenFlags } from '@/types/presets-ui'
+
+// 未指定 when 対策：アクションで when が空なら「click」を既定に。
+export function getEffectiveWhen(a: ActionDef, fallback?: WhenFlags): WhenFlags {
+  const w: WhenFlags = a.when ?? fallback ?? {}
+  const hasAny = !!(w.click || w.doubleClick || w.mount || w.inView || w.delayMs)
+  return hasAny ? w : { click: true }
+}
 let jsonLogic: any = null
 export const ensureJsonLogic = async () => {
   if (jsonLogic) return jsonLogic
@@ -50,8 +57,13 @@ export async function runAction(a: ActionDef, ctx: RuntimeCtx) {
   await wrapped()
 }
 
-export function bindWhen(el: HTMLElement, a: ActionDef, ctx: RuntimeCtx) {
-  const w = a.when || {}
+export function bindWhen(
+  el: HTMLElement,
+  a: ActionDef,
+  ctx: RuntimeCtx,
+  fallback?: WhenFlags,
+) {
+  const w = getEffectiveWhen(a, fallback)
   const subs: Array<() => void> = []
   if (w.click) {
     const h = () => runAction(a, ctx)


### PR DESCRIPTION
## Summary
- add `getEffectiveWhen` to ensure actions default to click when no triggers are set
- allow `bindWhen` to accept a fallback and use draft-level `when` if action lacks one
- tweak preview button style for hover color visibility

## Testing
- `pnpm test` *(fails: ReferenceError: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c3d159b4832cac9651f1047765f0