### PR TITLE
fix(interactive): combine transforms + add color picker & swatches for bgColor

### DIFF
--- a/web/app/dev/actions/EffectsCard.tsx
+++ b/web/app/dev/actions/EffectsCard.tsx
@@ -3,6 +3,20 @@ import { usePresetDraft } from '@/store/presetDraftStore'
 import { CardFieldset } from './_ui/Field'
 import React, { useState } from 'react'
 
+const DEFAULT_SWATCHES = ['#004cff','#0ea5e9','#22c55e','#f59e0b','#ef4444',
+                          '#a855f7','#ec4899','#111827','#334155','#e5e7eb']
+
+const recentKey = 'actions-recent-colors'
+const loadRecents = (): string[] => {
+  try { return JSON.parse(localStorage.getItem(recentKey) || '[]') } catch { return [] }
+}
+const pushRecent = (hex: string) => {
+  try {
+    const arr = [hex, ...loadRecents().filter(x => x !== hex)].slice(0, 8)
+    localStorage.setItem(recentKey, JSON.stringify(arr))
+  } catch {}
+}
+
 const ALL_EFFECTS = ['scale','bgColor','shadow','opacity','cursor','translate','rotate'] as const
 type Kind = typeof ALL_EFFECTS[number]
 
@@ -45,11 +59,38 @@ export default function EffectsCard(){
             )}
 
             {e.kind==='bgColor' && (
-              <div className="mt-2 flex items-center gap-2 text-xs">
-                <label>bg <input className="border rounded px-2 py-1 w-28 ml-1"
-                  type="text"
-                  value={e.value?.color ?? '#4440ff'}
-                  onChange={ev=>update(i,{ value:{ ...e.value, color:ev.target.value }})}/></label>
+              <div className="mt-2 space-y-2 text-xs">
+                <div className="flex items-center gap-2">
+                  <label className="inline-flex items-center gap-1">
+                    bg
+                    <input
+                      className="border rounded px-2 py-1 w-28 ml-1"
+                      type="text"
+                      value={e.value?.color ?? '#4440ff'}
+                      onChange={(ev)=>update(i,{ value:{ ...e.value, color:ev.target.value }})}
+                      onBlur={(ev)=>pushRecent(ev.target.value)}
+                    />
+                  </label>
+                  <input
+                    type="color"
+                    className="h-7 w-10 cursor-pointer"
+                    value={(e.value?.color ?? '#4440ff')}
+                    onChange={(ev)=>{ update(i,{ value:{ ...e.value, color:ev.target.value }}); pushRecent(ev.target.value) }}
+                  />
+                </div>
+
+                <div className="flex flex-wrap items-center gap-1">
+                  {[...loadRecents(), ...DEFAULT_SWATCHES].slice(0, 12).map(hex=>(
+                    <button
+                      key={hex}
+                      type="button"
+                      className="h-6 w-6 rounded border"
+                      style={{ background: hex }}
+                      title={hex}
+                      onClick={()=>{ update(i,{ value:{ ...e.value, color:hex }}); pushRecent(hex) }}
+                    />
+                  ))}
+                </div>
               </div>
             )}
 

--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -10,27 +10,74 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
   const router = useRouter()
 
   // 1) Triggers → ユニーククラス作成
