### PR TITLE
feat: add scoped form styles for inspector panels

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -29,3 +29,94 @@
     --tw-ring-color: hsl(var(--color-accent-default));
   }
 }
+
+/* ---- TamaDigi panel form styles (scoped) ---- */
+@layer components {
+  /* 右パネルなど、暗いフォームにしたいコンテナにこのクラスを付ける */
+  .td-form-scope {
+    --td-input-bg: rgba(24, 24, 27, 0.9);     /* zinc-900弱 */
+    --td-input-border: rgba(255, 255, 255, .08);
+    --td-input-border-focus: rgba(99, 102, 241, .35); /* indigo-500弱 */
+    --td-input-text: rgb(243, 244, 246);      /* gray-100 */
+    --td-input-placeholder: rgb(148, 163, 184); /* slate-400 */
+    --td-input-disabled: rgba(24, 24, 27, 0.6);
+  }
+
+  /* ネイティブの入力系を一括ターゲット（チェックボックス等は除外） */
+  .td-form-scope :where(
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="time"],
+    input[type="date"],
+    input[type="datetime-local"],
+    textarea,
+    select
+  ) {
+    background-color: var(--td-input-bg) !important;
+    color: var(--td-input-text);
+    border: 1px solid var(--td-input-border);
+    border-radius: 0.5rem;       /* rounded-md */
+    padding: 0.5rem 0.625rem;    /* px-2.5 py-2 */
+    line-height: 1.25rem;        /* 20px */
+    outline: none;
+    box-shadow: 0 0 0 0 rgba(0,0,0,0);
+    transition: border-color .15s ease, box-shadow .15s ease, background-color .2s ease;
+  }
+
+  .td-form-scope :where(input, textarea)::placeholder {
+    color: var(--td-input-placeholder);
+    opacity: 1;
+  }
+
+  .td-form-scope :where(select) {
+    padding-right: 2rem; /* 矢印分の余白 */
+  }
+
+  .td-form-scope :where(
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="time"],
+    input[type="date"],
+    input[type="datetime-local"],
+    textarea,
+    select
+  ):focus {
+    border-color: var(--td-input-border-focus);
+    box-shadow: 0 0 0 4px var(--td-input-border-focus);
+  }
+
+  .td-form-scope :where(
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="time"],
+    input[type="date"],
+    input[type="datetime-local"],
+    textarea,
+    select
+  ):disabled,
+  .td-form-scope :where(
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="time"],
+    input[type="date"],
+    input[type="datetime-local"],
+    textarea,
+    select
+  )[aria-disabled="true"] {
+    background-color: var(--td-input-disabled);
+    cursor: not-allowed;
+    opacity: .7;
+  }
+}

--- a/web/components/builder/RightInspectorBindings.tsx
+++ b/web/components/builder/RightInspectorBindings.tsx
@@ -22,7 +22,7 @@ export default function RightInspectorBindings() {
   }
 
   return (
-    <div className="p-2 space-y-2 text-xs">
+    <div className="td-form-scope p-2 space-y-2 text-xs">
       <div className="flex space-x-2">
         <select
           className="bg-gray-700 text-white p-1"

--- a/web/components/builder/RightSidebar.tsx
+++ b/web/components/builder/RightSidebar.tsx
@@ -20,7 +20,7 @@ export function RightSidebar() {
   if (!node) return <div className="p-2 text-sm text-gray-500">No selection</div>
   const meta = (node.meta || {}) as any
   return (
-    <div className="flex flex-col gap-4">
+    <div className="td-form-scope flex flex-col gap-4">
       <VariantPanelCompat componentKey={String(node.componentId || node.type)} value={meta.variant ?? null} onChange={(v)=>setMeta(node.id, { ...meta, variant: v })} />
       <AutoPropertyPanel componentKey={String(node.componentId || node.type)} propValues={node.propValues} onChange={(k,v)=>updateProp(node.id, k, v)} />
       <OverridePanelCompat value={meta.overrides} onChange={(v)=>setMeta(node.id, { ...meta, overrides: v })} />

--- a/web/components/editor/RightInspector.tsx
+++ b/web/components/editor/RightInspector.tsx
@@ -81,7 +81,7 @@ export default function RightInspector() {
   const unitLabel = unit === 'percent' ? '%' : unit;
 
   return (
-    <div className="bg-gray-800 p-2 space-y-2 overflow-y-auto">
+    <div className="td-form-scope bg-gray-800 p-2 space-y-2 overflow-y-auto">
       {(['x', 'y', 'w', 'h', 'rotation'] as const).map((k) => {
         const base = k === 'x' || k === 'w' ? percentBase.width : percentBase.height
         const value =


### PR DESCRIPTION
## Summary
- add reusable dark form styling via `.td-form-scope`
- apply scoped form class to inspector-related panels

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e02e786c832c8c7569d0836ad91c