### PR TITLE
feat: add anime.js action support

### DIFF
--- a/web/components/panels/EffectsPanel.tsx
+++ b/web/components/panels/EffectsPanel.tsx
@@ -1,0 +1,87 @@
+'use client'
+import { useState } from 'react'
+import type { Action, AnimePresetKey } from '@/types/actions'
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/30 p-3">
+      <div className="mb-2 text-xs uppercase tracking-wider text-white/60">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+/** ここが新規：Motion (anime.js) */
+function AnimePane({ onAdd, defaultTarget }: { onAdd: (a: Action) => void; defaultTarget?: string }) {
+  const [preset, setPreset] = useState<AnimePresetKey>('fadeIn')
+  const [duration, setDuration] = useState(300)
+  const [easing, setEasing] = useState('easeInOutQuad')
+  const [delay, setDelay] = useState(0)
+
+  const add = () =>
+    onAdd({
+      type: 'anime',
+      preset,
+      target: defaultTarget ? { type: 'nodeId', value: defaultTarget } : undefined,
+      options: { duration, easing, delay },
+    })
+
+  return (
+    <div className="td-form-scope space-y-2">
+      <label className="block text-xs text-white/70">Preset</label>
+      <select
+        className="w-full"
+        value={preset}
+        onChange={(e) => setPreset(e.target.value as AnimePresetKey)}
+      >
+        {['fadeIn','fadeOut','slideInUp','slideInRight','slideInDown','slideInLeft','scaleIn','scaleOut','rotateIn','rotateOut','pulse','shake']
+          .map(k => <option key={k} value={k}>{k}</option>)}
+      </select>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <label className="block text-xs text-white/70">Duration(ms)</label>
+          <input className="w-full" type="number" value={duration} onChange={(e)=>setDuration(+e.target.value || 0)} />
+        </div>
+        <div>
+          <label className="block text-xs text-white/70">Delay(ms)</label>
+          <input className="w-full" type="number" value={delay} onChange={(e)=>setDelay(+e.target.value || 0)} />
+        </div>
+        <div>
+          <label className="block text-xs text-white/70">Easing</label>
+          <input className="w-full" value={easing} onChange={(e)=>setEasing(e.target.value)} placeholder="easeInOutQuad" />
+        </div>
+      </div>
+
+      <button onClick={add} className="h-9 w-full rounded-xl bg-white/10 text-sm hover:bg-white/15">
+        Add action
+      </button>
+    </div>
+  )
+}
+
+/** 既存の visual 側はそのまま（例としてダミーのプレースホルダー） */
+function EffectsVisualPane() {
+  return <div className="text-white/60">（既存の Effects UI をここに）</div>
+}
+
+/** 親：2カラム配置 */
+export default function EffectsPanel({
+  onAddAction,
+  selectedNodeId,
+}: {
+  onAddAction: (a: Action) => void
+  selectedNodeId?: string
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <Section title="Effects (visual)">
+        <EffectsVisualPane />
+      </Section>
+
+      <Section title="Motion (anime.js)">
+        <AnimePane onAdd={onAddAction} defaultTarget={selectedNodeId} />
+      </Section>
+    </div>
+  )
+}

