### PR TITLE
Add node status configuration and hover motion effects

### DIFF
--- a/web/app/dev/actions/page.tsx
+++ b/web/app/dev/actions/page.tsx
@@ -1,11 +1,14 @@
 'use client'
 
-import TriggersCard from './TriggersCard'
+import TriggersPanel from './TriggersCard'
 import ActionsCard from './ActionsCard'
 import EffectsCard from './EffectsCard'
 import MotionEffectsPanel from '@/components/panels/MotionEffectsPanel'
 import PresetsSidebar from '@/components/panels/PresetsSidebar'
 import PreviewPane from '@/components/panels/PreviewPane'
+import NodeStatusPanel from '@/components/panels/NodeStatusPanel'
+import StatusConfigPanel from '@/components/panels/StatusConfigPanel'
+import type { NodeStatusState } from '@/types/status'
 
 import { builderStore, useBuilderStore } from '@/store/builderStore'
 import type { MotionEffect } from '@/types/motion'
@@ -27,6 +30,10 @@ export default function DevActionsPage() {
       }
     })
   }
+
+  const nodeStatus: NodeStatusState = selectedNode?.status ?? { base: 'notVisited', overlays: [] }
+  const setNodeStatus = (next: NodeStatusState) =>
+    updateSelectedNode((prev: any) => ({ ...prev, status: next }))
 
   const motion: MotionEffect[] = selectedNode?.effects?.motion ?? []
   const setMotion = (next: MotionEffect[]) =>
