### PR TITLE
feat: add motion presets with strength

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -83,13 +83,13 @@ export default function DevActionsPage() {
         <section className="rounded-2xl border bg-white p-4">
           <EffectsCard />
         </section>
-        {/* 右下：Animation (anime.js) */}
+        {/* 右下：Animation (preset) */}
         <section className="rounded-2xl border bg-white p-4">
-          <div className="mb-2 text-sm font-medium text-gray-700">Animation (anime.js)</div>
           <MotionEffectsPanel
             value={motion}
             onChange={setMotion}
             defaultTargetNodeId={selectedNode?.id}
+            mode="simple"
           />
         </section>
       </main>

--- a/web/app/dev/motion/page.tsx
+++ b/web/app/dev/motion/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { MOTION_PRESETS, buildAnimeParamsFromStrength } from '@/lib/motion-presets'
+import type { AnimeParams } from 'animejs'
+
+const animeP = () => import('animejs/lib/anime.es.js').then(m => m.default)
+
+export default function MotionLabPage() {
+  const url = new URL(typeof window !== 'undefined' ? window.location.href : 'http://localhost')
+  const initKey = (url.searchParams.get('p') || 'fadeIn')
+  const initStrength = Number(url.searchParams.get('s') || 50)
+
+  const [key, setKey] = useState<string>(initKey)
+  const [strength, setStrength] = useState<number>(initStrength)
+  const [duration, setDuration] = useState<number | ''>('') // 上書き用
+  const [easing, setEasing] = useState<string>('')
+
+  const previewRef = useRef<HTMLDivElement | null>(null)
+
+  const params: AnimeParams = useMemo(() => {
+    const base = buildAnimeParamsFromStrength(key, strength) || {}
+    const over: AnimeParams = {}
+    if (duration !== '') over.duration = duration
+    if (easing) over.easing = easing
+    return { ...base, ...over }
+  }, [key, strength, duration, easing])
+
+  const play = async () => {
+    const el = previewRef.current
+    if (!el) return
+    const anime = await animeP()
+    anime.remove(el)
+    anime({ targets: el, ...params })
+  }
+
+  useEffect(() => { play() }, [params]) // 値が変わるたびに試再生
+
+  const copyTs = async () => {
+    const def = MOTION_PRESETS[key]
+    const code = `{
+  key: '${def?.key ?? key}',
+  name: '${def?.name ?? key}',
+  build: (t) => (${JSON.stringify(def?.build(0.5) ?? {}, null, 2)}),
+  defaults: ${JSON.stringify(def?.defaults ?? {}, null, 2)}
+}`
+    await navigator.clipboard.writeText(code)
+    alert('Preset snippet copied!')
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[300px_1fr_380px]">
+      {/* 左：リスト */}
+      <aside className="rounded-2xl border bg-white p-4">
+        <div className="mb-2 text-sm font-medium">Presets</div>
+        <div className="space-y-2">
+          {Object.keys(MOTION_PRESETS).map(k => (
+            <button
+              key={k}
+              onClick={() => setKey(k)}
+              className={`block w-full rounded-md border px-3 py-2 text-left text-sm ${k===key?'bg-black/5':''}`}
+            >
+              {MOTION_PRESETS[k].name}
+            </button>
+          ))}
+        </div>
+      </aside>
+
+      {/* 中央：エディタ */}
+      <main className="rounded-2xl border bg-white p-4">
+        <div className="mb-4 text-sm font-medium">Editor</div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs text-gray-500">preset</label>
+            <select className="w-full" value={key} onChange={(e)=>setKey(e.target.value)}>
+              {Object.keys(MOTION_PRESETS).map(k => <option key={k} value={k}>{MOTION_PRESETS[k].name}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500">strength</label>
+            <input type="range" min={0} max={100} value={strength} onChange={(e)=>setStrength(+e.target.value)} className="w-full"/>
+            <div className="mt-1 text-right text-xs text-gray-500">{strength}</div>
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-500">duration (override)</label>
+            <input className="w-full" type="number" value={duration} onChange={(e)=>setDuration(e.target.value===''? '' : +e.target.value)}/>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500">easing (override)</label>
+            <input className="w-full" placeholder="easeOutCubic / cubicBezier(...)" value={easing} onChange={(e)=>setEasing(e.target.value)}/>
+          </div>
+        </div>
+
+        <div className="mt-4 flex gap-2">
+          <button onClick={play} className="rounded-md border px-3 py-2 text-sm">Play</button>
+          <a href={`/dev/actions`} className="rounded-md border px-3 py-2 text-sm">Back to /dev/actions</a>
+          <button onClick={copyTs} className="rounded-md border px-3 py-2 text-sm">Copy snippet</button>
+        </div>
+      </main>
+
+      {/* 右：プレビュー */}
+      <aside className="rounded-2xl border bg-white p-4">
+        <div className="mb-2 text-sm font-medium">Preview</div>
+        <div ref={previewRef} className="grid h-48 place-items-center rounded-xl border bg-gradient-to-br from-gray-50 to-gray-100 text-sm">
+          Preview box
+        </div>
+        <div className="mt-2 text-xs text-gray-500">
+          値を変えると自動再生します。Play で再生し直し。
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/web/components/panels/MotionEffectsPanel.tsx
+++ b/web/components/panels/MotionEffectsPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 import type { MotionEffect, AnimePresetKey, MotionEvent } from '@/types/motion'
+import { MOTION_PRESETS } from '@/lib/motion-presets'
 
 const PRESETS: AnimePresetKey[] = [
   'fadeIn','fadeOut',
@@ -16,11 +17,13 @@ export default function MotionEffectsPanel({
   value,
   onChange,
   defaultTargetNodeId,
+  mode = 'advanced',
   className,
 }: {
   value: MotionEffect[]
-  onChange: (next: MotionEffect[]) => void
+  onChange: (v: MotionEffect[]) => void
   defaultTargetNodeId?: string
+  mode?: 'simple' | 'advanced'
   className?: string
 }) {
   const list = value ?? []
@@ -31,7 +34,8 @@ export default function MotionEffectsPanel({
       preset: 'fadeIn',
       runWhen: ['click'],
       target: defaultTargetNodeId ? { type: 'nodeId', value: defaultTargetNodeId } : undefined,
-      options: { duration: 300, easing: 'easeInOutQuad' }
+      strength: 50,
+      options: { duration: 300, easing: 'easeInOutQuad' },
     }
     onChange([...list, eff])
   }
@@ -44,115 +48,164 @@ export default function MotionEffectsPanel({
 
   return (
     <div className={`td-form-scope space-y-3 ${className ?? ''}`}>
+      {/* ヘッダー */}
       <div className="flex items-center justify-between">
-        <div className="text-sm font-medium text-white/80">Motion (anime.js)</div>
-        <button onClick={add} className="h-8 rounded-lg bg-white/10 px-3 text-sm hover:bg-white/15">+ Add</button>
+        <div className="text-sm font-medium">{mode === 'simple' ? 'Animation (preset)' : 'Motion (anime.js)'}</div>
+        <div className="flex gap-2">
+          {/* Motion Lab へ */}
+          <a
+            href={`/dev/motion?p=${list[0]?.preset ?? 'fadeIn'}&s=${list[0]?.strength ?? 50}`}
+            className="h-8 rounded-lg border px-3 text-xs"
+          >
+            Open in Motion Lab
+          </a>
+          <button onClick={add} className="h-8 rounded-lg bg-black/5 px-3 text-xs">+ Add</button>
+        </div>
       </div>
 
-      {list.length === 0 && (
-        <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-xs text-white/60">
-          まだ効果がありません。「+ Add」で追加してください。
-        </div>
-      )}
-
       {list.map((eff, i) => (
-        <div key={eff.id} className="rounded-xl border border-white/10 bg-black/30 p-3">
+        <div key={eff.id} className="rounded-xl border bg-white p-3">
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-xs text-white/70">effect #{i + 1}</div>
-            <button onClick={() => del(eff.id)} className="text-xs text-red-300/80 hover:text-red-200">remove</button>
+            <div className="text-xs text-gray-500">effect #{i+1}</div>
+            <button onClick={()=>del(eff.id)} className="text-xs text-red-500">remove</button>
           </div>
 
-          {/* 行1: Preset / Duration / Delay */}
-          <div className="grid grid-cols-3 gap-2">
-            <div>
-              <label className="block text-xs text-white/70">preset</label>
-              <select
-                className="w-full"
-                value={eff.preset}
-                onChange={(e) => patch(eff.id, { preset: e.target.value as AnimePresetKey })}
-              >
-                {PRESETS.map(p => <option key={p} value={p}>{p}</option>)}
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs text-white/70">duration(ms)</label>
-              <input
-                className="w-full"
-                type="number"
-                value={eff.options?.duration ?? 300}
-                onChange={(e) => patchOpt(eff.id, { duration: +e.target.value || 0 })}
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-white/70">delay(ms)</label>
-              <input
-                className="w-full"
-                type="number"
-                value={eff.options?.delay ?? 0}
-                onChange={(e) => patchOpt(eff.id, { delay: +e.target.value || 0 })}
-              />
-            </div>
-          </div>
+          {/* === 簡易モード：preset + strength + runWhen === */}
+          {mode === 'simple' ? (
+            <>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className="block text-xs text-gray-500">preset</label>
+                  <select className="w-full" value={eff.preset}
+                    onChange={(e)=>patch(eff.id, { preset: e.target.value })}>
+                    {Object.keys(MOTION_PRESETS).map(k => <option key={k} value={k}>{MOTION_PRESETS[k].name}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-500">strength</label>
+                  <input className="w-full" type="range" min={0} max={100}
+                    value={eff.strength ?? 50}
+                    onChange={(e)=>patch(eff.id, { strength: Number(e.target.value) })} />
+                  <div className="mt-1 text-right text-xs text-gray-500">{eff.strength ?? 50}</div>
+                </div>
+              </div>
 
-          {/* 行2: easing / loop / direction */}
-          <div className="mt-2 grid grid-cols-3 gap-2">
-            <div>
-              <label className="block text-xs text-white/70">easing</label>
-              <input
-                className="w-full"
-                placeholder="easeInOutQuad"
-                value={eff.options?.easing ?? 'easeInOutQuad'}
-                onChange={(e) => patchOpt(eff.id, { easing: e.target.value })}
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-white/70">loop</label>
-              <input
-                className="w-full"
-                placeholder="false / true / 回数"
-                value={String(eff.options?.loop ?? 'false')}
-                onChange={(e) => {
-                  const v = e.target.value.trim()
-                  patchOpt(eff.id, v === 'true' ? { loop: true } : v === 'false' ? { loop: false } : { loop: Number(v) || 0 })
-                }}
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-white/70">direction</label>
-              <select
-                className="w-full"
-                value={eff.options?.direction ?? 'normal'}
-                onChange={(e) => patchOpt(eff.id, { direction: e.target.value as any })}
-              >
-                {['normal','reverse','alternate'].map(d => <option key={d} value={d}>{d}</option>)}
-              </select>
-            </div>
-          </div>
+              <div className="mt-2">
+                <div className="mb-1 text-xs text-gray-500">run when</div>
+                {['click','doubleClick','mount','inView'].map(ev => {
+                  const checked = eff.runWhen.includes(ev as any)
+                  return (
+                    <label key={ev} className="mr-3 inline-flex items-center gap-2 text-xs">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={()=>{
+                          const next = checked ? eff.runWhen.filter(x => x !== ev) : [...eff.runWhen, ev as any]
+                          patch(eff.id, { runWhen: next })
+                        }}
+                      />
+                      <span>{ev}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            </>
+          ) : (
+            /* === 従来の詳細UI（duration/easing など） === */
+            <>
+              {/* 行1: Preset / Duration / Delay */}
+              <div className="grid grid-cols-3 gap-2">
+                <div>
+                  <label className="block text-xs text-white/70">preset</label>
+                  <select
+                    className="w-full"
+                    value={eff.preset}
+                    onChange={(e) => patch(eff.id, { preset: e.target.value as AnimePresetKey })}
+                  >
+                    {PRESETS.map(p => <option key={p} value={p}>{p}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-white/70">duration(ms)</label>
+                  <input
+                    className="w-full"
+                    type="number"
+                    value={eff.options?.duration ?? 300}
+                    onChange={(e) => patchOpt(eff.id, { duration: +e.target.value || 0 })}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-white/70">delay(ms)</label>
+                  <input
+                    className="w-full"
+                    type="number"
+                    value={eff.options?.delay ?? 0}
+                    onChange={(e) => patchOpt(eff.id, { delay: +e.target.value || 0 })}
+                  />
+                </div>
+              </div>
 
-          {/* 行3: Run when */}
-          <div className="mt-2">
-            <div className="mb-1 text-xs text-white/70">run when</div>
-            <div className="flex flex-wrap gap-3">
-              {EVENTS.map(ev => {
-                const checked = eff.runWhen.includes(ev)
-                return (
-                  <label key={ev} className="inline-flex items-center gap-2 text-xs">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={() => {
-                        const next = checked
-                          ? eff.runWhen.filter(x => x !== ev)
-                          : [...eff.runWhen, ev]
-                        patch(eff.id, { runWhen: next })
-                      }}
-                    />
-                    <span className="text-white/80">{ev}</span>
-                  </label>
-                )
-              })}
-            </div>
-          </div>
+              {/* 行2: easing / loop / direction */}
+              <div className="mt-2 grid grid-cols-3 gap-2">
+                <div>
+                  <label className="block text-xs text-white/70">easing</label>
+                  <input
+                    className="w-full"
+                    placeholder="easeInOutQuad"
+                    value={eff.options?.easing ?? 'easeInOutQuad'}
+                    onChange={(e) => patchOpt(eff.id, { easing: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-white/70">loop</label>
+                  <input
+                    className="w-full"
+                    placeholder="false / true / 回数"
+                    value={String(eff.options?.loop ?? 'false')}
+                    onChange={(e) => {
+                      const v = e.target.value.trim()
+                      patchOpt(eff.id, v === 'true' ? { loop: true } : v === 'false' ? { loop: false } : { loop: Number(v) || 0 })
+                    }}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-white/70">direction</label>
+                  <select
+                    className="w-full"
+                    value={eff.options?.direction ?? 'normal'}
+                    onChange={(e) => patchOpt(eff.id, { direction: e.target.value as any })}
+                  >
+                    {['normal','reverse','alternate'].map(d => <option key={d} value={d}>{d}</option>)}
+                  </select>
+                </div>
+              </div>
+
+              {/* 行3: Run when */}
+              <div className="mt-2">
+                <div className="mb-1 text-xs text-white/70">run when</div>
+                <div className="flex flex-wrap gap-3">
+                  {EVENTS.map(ev => {
+                    const checked = eff.runWhen.includes(ev)
+                    return (
+                      <label key={ev} className="inline-flex items-center gap-2 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            const next = checked
+                              ? eff.runWhen.filter(x => x !== ev)
+                              : [...eff.runWhen, ev]
+                            patch(eff.id, { runWhen: next })
+                          }}
+                        />
+                        <span className="text-white/80">{ev}</span>
+                      </label>
+                    )
+                  })}
+                </div>
+              </div>
+            </>
+          )}
         </div>
       ))}
     </div>

--- a/web/lib/motion-presets.ts
+++ b/web/lib/motion-presets.ts
@@ -1,0 +1,69 @@
+import type { AnimeParams } from 'animejs'
+import type { AnimePresetKey } from '@/types/motion'
+
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n))
+const norm = (strength = 50) => clamp01(strength / 100) // 0..1 に正規化
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t
+
+export type MotionPresetDef = {
+  key: AnimePresetKey | string
+  name: string
+  build: (s01: number) => AnimeParams
+  defaults?: Pick<AnimeParams, 'duration' | 'easing'>
+}
+
+export const MOTION_PRESETS: Record<string, MotionPresetDef> = {
+  fadeIn: {
+    key: 'fadeIn',
+    name: 'Fade in',
+    build: (t) => ({
+      opacity: [0, 1],
+      translateY: [lerp(0, 8, t), 0], // 強度が高いほど浮上量が増える
+    }),
+    defaults: { duration: 280, easing: 'easeOutCubic' },
+  },
+  slideInUp: {
+    key: 'slideInUp',
+    name: 'Slide in up',
+    build: (t) => ({
+      translateY: [lerp(8, 64, t), 0],
+      opacity: [0, 1],
+    }),
+    defaults: { duration: 320, easing: 'easeOutCubic' },
+  },
+  pulse: {
+    key: 'pulse',
+    name: 'Pulse',
+    build: (t) => ({
+      scale: [
+        { value: lerp(1.02, 1.16, t), duration: 120 },
+        { value: 1, duration: 120 },
+      ],
+    }),
+    defaults: { duration: 240, easing: 'easeInOutQuad' },
+  },
+  shake: {
+    key: 'shake',
+    name: 'Shake',
+    build: (t) => {
+      const amp = lerp(4, 12, t)
+      return {
+        translateX: [
+          { value: -amp, duration: 60 },
+          { value: amp, duration: 60 },
+          { value: 0, duration: 60 },
+        ],
+      }
+    },
+    defaults: { duration: 200, easing: 'linear' },
+  },
+  // 既存の scaleIn / rotateIn なども必要ならここに追加
+}
+
+export function buildAnimeParamsFromStrength(key: string, strength?: number): AnimeParams | undefined {
+  const def = MOTION_PRESETS[key]
+  if (!def) return
+  const t = norm(strength ?? 50)
+  const base = def.build(t)
+  return { ...def.defaults, ...base }
+}

--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -2,6 +2,7 @@
 import type { AnimeParams } from 'animejs'
 import type { MotionEffect, MotionEvent, NodeTarget } from '@/types/motion'
 import { animePresets } from '@/lib/anime-presets'
+import { buildAnimeParamsFromStrength } from '@/lib/motion-presets'
 
 declare global {
   interface Window {
@@ -13,7 +14,7 @@ let _anime: any | null = null
 async function getAnime() {
   if (_anime) return _anime
   // ESMを動的に読み込んでSSRとバンドルの相性問題を回避
-  _anime = (await import('animejs')).default
+  _anime = (await import('animejs/lib/anime.es.js')).default
   return _anime
 }
 
@@ -50,10 +51,17 @@ export async function runMotionEffects(
         if (!el) continue
 
         const base: AnimeParams = { duration: 300, easing: 'easeInOutQuad', autoplay: true }
-        const preset = animePresets[eff.preset]?.(el) ?? {}
+
+        // ① 強度→プリセット（優先）
+        const fromStrength = buildAnimeParamsFromStrength(eff.preset as string, eff.strength)
+        // ② 旧プリセット（従来の Record ）
+        const fromLegacy = animePresets[eff.preset as any]?.(el)
+        // ③ 個別オプション（最優先）
         const opts = eff.options ?? {}
+
+        const params = { ...base, ...(fromLegacy || {}), ...(fromStrength || {}), ...opts }
         anime.remove(el)
-        anime({ targets: el, ...base, ...preset, ...opts })
+        anime({ targets: el, ...params })
       } catch (e) {
         // 個別の効果でコケても他に影響しないように
         console.error('[runMotionEffects:item]', e)

--- a/web/types/motion.ts
+++ b/web/types/motion.ts
@@ -1,8 +1,8 @@
+export type MotionEvent = 'click' | 'doubleClick' | 'mount' | 'inView'
+
 export type NodeTarget =
   | { type: 'nodeId'; value: string }
   | { type: 'css'; value: string }
-
-export type MotionEvent = 'click' | 'doubleClick' | 'mount' | 'inView'
 
 export type AnimePresetKey =
   | 'fadeIn' | 'fadeOut'
@@ -13,17 +13,20 @@ export type AnimePresetKey =
 
 export type MotionEffect = {
   id: string
-  preset: AnimePresetKey
-  runWhen: MotionEvent[]            // いつ走らせるか
-  target?: NodeTarget               // 未指定なら currentEl / 選択ノード
-  ifJson?: any                      // 既存UIの If(JSON logic) と合わせるなら
-  throttle?: number                 // ms
-  debounce?: number                 // ms
+  preset: AnimePresetKey | string
+  runWhen: MotionEvent[]
+  target?: NodeTarget
+  /** 0〜100（/dev/actions の簡易スライダで使う） */
+  strength?: number
+  /** 上書き用の生パラメータ（/dev/motion で詳細編集した結果） */
   options?: {
     duration?: number
     delay?: number
     easing?: string
     loop?: number | boolean
     direction?: 'normal' | 'reverse' | 'alternate'
+    // ほか anime.js の値（translateX など）もここに入る想定
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [k: string]: any
   }
 }


### PR DESCRIPTION
## Summary
- extend motion types with strength and preset support
- add motion preset registry and Motion Lab page
- hook runner and dev actions panel into strength presets

## Testing
- `pnpm test` *(fails: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c5795838832caf825d23e06ef3d7