--- a/web/lib/anime-presets.ts
+++ b/web/lib/anime-presets.ts
@@ -1,0 +1,20 @@
+import type { AnimeParams } from 'animejs'
+
+export const animePresets: Record<string, (el: Element)=>AnimeParams> = {
+  fadeIn: () => ({ opacity: [0, 1] }),
+  fadeOut: () => ({ opacity: [1, 0] }),
+
+  slideInUp: () => ({ translateY: [24, 0], opacity: [0, 1] }),
+  slideInRight: () => ({ translateX: [24, 0], opacity: [0, 1] }),
+  slideInDown: () => ({ translateY: [-24, 0], opacity: [0, 1] }),
+  slideInLeft: () => ({ translateX: [-24, 0], opacity: [0, 1] }),
+
+  scaleIn: () => ({ scale: [0.9, 1], opacity: [0, 1] }),
+  scaleOut: () => ({ scale: [1, 0.9], opacity: [1, 0] }),
+
+  rotateIn: () => ({ rotate: [-8, 0], opacity: [0, 1] }),
+  rotateOut: () => ({ rotate: [0, 8], opacity: [1, 0] }),
+
+  pulse: () => ({ scale: [{ value: 1.05, duration: 120 }, { value: 1, duration: 120 }] }),
+  shake: () => ({ translateX: [{ value: -6, duration: 60 }, { value: 6, duration: 60 }, { value: 0, duration: 60 }] }),
+}

--- a/web/lib/runAction.ts
+++ b/web/lib/runAction.ts
@@ -1,0 +1,33 @@
+'use client'
+import anime, { AnimeParams } from 'animejs'
+import type { Action } from '@/types/actions'
+import { animePresets } from '@/lib/anime-presets'
+
+const resolveTarget = (action: Action, fallbackEl?: HTMLElement | null) => {
+  // NodeId で NodeWrapper を掴む想定（div[data-node-id]）
+  if (action.type === 'anime' && action.target) {
+    if (action.target.type === 'css') return document.querySelector(action.target.value) as HTMLElement | null
+    if (action.target.type === 'nodeId') return document.querySelector<HTMLElement>(`[data-node-id="${action.target.value}"]`)
+  }
+  return fallbackEl ?? null
+}
+
+export function runAction(action: Action, ctx?: { currentEl?: HTMLElement | null }) {
+  if (action.type === 'openUrl') {
+    window.open(action.url, '_blank', 'noopener,noreferrer')
+    return
+  }
+  if (action.type === 'anime') {
+    if (typeof window === 'undefined') return
+    const el = resolveTarget(action, ctx?.currentEl)
+    if (!el) return
+    const base: AnimeParams = {
+      duration: 300,
+      easing: 'easeInOutQuad',
+      autoplay: true,
+    }
+    const preset = animePresets[action.preset]?.(el) ?? {}
+    anime.remove(el) // 前のアニメをクリア
+    anime({ targets: el, ...base, ...preset, ...(action.options || {}) })
+  }
+}

--- a/web/types/actions.ts
+++ b/web/types/actions.ts
@@ -1,5 +1,38 @@
-export type OpenUrlAction = { type: 'openUrl'; url: string; target?: '_self' | '_blank' }
+export type NodeTarget =
+  | { type: 'nodeId'; value: string }
+  | { type: 'css'; value: string }
+
+export type AnimePresetKey =
+  | 'fadeIn'
+  | 'fadeOut'
+  | 'slideInUp'
+  | 'slideInRight'
+  | 'slideInDown'
+  | 'slideInLeft'
+  | 'scaleIn'
+  | 'scaleOut'
+  | 'rotateIn'
+  | 'rotateOut'
+  | 'pulse'
+  | 'shake'
+
+export type OpenUrlAction = {
+  type: 'openUrl'
+  url: string
+  target?: '_self' | '_blank'
+}
+
 export type NavigateAction = { type: 'navigate'; path: string }
-export type Action = OpenUrlAction | NavigateAction
+
+export type ActionAnime = {
+  type: 'anime'
+  preset: AnimePresetKey
+  options?: Partial<import('animejs').AnimeParams>
+  target?: NodeTarget
+}
+
+export type Action = OpenUrlAction | NavigateAction | ActionAnime
+
 export type ActionMap = { onClick?: Action[] }
+
 export type ActionContext = { nodeId: string }


### PR DESCRIPTION
## Summary
- add anime.js dependency (already present)
- define anime action types and presets
- implement runtime runner for anime actions
- add Motion (anime.js) panel next to Effects

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e22cb948832ca03a7f9dcad36192