### PR TITLE
refactor: dynamically import anime.js for motion effects

### DIFF
--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -3,7 +3,7 @@ import type { AnimationParams } from 'animejs'
 import { animePresets } from '@/lib/anime-presets'
 import type { MotionEffect, MotionEvent, NodeTarget } from '@/types/motion'
 
-const animeP = () => import('animejs')
+const animeP = () => import('animejs').then(m => m.default)
 
 const resolveTarget = (target: NodeTarget | undefined, fallback: HTMLElement | null) => {
   if (!target) return fallback
@@ -18,7 +18,6 @@ export function runMotionEffects(
   fallbackEl: HTMLElement | null
 ) {
   if (!effects?.length) return
-  const modP = animeP()
   for (const eff of effects) {
     if (!eff.runWhen?.includes(when)) continue
     const el = resolveTarget(eff.target, fallbackEl)
@@ -31,9 +30,9 @@ export function runMotionEffects(
     }
     const preset = animePresets[eff.preset]?.(el) ?? {}
     const opts = eff.options ?? {}
-    modP.then(({ utils, animate }) => {
-      utils.remove(el)
-      animate(el, { ...base, ...preset, ...opts })
+    animeP().then((anime) => {
+      anime.remove(el)
+      anime({ targets: el, ...base, ...preset, ...opts })
     })
   }
 }


### PR DESCRIPTION
## Summary
- dynamically import `animejs` in motion runner to ensure client-side usage and avoid ESM issues

## Testing
- `pnpm test` *(fails: ELIFECYCLE – npm install stage)*

------
https://chatgpt.com/codex/tasks/task_e_68b719a95c74832c9073e99c08197093