### PR TITLE
feat: add motion bounce and path presets

### DIFF
--- a/web/lib/motion-presets.ts
+++ b/web/lib/motion-presets.ts
@@ -57,6 +57,63 @@ export const MOTION_PRESETS: Record<string, MotionPresetDef> = {
     },
     defaults: { duration: 200, easing: 'linear' },
   },
+  // 1) 弾む（その場で上下に減衰バウンス）
+  bounce: {
+    key: 'bounce',
+    name: 'Bounce',
+    build: (t) => {
+      const amp = lerp(6, 24, t) // 揺れ幅
+      return {
+        translateY: [
+          { value: -amp * 3, duration: 220, easing: 'easeOutCubic' },
+          { value: 0, duration: 180, easing: 'easeInCubic' },
+          { value: -amp * 1.5, duration: 160, easing: 'easeOutCubic' },
+          { value: 0, duration: 140, easing: 'easeInCubic' },
+          { value: -amp * 0.75, duration: 120, easing: 'easeOutCubic' },
+          { value: 0, duration: 100, easing: 'easeInCubic' },
+        ],
+      }
+    },
+    defaults: { duration: 920, easing: 'linear' },
+  },
+
+  // 2) バウンド（上から落下→床で数回バウンド）
+  groundBounce: {
+    key: 'groundBounce',
+    name: 'Ground bounce',
+    build: (t) => {
+      const drop = lerp(40, 180, t) // 落下距離（大きいほど上から）
+      const amp = lerp(10, 40, t) // 床でのバウンド振幅
+      return {
+        translateY: [
+          { value: [-drop, 0], duration: lerp(300, 600, t), easing: 'easeInQuad' }, // 落下
+          { value: -amp * 0.6, duration: 200, easing: 'easeOutQuad' }, // 1st up
+          { value: 0, duration: 160, easing: 'easeInQuad' }, // 1st down
+          { value: -amp * 0.3, duration: 140, easing: 'easeOutQuad' }, // 2nd up
+          { value: 0, duration: 120, easing: 'easeInQuad' }, // 2nd down
+          { value: -amp * 0.15, duration: 120, easing: 'easeOutQuad' }, // 3rd
+          { value: 0, duration: 100, easing: 'easeInQuad' },
+        ],
+      }
+    },
+    defaults: { duration: 1240, easing: 'linear' },
+  },
+
+  // 3) パスに沿って移動（SVG path を指定して移動）
+  //    options.pathSelector に CSS セレクタを渡してください
+  followPath: {
+    key: 'followPath',
+    name: 'Follow path',
+    build: (t) => ({
+      // runMotion 側で pathSelector があれば translateX/Y を path に置き換えます
+      translateX: 'path:x',
+      translateY: 'path:y',
+      // duration は強度でスピード変化（強いほど速い）
+      duration: Math.round(lerp(1800, 600, t)),
+      easing: 'linear',
+    }),
+    defaults: {},
+  },
   // 既存の scaleIn / rotateIn なども必要ならここに追加
 }
 

--- a/web/lib/runMotion.ts
+++ b/web/lib/runMotion.ts
@@ -21,14 +21,13 @@ async function getAnime() {
 const disabledByQuery = () =>
   typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('nomotion') === '1'
 
-const resolveTarget = (target: NodeTarget | undefined, fallback: HTMLElement | null) => {
+const resolveTarget = (t: NodeTarget | undefined, fb: HTMLElement | null) => {
   try {
-    if (!target) return fallback
-    if (target.type === 'css') return document.querySelector(target.value) as HTMLElement | null
-    if (target.type === 'nodeId') return document.querySelector<HTMLElement>(`[data-node-id="${target.value}"]`)
-    return fallback
+    if (!t) return fb
+    if (t.type === 'css') return document.querySelector(t.value) as HTMLElement | null
+    return document.querySelector<HTMLElement>(`[data-node-id="${t.value}"]`)
   } catch {
-    return fallback
+    return fb
   }
 }
 
@@ -52,14 +51,31 @@ export async function runMotionEffects(
 
         const base: AnimeParams = { duration: 300, easing: 'easeInOutQuad', autoplay: true }
 
-        // ① 強度→プリセット（優先）
-        const fromStrength = buildAnimeParamsFromStrength(eff.preset as string, eff.strength)
-        // ② 旧プリセット（従来の Record ）
+        // ① 強度プリセット
+        const fromStrength = buildAnimeParamsFromStrength(eff.preset, eff.strength)
+        // ② 旧来のプリセット（el 依存のものがあれば）
         const fromLegacy = animePresets[eff.preset as any]?.(el)
-        // ③ 個別オプション（最優先）
+        // ③ ユーザー上書き
         const opts = eff.options ?? {}
 
-        const params = { ...base, ...(fromLegacy || {}), ...(fromStrength || {}), ...opts }
+        const params: AnimeParams = {
+          ...base,
+          ...(fromLegacy || {}),
+          ...(fromStrength || {}),
+          ...opts,
+        }
+
+        // --- Path対応（followPath 用） ---
+        const sel: string | undefined = (opts as any).pathSelector
+        if (sel) {
+          const path = anime.path(sel)
+          const tx = (params as any).translateX
+          const ty = (params as any).translateY
+          if (tx === 'path:x' || tx == null) (params as any).translateX = path('x')
+          if (ty === 'path:y' || ty == null) (params as any).translateY = path('y')
+          if ((opts as any).followAngle) (params as any).rotate = path('angle')
+        }
+
         anime.remove(el)
         anime({ targets: el, ...params })
       } catch (e) {


### PR DESCRIPTION
## Summary
- add bounce, ground bounce, and follow path motion presets
- extend runMotion to support path-based motion and strength presets

## Testing
- `pnpm test` *(fails: ReferenceError: TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6ccc270832c911e411086876cc0