### PR TITLE
Unify dev-actions bg color palette UI

### DIFF
--- a/web/app/dev/actions/EffectsCard.tsx
+++ b/web/app/dev/actions/EffectsCard.tsx
@@ -3,12 +3,26 @@ import { usePresetDraft } from '@/store/presetDraftStore'
 import { CardFieldset } from './_ui/Field'
 import React, { useState } from 'react'
 
-const DEFAULT_SWATCHES = ['#004cff','#0ea5e9','#22c55e','#f59e0b','#ef4444',
-                          '#a855f7','#ec4899','#111827','#334155','#e5e7eb']
+const DEFAULT_SWATCHES = [
+  '#004cff',
+  '#38bdf8',
+  '#22c55e',
+  '#f59e0b',
+  '#ef4444',
+  '#a855f7',
+  '#ec4899',
+  '#111827',
+  '#334155',
+  '#e5e7eb',
+]
 
 const recentKey = 'actions-recent-colors'
 const loadRecents = (): string[] => {
-  try { return JSON.parse(localStorage.getItem(recentKey) || '[]') } catch { return [] }
+  try {
+    return JSON.parse(localStorage.getItem(recentKey) || '[]')
+  } catch {
+    return []
+  }
 }
 const pushRecent = (hex: string) => {
   try {
@@ -64,9 +78,9 @@ export default function EffectsCard(){
                   <label className="inline-flex items-center gap-1">
                     bg
                     <input
-                      className="border rounded px-2 py-1 w-28 ml-1"
+                      className="border rounded px-2 py-1 w-28 ml-1 bg-muted text-foreground"
                       type="text"
-                      value={e.value?.color ?? '#4440ff'}
+                      value={e.value?.color ?? '#004cff'}
                       onChange={(ev)=>update(i,{ value:{ ...e.value, color:ev.target.value }})}
                       onBlur={(ev)=>pushRecent(ev.target.value)}
                     />
@@ -74,20 +88,15 @@ export default function EffectsCard(){
                   <input
                     type="color"
                     className="h-7 w-10 cursor-pointer"
-                    value={(e.value?.color ?? '#4440ff')}
-                    onChange={(ev)=>{ update(i,{ value:{ ...e.value, color:ev.target.value }}); pushRecent(ev.target.value) }}
+                    value={e.value?.color ?? '#004cff'}
+                    onChange={(ev)=>{ update(i,{ value:{ ...e.value, color:ev.target.value }}); pushRecent(ev.target.value); }}
                   />
                 </div>
-
                 <div className="flex flex-wrap items-center gap-1">
-                  {[...loadRecents(), ...DEFAULT_SWATCHES].slice(0, 12).map(hex=>(
-                    <button
-                      key={hex}
-                      type="button"
-                      className="h-6 w-6 rounded border"
-                      style={{ background: hex }}
-                      title={hex}
-                      onClick={()=>{ update(i,{ value:{ ...e.value, color:hex }}); pushRecent(hex) }}
+                  {[...new Set([...loadRecents(), ...DEFAULT_SWATCHES])].slice(0,12).map(hex=>(
+                    <button key={hex} type="button"
+                      className="h-6 w-6 rounded border" style={{ background: hex }} title={hex}
+                      onClick={()=>{ update(i,{ value:{ ...e.value, color:hex }}); pushRecent(hex); }}
                     />
                   ))}
                 </div>
@@ -155,7 +164,7 @@ export default function EffectsCard(){
 function defaultValue(kind:Kind){
   switch(kind){
     case 'scale': return { scale:1 }
-    case 'bgColor': return { color:'#4440ff' }
+    case 'bgColor': return { color:'#004cff' }
     case 'shadow': return { level:'xl' }
     case 'opacity': return { opacity:0.9 }
     case 'cursor': return { cursor:'pointer' }

--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -15,7 +15,7 @@ export default function DevActionsPage(){
   const applyAll = useBuilderStore(s=>s.applyInteractiveToAll)
 
   return (
-    <div className="p-3">
+    <div className="dev-actions p-3">
       <div className="grid grid-cols-[220px,1fr,320px] gap-4">
         {/* 左：プリセット一覧（元の密度） */}
         <aside className="space-y-2">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -8,3 +8,24 @@
 
 .hide-header header { display: none; }
 .hide-footer footer { display: none; }
+
+@layer components {
+  /* /dev/actions 内のフォーム要素を見やすく固定 */
+  .dev-actions :where(input[type="text"],
+                      input[type="number"],
+                      input[type="url"],
+                      textarea,
+                      select) {
+    @apply border rounded px-2 py-1 text-xs outline-none;
+    background: hsl(var(--color-bg-muted));
+    color: hsl(var(--color-fg-default));
+    border-color: hsl(var(--color-border-default));
+  }
+  .dev-actions :where(input, textarea, select)::placeholder {
+    color: hsl(var(--color-fg-default) / 0.6);
+  }
+  .dev-actions :where(input, textarea, select):focus {
+    @apply ring-1;
+    --tw-ring-color: hsl(var(--color-accent-default));
+  }
+}


### PR DESCRIPTION
## Summary
- streamline EffectsCard bgColor editor with hex field, color input and horizontal swatch palette (recents + defaults)
- drop input-style toggles and add `.dev-actions` container styling
- style /dev/actions form controls for consistent dark theme

## Testing
- `NEXT_PUBLIC_FIREBASE_API_KEY=... NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=... NEXT_PUBLIC_FIREBASE_PROJECT_ID=... NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=... NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=... NEXT_PUBLIC_FIREBASE_APP_ID=... NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=... pnpm -C web build`

------
https://chatgpt.com/codex/tasks/task_e_68b6d5f10ed0832cb2224d1b2b8dd3e0