### PR TITLE
feat: add Anime.js smoke test component and dynamic loader

### DIFF
--- a/web/components/AnimePing.tsx
+++ b/web/components/AnimePing.tsx
@@ -1,0 +1,18 @@
+'use client'
+const animeP = () => import('animejs').then(m => m.default)
+
+export default function AnimePing() {
+  return (
+    <button
+      className="rounded-lg bg-white/10 px-3 py-2"
+      onClick={async (e) => {
+        const anime = await animeP()
+        const el = e.currentTarget
+        anime.remove(el)
+        anime({ targets: el, scale: [1, 1.08, 1], duration: 280, easing: 'easeInOutQuad' })
+      }}
+    >
+      ping
+    </button>
+  )
+}

--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -1,7 +1,9 @@
 'use client'
-import { animate, utils, type AnimationParams } from 'animejs'
+import type { AnimationParams } from 'animejs'
 import { animePresets } from '@/lib/anime-presets'
 import type { MotionEffect, MotionEvent, NodeTarget } from '@/types/motion'
+
+const animeP = () => import('animejs')
 
 const resolveTarget = (target: NodeTarget | undefined, fallback: HTMLElement | null) => {
   if (!target) return fallback
@@ -16,6 +18,7 @@ export function runMotionEffects(
   fallbackEl: HTMLElement | null
 ) {
   if (!effects?.length) return
+  const modP = animeP()
   for (const eff of effects) {
     if (!eff.runWhen?.includes(when)) continue
     const el = resolveTarget(eff.target, fallbackEl)
@@ -28,7 +31,9 @@ export function runMotionEffects(
     }
     const preset = animePresets[eff.preset]?.(el) ?? {}
     const opts = eff.options ?? {}
-    utils.remove(el)
-    animate(el, { ...base, ...preset, ...opts })
+    modP.then(({ utils, animate }) => {
+      utils.remove(el)
+      animate(el, { ...base, ...preset, ...opts })
+    })
   }
 }


### PR DESCRIPTION
## Summary
- load anime.js dynamically in runMotion to avoid ESM issues
- add `AnimePing` client component for quick anime.js smoke testing

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68b6fde6c7d8832ca2d9c10f3b1a6b1d