@@ -76,13 +83,17 @@ export default function DevActionsPage() {
           onUpdate={updatePrimary}
           openLabHref={`/dev/motion?p=${encodeURIComponent(preset)}&s=${strength}`}
         />
+        <div className="mt-4">
+          <StatusConfigPanel />
+        </div>
       </aside>
 
       {/* 中央：2×2 グリッド */}
       <main className="grid gap-4 lg:grid-cols-2">
-        {/* 左上：Triggers */}
-        <section className="rounded-2xl border bg-white p-4">
-          <TriggersCard />
+        {/* 左上：Triggers + NodeStatus */}
+        <section className="rounded-2xl border bg-white p-4 space-y-4">
+          <TriggersPanel />
+          <NodeStatusPanel value={nodeStatus} onChange={setNodeStatus} />
         </section>
         {/* 右上：Actions */}
         <section className="rounded-2xl border bg-white p-4">

--- a/web/components/interactive/InteractiveWrapper.tsx
+++ b/web/components/interactive/InteractiveWrapper.tsx
@@ -1,120 +1,25 @@
 'use client'
-import React, { useEffect, useMemo, useRef, useId } from 'react'
-import { buildInteractiveClass } from '@/lib/interactiveCSS'
-import { bindWhen, type RuntimeCtx } from '@/lib/interactiveActions'
-import type { PresetDraft } from '@/types/presets-ui'
-import { useRouter } from 'next/navigation'
 import { runMotionEffects } from '@/lib/runMotion'
+import { buildMotionFromStatus, computeBgColor } from '@/lib/status-engine'
+import type { ReactNode } from 'react'
 
-export default function InteractiveWrapper({ draft, children }:{ draft: PresetDraft; children: React.ReactNode }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const router = useRouter()
-  const id = useId()
-  const motion = (draft as any)?.motion ?? (draft as any)?.effects?.motion
-
-  // 1) Triggers → ユニーククラス作成
-  const cls = useMemo(() => {
-    const t = draft.triggers
-    // draft.effects は汎用配列なので kind を寄せて取り出す（最小）
-    const pack = (kind: string) => (draft.effects as any[]).find(e => e.kind === kind)?.value
-    const base = {
-      transitionMs: t.transitionMs,
-      easing: t.easing,
-      hover: t.hover
-        ? {
-            scale: pack('scale')?.scale,
-            rotateDeg: pack('rotate')?.deg,
-            tx: pack('translate')?.x,
-            ty: pack('translate')?.y,
-            bg: pack('bgColor')?.color,
-            shadow: pack('shadow')?.level,
-            opacity: pack('opacity')?.opacity,
-            cursor: pack('cursor')?.cursor,
-          }
-        : undefined,
-      active: t.active
-        ? {
-            scale: pack('scale')?.scale,
-            rotateDeg: pack('rotate')?.deg,
-            tx: pack('translate')?.x,
-            ty: pack('translate')?.y,
-            bg: pack('bgColor')?.color,
-            shadow: pack('shadow')?.level,
-            opacity: pack('opacity')?.opacity,
-            cursor: pack('cursor')?.cursor,
-          }
-        : undefined,
-      focus: t.focus
-        ? {
-            scale: pack('scale')?.scale,
-            rotateDeg: pack('rotate')?.deg,
-            tx: pack('translate')?.x,
-            ty: pack('translate')?.y,
-            bg: pack('bgColor')?.color,
-            shadow: pack('shadow')?.level,
-            opacity: pack('opacity')?.opacity,
-            cursor: pack('cursor')?.cursor,
-          }
-        : undefined,
-      focusWithin: t.focusWithin
-        ? {
-            scale: pack('scale')?.scale,
-            rotateDeg: pack('rotate')?.deg,
-            tx: pack('translate')?.x,
-            ty: pack('translate')?.y,
-            bg: pack('bgColor')?.color,
-            shadow: pack('shadow')?.level,
-            opacity: pack('opacity')?.opacity,
-            cursor: pack('cursor')?.cursor,
-          }
-        : undefined,
-      groupHover: t.groupHover
-        ? {
-            scale: pack('scale')?.scale,
-            rotateDeg: pack('rotate')?.deg,
-            tx: pack('translate')?.x,
-            ty: pack('translate')?.y,
-            bg: pack('bgColor')?.color,
-            shadow: pack('shadow')?.level,
-            opacity: pack('opacity')?.opacity,
-            cursor: pack('cursor')?.cursor,
-          }
-        : undefined,
-    }
-    return buildInteractiveClass(id, base as any)
-  }, [draft, id])
-
-  // 2) When → Action バインド
-  useEffect(()=>{
-    const el = ref.current; if(!el) return
-    const cleaners = draft.actions.map(a => bindWhen(
-      el,
-      a,
-      { el, data:{}, emit:(ev,p)=>window.dispatchEvent(new CustomEvent(ev,{detail:p})), navigate:(u)=>router.push(u) } as RuntimeCtx,
-      // 後方互換：もし a.when が空なら draft.when を使う
-      (draft as any).when
-    ))
-    return () => cleaners.forEach(c=>c())
-  }, [draft])
-
-  // mount
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    // ↓ 一時的に mount トリガーを止めたい場合はコメントアウト
-    // queueMicrotask(() => runMotionEffects(motion, 'mount', el))
-  }, [])
+export default function InteractiveWrapper({ node, children }:{ node:any; children: ReactNode }) {
+  const status = (node.status as import('@/types/status').NodeStatusState) ?? { base:'notVisited', overlays:[] }
+  const bg = computeBgColor(status)
+  const statusEff = buildMotionFromStatus(node.id, status)
 
   return (
     <div
-      ref={ref}
-      className={cls}
-      onClick={(e) => {
-        runMotionEffects(motion, 'click', e.currentTarget as HTMLElement)
-      }}
-      onDoubleClick={(e) => {
-        runMotionEffects(motion, 'doubleClick', e.currentTarget as HTMLElement)
-      }}
+      data-node-id={node.id}
+      style={{ backgroundColor: bg }}
+      onMouseEnter={(e)=> runMotionEffects(statusEff.hoverEnter, 'hoverEnter', e.currentTarget as HTMLElement)}
+      onMouseLeave={(e)=> { /* hoverLeave は stop 用に remove も可 */ runMotionEffects(statusEff.hoverLeave, 'hoverLeave', e.currentTarget as HTMLElement) }}
+      onClick={(e)=> runMotionEffects(node?.effects?.motion, 'click', e.currentTarget as HTMLElement)}
+      onDoubleClick={(e)=> runMotionEffects(node?.effects?.motion, 'doubleClick', e.currentTarget as HTMLElement)}
+      ref={(el)=>{ if (el) queueMicrotask(()=> {
+        runMotionEffects(statusEff.mount, 'mount', el)
+        runMotionEffects(node?.effects?.motion, 'mount', el)
+      })}}
     >
       {children}
     </div>

--- a/web/components/panels/NodeStatusPanel.tsx
+++ b/web/components/panels/NodeStatusPanel.tsx
@@ -1,0 +1,67 @@
+'use client'
+import type { BaseStatus, OverlayStatus, NodeStatusState } from '@/types/status'
+import { computeBgColor } from '@/lib/status-engine'
+
+const BASES: { key: BaseStatus; label: string }[] = [
+  { key: 'visited', label: '行った' },
+  { key: 'living', label: '住んでる' },
+  { key: 'notVisited', label: '行ってない' },
+]
+const OVS: { key: OverlayStatus; label: string }[] = [
+  { key: 'want', label: '行きたい（ブースト）' },
+  { key: 'hasPhoto', label: '写真あり（ブースト）' },
+]
+
+export default function NodeStatusPanel({
+  value,
+  onChange,
+}: {
+  value: NodeStatusState
+  onChange: (v: NodeStatusState) => void
+}) {
+  const bg = computeBgColor(value)
+
+  return (
+    <div className="rounded-2xl border bg-white p-4">
+      <div className="mb-2 text-sm font-medium text-gray-700">Status (node)</div>
+
+      <div className="mb-2 text-xs text-gray-500">ベース</div>
+      <div className="grid grid-cols-3 gap-2">
+        {BASES.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => onChange({ ...value, base: key })}
+            className={`rounded-md border px-2 py-1 text-sm ${value.base === key ? 'border-indigo-400 bg-indigo-50' : ''}`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 text-xs text-gray-500">ブースト（複数可）</div>
+      <div className="flex flex-wrap gap-2">
+        {OVS.map(({ key, label }) => {
+          const on = value.overlays.includes(key)
+          return (
+            <label key={key} className="inline-flex items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={on}
+                onChange={() => {
+                  const overlays = on ? value.overlays.filter(k => k !== key) : [...value.overlays, key]
+                  onChange({ ...value, overlays })
+                }}
+              />
+              <span>{label}</span>
+            </label>
+          )
+        })}
+      </div>
+
+      <div className="mt-4 rounded-md border p-3 text-xs">
+        <div className="mb-1 text-gray-500">プレビュー（背景色）</div>
+        <div className="h-10 rounded" style={{ backgroundColor: bg }} />
+      </div>
+    </div>
+  )
+}

--- a/web/components/panels/StatusConfigPanel.tsx
+++ b/web/components/panels/StatusConfigPanel.tsx
@@ -1,0 +1,85 @@
+'use client'
+import { useStatusConfig } from '@/stores/statusConfig'
+import type { AnyStatus } from '@/types/status'
+import { MOTION_PRESETS } from '@/lib/motion-presets'
+
+const LABEL: Record<AnyStatus, string> = {
+  visited: '行った',
+  living: '住んでる',
+  notVisited: '行ってない',
+  want: '行きたい(ブースト)',
+  hasPhoto: '写真あり(ブースト)',
+}
+
+export default function StatusConfigPanel() {
+  const { config, setStyle, reset } = useStatusConfig()
+  const keys = Object.keys(config) as AnyStatus[]
+
+  return (
+    <div className="rounded-2xl border bg-white p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-sm font-medium text-gray-700">Status settings</div>
+        <button className="text-xs text-red-500" onClick={reset}>Reset</button>
+      </div>
+
+      <div className="space-y-4">
+        {keys.map((k) => {
+          const s = config[k]
+          return (
+            <div key={k} className="rounded-lg border p-3">
+              <div className="mb-2 text-sm font-medium">{LABEL[k]}</div>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="text-xs text-gray-500">
+                  <div className="mb-1">color</div>
+                  <input type="color" value={s.color} onChange={(e) => setStyle(k, { color: e.target.value })} />
+                </label>
+
+                <label className="text-xs text-gray-500">
+                  <div className="mb-1">base preset</div>
+                  <select
+                    className="w-full"
+                    value={s.motionPreset ?? ''}
+                    onChange={(e) => setStyle(k, { motionPreset: e.target.value || undefined })}
+                  >
+                    <option value="">(none)</option>
+                    {Object.keys(MOTION_PRESETS).map(p => (
+                      <option key={p} value={p}>{MOTION_PRESETS[p].name}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="text-xs text-gray-500">
+                  <div className="mb-1">base strength</div>
+                  <input type="range" min={0} max={100}
+                    value={s.motionStrength ?? 0}
+                    onChange={(e)=> setStyle(k, { motionStrength: Number(e.target.value) })}/>
+                </label>
+
+                <label className="text-xs text-gray-500">
+                  <div className="mb-1">hover preset</div>
+                  <select
+                    className="w-full"
+                    value={s.hoverPreset ?? ''}
+                    onChange={(e) => setStyle(k, { hoverPreset: e.target.value || undefined })}
+                  >
+                    <option value="">(none)</option>
+                    {Object.keys(MOTION_PRESETS).map(p => (
+                      <option key={p} value={p}>{MOTION_PRESETS[p].name}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="text-xs text-gray-500">
+                  <div className="mb-1">hover strength</div>
+                  <input type="range" min={0} max={100}
+                    value={s.hoverStrength ?? 0}
+                    onChange={(e)=> setStyle(k, { hoverStrength: Number(e.target.value) })}/>
+                </label>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/lib/status-engine.ts
+++ b/web/lib/status-engine.ts
@@ -1,0 +1,72 @@
+import type { NodeStatusState, AnyStatus } from '@/types/status'
+import type { MotionEffect } from '@/types/motion'
+import { useStatusConfig } from '@/stores/statusConfig'
+
+/** 背景色を決定（ベース色に、オーバーレイがあれば “縁取り”など拡張も後で可） */
+export function computeBgColor(state: NodeStatusState): string {
+  const { config } = useStatusConfig.getState()
+  return config[state.base]?.color ?? '#eee'
+}
+
+/** 常時＆ホバー用の Motion を合成（オーバーレイは “追加ブースト” として上書き） */
+export function buildMotionFromStatus(nodeId: string, state: NodeStatusState): {
+  mount: MotionEffect[]
+  hoverEnter: MotionEffect[]
+  hoverLeave: MotionEffect[]
+} {
+  const { config } = useStatusConfig.getState()
+
+  const pick = (key: AnyStatus) => config[key]
+  const eff = [] as MotionEffect[]
+  const hover = [] as MotionEffect[]
+
+  // base 常時
+  const base = pick(state.base)
+  if (base.motionPreset) {
+    eff.push({
+      id: `${nodeId}-base`,
+      preset: base.motionPreset,
+      strength: base.motionStrength ?? 40,
+      runWhen: ['mount'],
+      target: { type: 'nodeId', value: nodeId },
+    })
+  }
+  if (base.hoverPreset) {
+    hover.push({
+      id: `${nodeId}-base-hover`,
+      preset: base.hoverPreset,
+      strength: base.hoverStrength ?? 30,
+      runWhen: ['hoverEnter'],
+      target: { type: 'nodeId', value: nodeId },
+    })
+  }
+
+  // overlay は加算（want = 光る、hasPhoto = 小刻み 等、上書きで強める）
+  for (const ov of state.overlays) {
+    const s = pick(ov)
+    if (s.motionPreset) {
+      eff.push({
+        id: `${nodeId}-${ov}`,
+        preset: s.motionPreset,
+        strength: s.motionStrength ?? 30,
+        runWhen: ['mount'],
+        target: { type: 'nodeId', value: nodeId },
+      })
+    }
+    if (s.hoverPreset) {
+      hover.push({
+        id: `${nodeId}-${ov}-hover`,
+        preset: s.hoverPreset,
+        strength: s.hoverStrength ?? 30,
+        runWhen: ['hoverEnter'],
+        target: { type: 'nodeId', value: nodeId },
+      })
+    }
+  }
+
+  return {
+    mount: eff,
+    hoverEnter: hover,
+    hoverLeave: [], // 必要ならここで “戻すエフェクト” を定義。今は leave で remove する運用。
+  }
+}

--- a/web/stores/statusConfig.ts
+++ b/web/stores/statusConfig.ts
@@ -1,0 +1,25 @@
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { AnyStatus, StatusStyle } from '@/types/status'
+import { DEFAULT_STATUS_CONFIG } from '@/types/status'
+
+type StatusConfigState = {
+  config: Record<AnyStatus, StatusStyle>
+  setStyle: (k: AnyStatus, patch: Partial<StatusStyle>) => void
+  reset: () => void
+}
+
+export const useStatusConfig = create<StatusConfigState>()(
+  persist(
+    (set, get) => ({
+      config: DEFAULT_STATUS_CONFIG,
+      setStyle: (k, patch) => {
+        const cur = get().config
+        set({ config: { ...cur, [k]: { ...cur[k], ...patch } } })
+      },
+      reset: () => set({ config: DEFAULT_STATUS_CONFIG }),
+    }),
+    { name: 'status-config-v1' }
+  )
+)

--- a/web/types/motion.ts
+++ b/web/types/motion.ts
@@ -1,4 +1,10 @@
-export type MotionEvent = 'click' | 'doubleClick' | 'mount' | 'inView'
+export type MotionEvent =
+  | 'click'
+  | 'doubleClick'
+  | 'mount'
+  | 'inView'
+  | 'hoverEnter'
+  | 'hoverLeave'
 
 export type NodeTarget =
   | { type: 'nodeId'; value: string }

--- a/web/types/status.ts
+++ b/web/types/status.ts
@@ -1,0 +1,29 @@
+export type BaseStatus = 'visited' | 'living' | 'notVisited'
+export type OverlayStatus = 'want' | 'hasPhoto'
+export type AnyStatus = BaseStatus | OverlayStatus
+
+export type StatusStyle = {
+  /** カードの背景色（例: #3b82f6） */
+  color: string
+  /** ベース常時エフェクト（mount 等） */
+  motionPreset?: string
+  motionStrength?: number
+  /** ホバー時のエフェクト */
+  hoverPreset?: string
+  hoverStrength?: number
+}
+
+/** グローバルの初期（ちゃぴおすすめ） */
+export const DEFAULT_STATUS_CONFIG: Record<AnyStatus, StatusStyle> = {
+  visited:   { color: '#3b82f6', motionPreset: 'fadeIn',     motionStrength: 40, hoverPreset: 'pulse', hoverStrength: 40 },
+  living:    { color: '#22c55e', motionPreset: 'slideInUp',  motionStrength: 35, hoverPreset: 'pulse', hoverStrength: 35 },
+  notVisited:{ color: '#d1d5db', motionPreset: undefined,    motionStrength: 0,  hoverPreset: 'pulse', hoverStrength: 20 },
+  want:      { color: '#eab308', motionPreset: undefined,    motionStrength: 0,  hoverPreset: 'bounce', hoverStrength: 40 },
+  hasPhoto:  { color: '#8b5cf6', motionPreset: undefined,    motionStrength: 0,  hoverPreset: 'shake',  hoverStrength: 30 },
+}
+
+/** ノードに保存する状態 */
+export type NodeStatusState = {
+  base: BaseStatus
+  overlays: OverlayStatus[] // 例: ['want','hasPhoto']
+}


### PR DESCRIPTION
## Summary
- define node status types and default styles
- add status config store and UI panels
- combine status motion effects and wire hover events

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91a2cf824832cb597b3824f2b3493