### PR TITLE
refactor: update animejs import for v4 compatibility

### DIFF
--- a/web/lib/anime-presets.ts
+++ b/web/lib/anime-presets.ts
@@ -1,7 +1,7 @@
-import type { AnimeParams } from 'animejs'
+import type { AnimationParams } from 'animejs'
 import type { AnimePresetKey } from '@/types/motion'
 
-export const animePresets: Record<AnimePresetKey, (el: Element)=>AnimeParams> = {
+export const animePresets: Record<AnimePresetKey, (el: Element) => AnimationParams> = {
   fadeIn: () => ({ opacity: [0, 1] }),
   fadeOut: () => ({ opacity: [1, 0] }),
 

--- a/web/lib/runAction.ts
+++ b/web/lib/runAction.ts
@@ -1,5 +1,5 @@
 'use client'
-import anime, { AnimeParams } from 'animejs'
+import { animate, utils, type AnimationParams } from 'animejs'
 import type { Action } from '@/types/actions'
 import { animePresets } from '@/lib/anime-presets'
 
@@ -21,13 +21,13 @@ export function runAction(action: Action, ctx?: { currentEl?: HTMLElement | null
     if (typeof window === 'undefined') return
     const el = resolveTarget(action, ctx?.currentEl)
     if (!el) return
-    const base: AnimeParams = {
+    const base: AnimationParams = {
       duration: 300,
       easing: 'easeInOutQuad',
       autoplay: true,
     }
     const preset = animePresets[action.preset]?.(el) ?? {}
-    anime.remove(el) // 前のアニメをクリア
-    anime({ targets: el, ...base, ...preset, ...(action.options || {}) })
+    utils.remove(el) // 前のアニメをクリア
+    animate(el, { ...base, ...preset, ...(action.options || {}) })
   }
 }

--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -1,5 +1,5 @@
 'use client'
-import anime, { type AnimeParams } from 'animejs'
+import { animate, utils, type AnimationParams } from 'animejs'
 import { animePresets } from '@/lib/anime-presets'
 import type { MotionEffect, MotionEvent, NodeTarget } from '@/types/motion'
 
@@ -21,14 +21,14 @@ export function runMotionEffects(
     const el = resolveTarget(eff.target, fallbackEl)
     if (!el) continue
 
-    const base: AnimeParams = {
+    const base: AnimationParams = {
       duration: 300,
       easing: 'easeInOutQuad',
       autoplay: true,
     }
     const preset = animePresets[eff.preset]?.(el) ?? {}
     const opts = eff.options ?? {}
-    anime.remove(el)
-    anime({ targets: el, ...base, ...preset, ...opts })
+    utils.remove(el)
+    animate(el, { ...base, ...preset, ...opts })
   }
 }

--- a/web/types/actions.ts
+++ b/web/types/actions.ts
@@ -27,7 +27,7 @@ export type NavigateAction = { type: 'navigate'; path: string }
 export type ActionAnime = {
   type: 'anime'
   preset: AnimePresetKey
-  options?: Partial<import('animejs').AnimeParams>
+  options?: Partial<import('animejs').AnimationParams>
   target?: NodeTarget
 }
 


### PR DESCRIPTION
## Summary
- update animation utilities to use animejs v4 `animate` and `utils.remove`
- replace AnimeParams types with AnimationParams

## Testing
- `pnpm build` *(fails: Cannot find module '@tailwindcss/forms')*


------
https://chatgpt.com/codex/tasks/task_e_68b6f6197fd8832ca1a91cf4c0ce35f8