-  const cls = useMemo(()=>{
-    const id = Math.random().toString(36).slice(2,8)
+  const cls = useMemo(() => {
+    const id = Math.random().toString(36).slice(2, 8)
     const t = draft.triggers
-    const to = (eff?: any) => {
-      if (!eff) return undefined
-      const o:any = {}
-      if (eff.scale?.scale) o.scale = eff.scale.scale
-      if (eff.bgColor?.color) o.bg = eff.bgColor.color
-      if (eff.shadow?.level) o.shadow = eff.shadow.level
-      if (eff.opacity?.opacity != null) o.opacity = eff.opacity.opacity
-      return o
-    }
     // draft.effects は汎用配列なので kind を寄せて取り出す（最小）
-    const pack = (kind:string) => draft.effects.find(e=>e.kind===kind)?.value
+    const pack = (kind: string) => (draft.effects as any[]).find(e => e.kind === kind)?.value
     const base = {
-      transitionMs: t.transitionMs, easing: t.easing,
-      hover: t.hover ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
-      active: t.active ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
-      focus: t.focus ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
-      focusWithin: t.focusWithin ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
-      groupHover: t.groupHover ? { scale: pack('scale')?.scale, bg: pack('bgColor')?.color, shadow: pack('shadow')?.level, opacity: pack('opacity')?.opacity } : undefined,
+      transitionMs: t.transitionMs,
+      easing: t.easing,
+      hover: t.hover
+        ? {
+            scale: pack('scale')?.scale,
+            rotateDeg: pack('rotate')?.deg,
+            tx: pack('translate')?.x,
+            ty: pack('translate')?.y,
+            bg: pack('bgColor')?.color,
+            shadow: pack('shadow')?.level,
+            opacity: pack('opacity')?.opacity,
+            cursor: pack('cursor')?.cursor,
+          }
+        : undefined,
+      active: t.active
+        ? {
+            scale: pack('scale')?.scale,
+            rotateDeg: pack('rotate')?.deg,
+            tx: pack('translate')?.x,
+            ty: pack('translate')?.y,
+            bg: pack('bgColor')?.color,
+            shadow: pack('shadow')?.level,
+            opacity: pack('opacity')?.opacity,
+            cursor: pack('cursor')?.cursor,
+          }
+        : undefined,
+      focus: t.focus
+        ? {
+            scale: pack('scale')?.scale,
+            rotateDeg: pack('rotate')?.deg,
+            tx: pack('translate')?.x,
+            ty: pack('translate')?.y,
+            bg: pack('bgColor')?.color,
+            shadow: pack('shadow')?.level,
+            opacity: pack('opacity')?.opacity,
+            cursor: pack('cursor')?.cursor,
+          }
+        : undefined,
+      focusWithin: t.focusWithin
+        ? {
+            scale: pack('scale')?.scale,
+            rotateDeg: pack('rotate')?.deg,
+            tx: pack('translate')?.x,
+            ty: pack('translate')?.y,
+            bg: pack('bgColor')?.color,
+            shadow: pack('shadow')?.level,
+            opacity: pack('opacity')?.opacity,
+            cursor: pack('cursor')?.cursor,
+          }
+        : undefined,
+      groupHover: t.groupHover
+        ? {
+            scale: pack('scale')?.scale,
+            rotateDeg: pack('rotate')?.deg,
+            tx: pack('translate')?.x,
+            ty: pack('translate')?.y,
+            bg: pack('bgColor')?.color,
+            shadow: pack('shadow')?.level,
+            opacity: pack('opacity')?.opacity,
+            cursor: pack('cursor')?.cursor,
+          }
+        : undefined,
     }
     return buildInteractiveClass(id, base as any)
   }, [draft])

--- a/web/lib/interactiveCSS.ts
+++ b/web/lib/interactiveCSS.ts
@@ -9,46 +9,72 @@ const ensureSheet = () => {
   return styleEl
 }
 
-/** ユニーククラス名を発行し、トリガに応じた CSS を返す */
-export function buildInteractiveClass(id: string, opts: {
-  transitionMs: number
-  easing: string
-  hover?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
-  active?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
-  focus?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
-  focusWithin?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
-  groupHover?: { scale?: number, bg?: string, shadow?: string, opacity?: number }
-}) {
+export type StateStyle = {
+  scale?: number
+  rotateDeg?: number
+  tx?: number
+  ty?: number
+  bg?: string
+  shadow?: string
+  opacity?: number
+  cursor?: string
+}
+
+export function buildInteractiveClass(
+  id: string,
+  opts: {
+    transitionMs: number
+    easing: string
+    hover?: StateStyle
+    active?: StateStyle
+    focus?: StateStyle
+    focusWithin?: StateStyle
+    groupHover?: StateStyle
+  }
+) {
   const cls = `ix-${id}`
   const lines: string[] = []
-  const base = `.\\${cls}{transition:${opts.transitionMs}ms ${opts.easing};}`
-  lines.push(base)
-  const rule = (pseudo: string, v?: any) => {
+
+  // ベース：トランジション＆描画ヒント
+  lines.push(`.${css(cls)}{transition:${opts.transitionMs}ms ${opts.easing};will-change:transform,background,opacity,box-shadow;}`)
+
+  const toShadow = (lvl?: string) => {
+    if (!lvl) return ''
+    if (lvl === 'xl') return '0 20px 25px -5px rgb(0 0 0 / .1),0 8px 10px -6px rgb(0 0 0 / .1)'
+    if (lvl === 'lg') return '0 10px 15px -3px rgb(0 0 0 / .1),0 4px 6px -4px rgb(0 0 0 / .1)'
+    if (lvl === 'md') return '0 4px 6px -1px rgb(0 0 0 / .1),0 2px 4px -2px rgb(0 0 0 / .1)'
+    return '0 1px 2px 0 rgb(0 0 0 / .05)'
+  }
+
+  const rule = (sel: string, v?: StateStyle) => {
     if (!v) return
+    const cssParts: string[] = []
+    // ★ transform を合成
     const t: string[] = []
-    if (v.scale != null) t.push(`transform:scale(${v.scale});`)
-    if (v.bg) t.push(`background:${v.bg};`)
-    if (v.shadow) t.push(`box-shadow:${shadow(v.shadow)};`)
-    if (v.opacity != null) t.push(`opacity:${v.opacity};`)
-    if (!t.length) return
-    lines.push(`${pseudo}{${t.join('')}}`)
+    if (v.tx || v.ty) t.push(`translate(${v.tx || 0}px, ${v.ty || 0}px)`)
+    if (v.rotateDeg)  t.push(`rotate(${v.rotateDeg}deg)`)
+    if (v.scale != null) t.push(`scale(${v.scale})`)
+    if (t.length) cssParts.push(`transform:${t.join(' ')}; transform-origin:center;`)
+
+    if (v.bg) cssParts.push(`background:${v.bg};`)
+    if (v.shadow) cssParts.push(`box-shadow:${toShadow(v.shadow)};`)
+    if (v.opacity != null) cssParts.push(`opacity:${v.opacity};`)
+    if (v.cursor) cssParts.push(`cursor:${v.cursor};`)
+    if (cssParts.length) lines.push(`${sel}{${cssParts.join('')}}`)
   }
-  const shadow = (lvl: string) => {
-    // 最小実装（Tailwind近似）
-    if (lvl === 'xl') return '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)'
-    if (lvl === 'lg') return '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
-    return '0 1px 2px 0 rgb(0 0 0 / 0.05)'
-  }
-  rule(`.\\${cls}:hover`, opts.hover)
-  rule(`.\\${cls}:active`, opts.active)
-  rule(`.\\${cls}:focus`, opts.focus)
-  rule(`.\\${cls}:focus-within`, opts.focusWithin)
-  rule(`.group:hover .\\${cls}`, opts.groupHover)
+
+  rule(`.${css(cls)}:hover`, opts.hover)
+  rule(`.${css(cls)}:active`, opts.active)
+  rule(`.${css(cls)}:focus`, opts.focus)
+  rule(`.${css(cls)}:focus-within`, opts.focusWithin)
+  rule(`.group:hover .${css(cls)}`, opts.groupHover)
 
   const sheet = ensureSheet()
   if (sheet) sheet.textContent += '\n' + lines.join('\n')
   return cls
 }
+
+const css = (c: string) => c.replace(/([^a-zA-Z0-9_-])/g, '\\$1')
 
 export function removeInteractiveRules() {
   if (styleEl) { styleEl.remove(); styleEl = null }


### PR DESCRIPTION
## Summary
- combine scale/rotate/translate and cursor into interactive transform generation
- support rotate, translate, and cursor styles in interactive wrapper
- add color input, swatches, and recent color storage to bgColor effect editor

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ceb99cc0832c8cfdda3aa61f5375