### PR TITLE
feat: add motion effects panel

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -7,12 +7,15 @@ import { PRESETS } from '@/lib/presets'
 import { useBuilderStore } from '@/store/builderStore'
 import { usePresetDraft } from '@/store/presetDraftStore'
 import InteractiveWrapper from '@/components/interactive/InteractiveWrapper'
+import MotionEffectsPanel from '@/components/panels/MotionEffectsPanel'
 
 export default function DevActionsPage(){
   const placePreset = useBuilderStore(s=>s.placePreset)
   const draft = usePresetDraft(s=>s.draft)
   const applySel = useBuilderStore(s=>s.applyInteractiveToSelection)
   const applyAll = useBuilderStore(s=>s.applyInteractiveToAll)
+  const motion = usePresetDraft(s=>s.draft.motion)
+  const setMotion = usePresetDraft(s=>s.setMotion)
 
   return (
     <div className="dev-actions p-3">
@@ -47,14 +50,25 @@ export default function DevActionsPage(){
             <button className="px-3 py-1 border rounded" onClick={()=>applyAll(draft,'remove')}>Remove All</button>
           </div>
 
-          <div className="grid md:grid-cols-2 gap-3">
-            <TriggersCard/>
-            {/* ★ When は Actions 枠の中に表示（下のActionsCardで対応） */}
-            <ActionsCard/>
-          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <section className="md:col-start-1 md:row-start-1">
+              <TriggersCard/>
+            </section>
 
-          {/* 詳細エディタは削らない（EffectsCardの中に残す） */}
-          <EffectsCard/>
+            <section className="md:col-start-2 md:row-start-1">
+              <ActionsCard/>
+            </section>
+
+            <section className="md:col-start-1 md:row-start-2">
+              <EffectsCard/>
+            </section>
+
+            <section className="md:col-start-2 md:row-start-2">
+              <div className="rounded-md border p-3">
+                <MotionEffectsPanel value={motion} onChange={setMotion} />
+              </div>
+            </section>
+          </div>
         </main>
 
         {/* 右：プレビュー */}

--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -10,6 +10,7 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
   const ref = useRef<HTMLDivElement>(null)
   const router = useRouter()
   const id = useId()
+  const motion = (draft as any)?.motion ?? (draft as any)?.effects?.motion
 
   // 1) Triggers → ユニーククラス作成
   const cls = useMemo(() => {
@@ -101,7 +102,7 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
     const el = ref.current
     if (!el) return
     // ↓ 一時的に mount トリガーを止めたい場合はコメントアウト
-    // queueMicrotask(() => runMotionEffects((draft as any)?.effects?.motion, 'mount', el))
+    // queueMicrotask(() => runMotionEffects(motion, 'mount', el))
   }, [])
 
   return (
@@ -109,10 +110,10 @@ export default function InteractiveWrapper({ draft, children }:{ draft: PresetDr
       ref={ref}
       className={cls}
       onClick={(e) => {
-        runMotionEffects((draft as any)?.effects?.motion, 'click', e.currentTarget as HTMLElement)
+        runMotionEffects(motion, 'click', e.currentTarget as HTMLElement)
       }}
       onDoubleClick={(e) => {
-        runMotionEffects((draft as any)?.effects?.motion, 'doubleClick', e.currentTarget as HTMLElement)
+        runMotionEffects(motion, 'doubleClick', e.currentTarget as HTMLElement)
       }}
     >
       {children}

--- a/web/store/presetDraftStore.ts
+++ b/web/store/presetDraftStore.ts
@@ -1,6 +1,7 @@
 'use client'
 import { create } from 'zustand'
 import type { PresetDraft, ActionDef, Effect, TriggerState } from '@/types/presets-ui'
+import type { MotionEffect } from '@/types/motion'
 
 const defaultTriggers: TriggerState = {
   hover:true, active:false, focus:false, focusWithin:false, groupHover:false,
@@ -17,11 +18,13 @@ export const usePresetDraft = create<{
   addAction:(a:ActionDef)=>void
   updateAction:(idx:number, a:Partial<ActionDef>)=>void
   removeAction:(idx:number)=>void
+  setMotion:(m:MotionEffect[])=>void
 }>((set)=>({
   draft: {
     name:'New Preset',
     triggers: defaultTriggers,
     effects: [{ kind:'scale', value:{ scale:1.09 } }, { kind:'bgColor', value:{ color:'#004cff' } }, { kind:'shadow', value:{ level:'xl' } }, { kind:'opacity', value:{ opacity:0.9 } }],
+    motion: [],
     actions: [{
       type:'openUrl',
       params:{ url:'' },
@@ -39,4 +42,5 @@ export const usePresetDraft = create<{
   addAction:(a)=>set(s=>({ draft:{ ...s.draft, actions:[...s.draft.actions, a]}})),
   updateAction:(i,a)=>set(s=>{ const arr=[...s.draft.actions]; arr[i]={ ...arr[i], ...a }; return { draft:{ ...s.draft, actions:arr }}}),
   removeAction:(i)=>set(s=>{ const arr=[...s.draft.actions]; arr.splice(i,1); return { draft:{ ...s.draft, actions:arr }}}),
+  setMotion:(m)=>set(s=>({ draft:{ ...s.draft, motion:m }})),
 }))

--- a/web/types/presets-ui.ts
+++ b/web/types/presets-ui.ts
@@ -1,3 +1,5 @@
+import type { MotionEffect } from './motion'
+
 export type JsonLogic = any // 既存実装か後日差し替え
 
 export type TriggerState = {
@@ -36,4 +38,5 @@ export type PresetDraft = {
   triggers: TriggerState
   effects: Effect[]
   actions: ActionDef[]
+  motion: MotionEffect[]
 }


### PR DESCRIPTION
## Summary
- layout dev actions page with a 2x2 grid and add MotionEffectsPanel
- support motion effects in preset draft store and types
- run motion effects from InteractiveWrapper

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7950a2114832ca016c5ab888fbf1c