### PR TITLE
feat: add anime.js motion effects

### DIFF
--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -4,6 +4,7 @@ import { buildInteractiveClass } from '@/lib/interactiveCSS'
 import { bindWhen, type RuntimeCtx } from '@/lib/interactiveActions'
 import type { PresetDraft } from '@/types/presets-ui'
 import { useRouter } from 'next/navigation'
+import { runMotionEffects } from '@/lib/runMotion'
 
 export default function InteractiveWrapper({ draft, children }:{ draft: PresetDraft; children: React.ReactNode }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -95,5 +96,25 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
     return () => cleaners.forEach(c=>c())
   }, [draft])
 
-  return <div ref={ref} className={cls}>{children}</div>
+  // mount
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    queueMicrotask(() => runMotionEffects((draft as any)?.effects?.motion, 'mount', el))
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      className={cls}
+      onClick={(e) => {
+        runMotionEffects((draft as any)?.effects?.motion, 'click', e.currentTarget as HTMLElement)
+      }}
+      onDoubleClick={(e) => {
+        runMotionEffects((draft as any)?.effects?.motion, 'doubleClick', e.currentTarget as HTMLElement)
+      }}
+    >
+      {children}
+    </div>
+  )
 }

--- a/web/components/panels/EffectsPanel.tsx
+++ b/web/components/panels/EffectsPanel.tsx
@@ -1,87 +1,37 @@
 'use client'
-import { useState } from 'react'
-import type { Action, AnimePresetKey } from '@/types/actions'
+import MotionEffectsPanel from './MotionEffectsPanel'
+import type { MotionEffect } from '@/types/motion'
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-2xl border border-white/10 bg-black/30 p-3">
-      <div className="mb-2 text-xs uppercase tracking-wider text-white/60">{title}</div>
-      {children}
-    </div>
-  )
-}
-
-/** ここが新規：Motion (anime.js) */
-function AnimePane({ onAdd, defaultTarget }: { onAdd: (a: Action) => void; defaultTarget?: string }) {
-  const [preset, setPreset] = useState<AnimePresetKey>('fadeIn')
-  const [duration, setDuration] = useState(300)
-  const [easing, setEasing] = useState('easeInOutQuad')
-  const [delay, setDelay] = useState(0)
-
-  const add = () =>
-    onAdd({
-      type: 'anime',
-      preset,
-      target: defaultTarget ? { type: 'nodeId', value: defaultTarget } : undefined,
-      options: { duration, easing, delay },
-    })
-
-  return (
-    <div className="td-form-scope space-y-2">
-      <label className="block text-xs text-white/70">Preset</label>
-      <select
-        className="w-full"
-        value={preset}
-        onChange={(e) => setPreset(e.target.value as AnimePresetKey)}
-      >
-        {['fadeIn','fadeOut','slideInUp','slideInRight','slideInDown','slideInLeft','scaleIn','scaleOut','rotateIn','rotateOut','pulse','shake']
-          .map(k => <option key={k} value={k}>{k}</option>)}
-      </select>
-
-      <div className="grid grid-cols-3 gap-2">
-        <div>
-          <label className="block text-xs text-white/70">Duration(ms)</label>
-          <input className="w-full" type="number" value={duration} onChange={(e)=>setDuration(+e.target.value || 0)} />
-        </div>
-        <div>
-          <label className="block text-xs text-white/70">Delay(ms)</label>
-          <input className="w-full" type="number" value={delay} onChange={(e)=>setDelay(+e.target.value || 0)} />
-        </div>
-        <div>
-          <label className="block text-xs text-white/70">Easing</label>
-          <input className="w-full" value={easing} onChange={(e)=>setEasing(e.target.value)} placeholder="easeInOutQuad" />
-        </div>
-      </div>
-
-      <button onClick={add} className="h-9 w-full rounded-xl bg-white/10 text-sm hover:bg-white/15">
-        Add action
-      </button>
-    </div>
-  )
-}
-
-/** 既存の visual 側はそのまま（例としてダミーのプレースホルダー） */
-function EffectsVisualPane() {
-  return <div className="text-white/60">（既存の Effects UI をここに）</div>
-}
-
-/** 親：2カラム配置 */
 export default function EffectsPanel({
-  onAddAction,
-  selectedNodeId,
+  visualPane,
+  selectedNode,
+  onChangeSelectedNode,
 }: {
-  onAddAction: (a: Action) => void
-  selectedNodeId?: string
+  visualPane: React.ReactNode
+  selectedNode: any
+  onChangeSelectedNode: (updater: (prev: any) => any) => void
 }) {
+  const motion: MotionEffect[] = selectedNode?.effects?.motion ?? []
+  const setMotion = (next: MotionEffect[]) =>
+    onChangeSelectedNode((prev) => ({
+      ...prev,
+      effects: { ...(prev.effects ?? {}), motion: next },
+    }))
+
   return (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <Section title="Effects (visual)">
-        <EffectsVisualPane />
-      </Section>
+      <div className="rounded-2xl border border-white/10 bg-black/30 p-3">
+        <div className="mb-2 text-xs uppercase tracking-wider text-white/60">Effects (visual)</div>
+        {visualPane}
+      </div>
 
-      <Section title="Motion (anime.js)">
-        <AnimePane onAdd={onAddAction} defaultTarget={selectedNodeId} />
-      </Section>
+      <div className="rounded-2xl border border-white/10 bg-black/30 p-3">
+        <MotionEffectsPanel
+          value={motion}
+          onChange={setMotion}
+          defaultTargetNodeId={selectedNode?.id}
+        />
+      </div>
     </div>
   )
 }

