### PR TITLE
Add motion safety guard and error boundary

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -5,6 +5,7 @@ import Providers from './providers'
 import SiteHeader from '@/components/layout/SiteHeader'
 import SiteFooter from '@/components/layout/SiteFooter'
 import ChromeController from '@/components/layout/ChromeController'
+import ErrorBoundary from '@/components/ErrorBoundary'
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
   const cookieStore = await cookies()
@@ -13,12 +14,14 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   return (
     <html lang="ja" data-theme={uiTheme} suppressHydrationWarning>
       <body>
-        <Providers initialTheme={uiTheme}>
-          <ChromeController />
-          <SiteHeader />
-          <main className="min-h-[calc(100vh-6rem)]">{children}</main>
-          <SiteFooter />
-        </Providers>
+        <ErrorBoundary>
+          <Providers initialTheme={uiTheme}>
+            <ChromeController />
+            <SiteHeader />
+            <main className="min-h-[calc(100vh-6rem)]">{children}</main>
+            <SiteFooter />
+          </Providers>
+        </ErrorBoundary>
       </body>
     </html>
   )

--- a/web/components/ErrorBoundary.tsx
+++ b/web/components/ErrorBoundary.tsx
@@ -1,0 +1,23 @@
+'use client'
+import React from 'react'
+
+export default class ErrorBoundary extends React.Component<
+  { fallback?: (info: { error: unknown }) => React.ReactNode; children: React.ReactNode },
+  { error: unknown | null }
+> {
+  state = { error: null as unknown | null }
+  static getDerivedStateFromError(error: unknown) { return { error } }
+  componentDidCatch(error: unknown, info: unknown) { console.error('[ErrorBoundary]', error, info) }
+  render() {
+    if (this.state.error) {
+      const Fallback = this.props.fallback
+      return Fallback ? Fallback({ error: this.state.error }) : (
+        <div className="p-6 text-sm">
+          <div className="mb-2 font-semibold text-red-400">Runtime error</div>
+          <pre className="whitespace-pre-wrap text-red-200">{String(this.state.error)}</pre>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -100,7 +100,8 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
   useEffect(() => {
     const el = ref.current
     if (!el) return
-    queueMicrotask(() => runMotionEffects((draft as any)?.effects?.motion, 'mount', el))
+    // ↓ 一時的に mount トリガーを止めたい場合はコメントアウト
+    // queueMicrotask(() => runMotionEffects((draft as any)?.effects?.motion, 'mount', el))
   }, [])
 
   return (

--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -1,38 +1,65 @@
 'use client'
-import type { AnimationParams } from 'animejs'
-import { animePresets } from '@/lib/anime-presets'
+import type { AnimeParams } from 'animejs'
 import type { MotionEffect, MotionEvent, NodeTarget } from '@/types/motion'
+import { animePresets } from '@/lib/anime-presets'
 
-const animeP = () => import('animejs').then(m => m.default)
-
-const resolveTarget = (target: NodeTarget | undefined, fallback: HTMLElement | null) => {
-  if (!target) return fallback
-  if (target.type === 'css') return document.querySelector(target.value) as HTMLElement | null
-  if (target.type === 'nodeId') return document.querySelector<HTMLElement>(`[data-node-id="${target.value}"]`)
-  return fallback
+declare global {
+  interface Window {
+    __TD_DISABLE_MOTION__?: boolean
+  }
 }
 
-export function runMotionEffects(
+let _anime: any | null = null
+async function getAnime() {
+  if (_anime) return _anime
+  // ESMを直接読んでSSRを避ける（バンドルの相性問題も回避）
+  _anime = (await import('animejs/lib/anime.es.js')).default
+  return _anime
+}
+
+const disabledByQuery = () =>
+  typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('nomotion') === '1'
+
+const resolveTarget = (target: NodeTarget | undefined, fallback: HTMLElement | null) => {
+  try {
+    if (!target) return fallback
+    if (target.type === 'css') return document.querySelector(target.value) as HTMLElement | null
+    if (target.type === 'nodeId') return document.querySelector<HTMLElement>(`[data-node-id="${target.value}"]`)
+    return fallback
+  } catch {
+    return fallback
+  }
+}
+
+export async function runMotionEffects(
   effects: MotionEffect[] | undefined,
   when: MotionEvent,
   fallbackEl: HTMLElement | null
 ) {
-  if (!effects?.length) return
-  for (const eff of effects) {
-    if (!eff.runWhen?.includes(when)) continue
-    const el = resolveTarget(eff.target, fallbackEl)
-    if (!el) continue
+  try {
+    if (typeof window === 'undefined') return
+    if (window.__TD_DISABLE_MOTION__ || disabledByQuery()) return
+    if (!effects?.length) return
 
-    const base: AnimationParams = {
-      duration: 300,
-      easing: 'easeInOutQuad',
-      autoplay: true,
+    const anime = await getAnime()
+
+    for (const eff of effects) {
+      try {
+        if (!eff.runWhen?.includes(when)) continue
+        const el = resolveTarget(eff.target, fallbackEl)
+        if (!el) continue
+
+        const base: AnimeParams = { duration: 300, easing: 'easeInOutQuad', autoplay: true }
+        const preset = animePresets[eff.preset]?.(el) ?? {}
+        const opts = eff.options ?? {}
+        anime.remove(el)
+        anime({ targets: el, ...base, ...preset, ...opts })
+      } catch (e) {
+        // 個別の効果でコケても他に影響しないように
+        console.error('[runMotionEffects:item]', e)
+      }
     }
-    const preset = animePresets[eff.preset]?.(el) ?? {}
-    const opts = eff.options ?? {}
-    animeP().then((anime) => {
-      anime.remove(el)
-      anime({ targets: el, ...base, ...preset, ...opts })
-    })
+  } catch (e) {
+    console.error('[runMotionEffects]', e)
   }
 }


### PR DESCRIPTION
## Summary
- Harden motion effect runner with query/flag off switch, ESM anime.js import and error guards
- Introduce reusable `ErrorBoundary` and wrap root layout
- Temporarily disable motion mount trigger for debugging stability

## Testing
- `pnpm test` *(fails: ReferenceError: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b78bdbc0c8832cb7d445b2f7d86644