### PR TITLE
feat: restore 3-column layout for dev actions page

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -5,18 +5,28 @@ import dynamic from 'next/dynamic'
 import TriggersCard from './TriggersCard'
 import ActionsCard from './ActionsCard'
 import EffectsCard from './EffectsCard'
+import MotionEffectsPanel from '@/components/panels/MotionEffectsPanel'
 
-// Motion panel with placeholder when missing
-const MotionEffectsPanel = dynamic(
+const PresetsSidebar = dynamic(
   () =>
-    import('@/components/panels/MotionEffectsPanel').catch(() => ({
+    import('@/components/panels/PresetsSidebar').catch(() => ({
       default: () => (
-        <div className="rounded-2xl border bg-white p-4">
-          <div className="mb-2 text-sm font-medium text-gray-700">Animation (anime.js)</div>
-          <p className="text-xs text-gray-500">
-            MotionEffectsPanel が見つかりません。<code>components/panels/MotionEffectsPanel.tsx</code>
-            を追加してください。
-          </p>
+        <div className="rounded-2xl border bg-white p-4 text-sm text-gray-500">
+          PresetsSidebar が見つかりません。<code>components/panels/PresetsSidebar.tsx</code>
+          を用意してください。
+        </div>
+      ),
+    })),
+  { ssr: false }
+)
+
+const PreviewPane = dynamic(
+  () =>
+    import('@/components/panels/PreviewPane').catch(() => ({
+      default: () => (
+        <div className="rounded-2xl border bg-white p-4 text-sm text-gray-500">
+          PreviewPane が見つかりません。<code>components/panels/PreviewPane.tsx</code>
+          を用意してください。
         </div>
       ),
     })),
@@ -52,32 +62,42 @@ export default function DevActionsPage() {
     }))
 
   return (
-    // 2×2 grid: left-top Triggers, right-top Actions, left-bottom Effects, right-bottom Animation
-    <div id="dev-actions-grid" className="grid gap-4 lg:grid-cols-2">
-      {/* 左上：Triggers */}
-      <section className="rounded-2xl border bg-white p-4">
-        <TriggersCard />
-      </section>
+    // 3カラム：左=Presets／中央=2×2／右=Preview
+    <div className="grid gap-4 xl:grid-cols-[260px_1fr_320px]">
+      {/* 左：Presets（スクロール追従） */}
+      <aside className="xl:sticky xl:top-4 xl:self-start">
+        <PresetsSidebar />
+      </aside>
 
-      {/* 右上：Actions */}
-      <section className="rounded-2xl border bg-white p-4">
-        <ActionsCard />
-      </section>
+      {/* 中央：2×2 グリッド */}
+      <main className="grid gap-4 lg:grid-cols-2">
+        {/* 左上：Triggers */}
+        <section className="rounded-2xl border bg-white p-4">
+          <TriggersCard />
+        </section>
+        {/* 右上：Actions */}
+        <section className="rounded-2xl border bg-white p-4">
+          <ActionsCard />
+        </section>
+        {/* 左下：Effects (visual) */}
+        <section className="rounded-2xl border bg-white p-4">
+          <EffectsCard />
+        </section>
+        {/* 右下：Animation (anime.js) */}
+        <section className="rounded-2xl border bg-white p-4">
+          <div className="mb-2 text-sm font-medium text-gray-700">Animation (anime.js)</div>
+          <MotionEffectsPanel
+            value={motion}
+            onChange={setMotion}
+            defaultTargetNodeId={selectedNode?.id}
+          />
+        </section>
+      </main>
 
-      {/* 左下：Effects (visual) */}
-      <section className="rounded-2xl border bg-white p-4">
-        <EffectsCard />
-      </section>
-
-      {/* 右下：Animation (anime.js) */}
-      <section className="rounded-2xl border bg-white p-4">
-        <div className="mb-2 text-sm font-medium text-gray-700">Animation (anime.js)</div>
-        <MotionEffectsPanel
-          value={motion}
-          onChange={setMotion}
-          defaultTargetNodeId={selectedNode?.id}
-        />
-      </section>
+      {/* 右：Preview（スクロール追従） */}
+      <aside className="xl:sticky xl:top-4 xl:self-start">
+        <PreviewPane />
+      </aside>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- restore three-column layout on dev actions page with presets sidebar, 2x2 center grid, and preview pane
- add dynamic imports with helpful fallbacks for missing PresetsSidebar and PreviewPane components

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68b7c48d7e10832ca723ed881ae7e675