--- a/web/components/panels/MotionEffectsPanel.tsx
+++ b/web/components/panels/MotionEffectsPanel.tsx
@@ -1,0 +1,160 @@
+'use client'
+import type { MotionEffect, AnimePresetKey, MotionEvent } from '@/types/motion'
+
+const PRESETS: AnimePresetKey[] = [
+  'fadeIn','fadeOut',
+  'slideInUp','slideInRight','slideInDown','slideInLeft',
+  'scaleIn','scaleOut',
+  'rotateIn','rotateOut',
+  'pulse','shake'
+]
+const EVENTS: MotionEvent[] = ['click','doubleClick','mount','inView']
+
+function rid() { return Math.random().toString(36).slice(2, 9) }
+
+export default function MotionEffectsPanel({
+  value,
+  onChange,
+  defaultTargetNodeId,
+  className,
+}: {
+  value: MotionEffect[]
+  onChange: (next: MotionEffect[]) => void
+  defaultTargetNodeId?: string
+  className?: string
+}) {
+  const list = value ?? []
+
+  const add = () => {
+    const eff: MotionEffect = {
+      id: rid(),
+      preset: 'fadeIn',
+      runWhen: ['click'],
+      target: defaultTargetNodeId ? { type: 'nodeId', value: defaultTargetNodeId } : undefined,
+      options: { duration: 300, easing: 'easeInOutQuad' }
+    }
+    onChange([...list, eff])
+  }
+
+  const del = (id: string) => onChange(list.filter(e => e.id !== id))
+  const patch = (id: string, part: Partial<MotionEffect>) =>
+    onChange(list.map(e => e.id === id ? { ...e, ...part } : e))
+  const patchOpt = (id: string, part: Partial<NonNullable<MotionEffect['options']>>) =>
+    onChange(list.map(e => e.id === id ? { ...e, options: { ...(e.options ?? {}), ...part } } : e))
+
+  return (
+    <div className={`td-form-scope space-y-3 ${className ?? ''}`}>
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium text-white/80">Motion (anime.js)</div>
+        <button onClick={add} className="h-8 rounded-lg bg-white/10 px-3 text-sm hover:bg-white/15">+ Add</button>
+      </div>
+
+      {list.length === 0 && (
+        <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-xs text-white/60">
+          まだ効果がありません。「+ Add」で追加してください。
+        </div>
+      )}
+
+      {list.map((eff, i) => (
+        <div key={eff.id} className="rounded-xl border border-white/10 bg-black/30 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-xs text-white/70">effect #{i + 1}</div>
+            <button onClick={() => del(eff.id)} className="text-xs text-red-300/80 hover:text-red-200">remove</button>
+          </div>
+
+          {/* 行1: Preset / Duration / Delay */}
+          <div className="grid grid-cols-3 gap-2">
+            <div>
+              <label className="block text-xs text-white/70">preset</label>
+              <select
+                className="w-full"
+                value={eff.preset}
+                onChange={(e) => patch(eff.id, { preset: e.target.value as AnimePresetKey })}
+              >
+                {PRESETS.map(p => <option key={p} value={p}>{p}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-white/70">duration(ms)</label>
+              <input
+                className="w-full"
+                type="number"
+                value={eff.options?.duration ?? 300}
+                onChange={(e) => patchOpt(eff.id, { duration: +e.target.value || 0 })}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-white/70">delay(ms)</label>
+              <input
+                className="w-full"
+                type="number"
+                value={eff.options?.delay ?? 0}
+                onChange={(e) => patchOpt(eff.id, { delay: +e.target.value || 0 })}
+              />
+            </div>
+          </div>
+
+          {/* 行2: easing / loop / direction */}
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            <div>
+              <label className="block text-xs text-white/70">easing</label>
+              <input
+                className="w-full"
+                placeholder="easeInOutQuad"
+                value={eff.options?.easing ?? 'easeInOutQuad'}
+                onChange={(e) => patchOpt(eff.id, { easing: e.target.value })}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-white/70">loop</label>
+              <input
+                className="w-full"
+                placeholder="false / true / 回数"
+                value={String(eff.options?.loop ?? 'false')}
+                onChange={(e) => {
+                  const v = e.target.value.trim()
+                  patchOpt(eff.id, v === 'true' ? { loop: true } : v === 'false' ? { loop: false } : { loop: Number(v) || 0 })
+                }}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-white/70">direction</label>
+              <select
+                className="w-full"
+                value={eff.options?.direction ?? 'normal'}
+                onChange={(e) => patchOpt(eff.id, { direction: e.target.value as any })}
+              >
+                {['normal','reverse','alternate'].map(d => <option key={d} value={d}>{d}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {/* 行3: Run when */}
+          <div className="mt-2">
+            <div className="mb-1 text-xs text-white/70">run when</div>
+            <div className="flex flex-wrap gap-3">
+              {EVENTS.map(ev => {
+                const checked = eff.runWhen.includes(ev)
+                return (
+                  <label key={ev} className="inline-flex items-center gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => {
+                        const next = checked
+                          ? eff.runWhen.filter(x => x !== ev)
+                          : [...eff.runWhen, ev]
+                        patch(eff.id, { runWhen: next })
+                      }}
+                    />
+                    <span className="text-white/80">{ev}</span>
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/lib/anime-presets.ts
+++ b/web/lib/anime-presets.ts
@@ -1,6 +1,7 @@
 import type { AnimeParams } from 'animejs'
+import type { AnimePresetKey } from '@/types/motion'
 
-export const animePresets: Record<string, (el: Element)=>AnimeParams> = {
+export const animePresets: Record<AnimePresetKey, (el: Element)=>AnimeParams> = {
   fadeIn: () => ({ opacity: [0, 1] }),
   fadeOut: () => ({ opacity: [1, 0] }),
 

--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -1,0 +1,34 @@
+'use client'
+import anime, { type AnimeParams } from 'animejs'
+import { animePresets } from '@/lib/anime-presets'
+import type { MotionEffect, MotionEvent, NodeTarget } from '@/types/motion'
+
+const resolveTarget = (target: NodeTarget | undefined, fallback: HTMLElement | null) => {
+  if (!target) return fallback
+  if (target.type === 'css') return document.querySelector(target.value) as HTMLElement | null
+  if (target.type === 'nodeId') return document.querySelector<HTMLElement>(`[data-node-id="${target.value}"]`)
+  return fallback
+}
+
+export function runMotionEffects(
+  effects: MotionEffect[] | undefined,
+  when: MotionEvent,
+  fallbackEl: HTMLElement | null
+) {
+  if (!effects?.length) return
+  for (const eff of effects) {
+    if (!eff.runWhen?.includes(when)) continue
+    const el = resolveTarget(eff.target, fallbackEl)
+    if (!el) continue
+
+    const base: AnimeParams = {
+      duration: 300,
+      easing: 'easeInOutQuad',
+      autoplay: true,
+    }
+    const preset = animePresets[eff.preset]?.(el) ?? {}
+    const opts = eff.options ?? {}
+    anime.remove(el)
+    anime({ targets: el, ...base, ...preset, ...opts })
+  }
+}

--- a/web/types/motion.ts
+++ b/web/types/motion.ts
@@ -1,0 +1,29 @@
+export type NodeTarget =
+  | { type: 'nodeId'; value: string }
+  | { type: 'css'; value: string }
+
+export type MotionEvent = 'click' | 'doubleClick' | 'mount' | 'inView'
+
+export type AnimePresetKey =
+  | 'fadeIn' | 'fadeOut'
+  | 'slideInUp' | 'slideInRight' | 'slideInDown' | 'slideInLeft'
+  | 'scaleIn' | 'scaleOut'
+  | 'rotateIn' | 'rotateOut'
+  | 'pulse' | 'shake'
+
+export type MotionEffect = {
+  id: string
+  preset: AnimePresetKey
+  runWhen: MotionEvent[]            // いつ走らせるか
+  target?: NodeTarget               // 未指定なら currentEl / 選択ノード
+  ifJson?: any                      // 既存UIの If(JSON logic) と合わせるなら
+  throttle?: number                 // ms
+  debounce?: number                 // ms
+  options?: {
+    duration?: number
+    delay?: number
+    easing?: string
+    loop?: number | boolean
+    direction?: 'normal' | 'reverse' | 'alternate'
+  }
+}


### PR DESCRIPTION
## Summary
- add motion effect types and anime.js presets
- implement runMotion utility and panel to configure effects
- trigger motion presets from interactive wrapper

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f4060a78832c844e7300d5c282bf