### PR TITLE
feat: add presets and preview panels

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -1,37 +1,11 @@
 'use client'
 
-import dynamic from 'next/dynamic'
-
 import TriggersCard from './TriggersCard'
 import ActionsCard from './ActionsCard'
 import EffectsCard from './EffectsCard'
 import MotionEffectsPanel from '@/components/panels/MotionEffectsPanel'
-
-const PresetsSidebar = dynamic(
-  () =>
-    import('@/components/panels/PresetsSidebar').catch(() => ({
-      default: () => (
-        <div className="rounded-2xl border bg-white p-4 text-sm text-gray-500">
-          PresetsSidebar が見つかりません。<code>components/panels/PresetsSidebar.tsx</code>
-          を用意してください。
-        </div>
-      ),
-    })),
-  { ssr: false }
-)
-
-const PreviewPane = dynamic(
-  () =>
-    import('@/components/panels/PreviewPane').catch(() => ({
-      default: () => (
-        <div className="rounded-2xl border bg-white p-4 text-sm text-gray-500">
-          PreviewPane が見つかりません。<code>components/panels/PreviewPane.tsx</code>
-          を用意してください。
-        </div>
-      ),
-    })),
-  { ssr: false }
-)
+import PresetsSidebar from '@/components/panels/PresetsSidebar'
+import PreviewPane from '@/components/panels/PreviewPane'
 
 import { builderStore, useBuilderStore } from '@/store/builderStore'
 import type { MotionEffect } from '@/types/motion'

--- a/web/components/panels/PresetsSidebar.tsx
+++ b/web/components/panels/PresetsSidebar.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+export default function PresetsSidebar() {
+  return (
+    <div className="rounded-2xl border bg-white p-4">
+      <div className="mb-2 text-sm font-medium text-gray-700">Presets</div>
+      <ul className="space-y-2 text-sm">
+        <li className="text-gray-600">Fade / Slide / Scale / Rotate</li>
+        <li className="text-gray-600">Bounce / Ground bounce</li>
+        <li className="text-gray-600">Arc zoom fade</li>
+        <li className="text-gray-600">Follow path</li>
+        <li className="text-gray-600">Card shuffle</li>
+      </ul>
+      <p className="mt-3 text-xs text-gray-500">
+        ※ ここはプリセットの目次/説明プレースホルダーです。後で選択UIに差し替えてOK。
+      </p>
+    </div>
+  )
+}

--- a/web/components/panels/PreviewPane.tsx
+++ b/web/components/panels/PreviewPane.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export default function PreviewPane() {
+  return (
+    <div className="rounded-2xl border bg-white p-4">
+      <div className="mb-2 text-sm font-medium text-gray-700">Preview</div>
+      <div className="grid h-48 place-items-center rounded-xl border bg-gradient-to-br from-gray-50 to-gray-100 text-sm text-gray-600">
+        Preview area
+      </div>
+      <p className="mt-2 text-xs text-gray-500">
+        /dev/actions では簡易プレビュー、詳細は /dev/motion を利用してください。
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add PresetsSidebar and PreviewPane components with placeholder content
- wire dev/actions page to use new components directly instead of dynamic imports

## Testing
- `pnpm -C web build` *(fails: Module not found: Package path ./lib/anime.es.js is not exported from package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8efe4e8832c8e9c1e4d61405723