### PR TITLE
feat(map): add scrolling ribbon galleries

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -89,3 +89,13 @@
   }
 }
 
+@keyframes marquee-left {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+@keyframes marquee-right {
+  0% { transform: translateX(-50%); }
+  100% { transform: translateX(0); }
+}
+

--- a/web/app/map/[pref]/page.tsx
+++ b/web/app/map/[pref]/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+import Link from 'next/link'
+import PrefGallery from '@/components/gallery/PrefGallery'
+import type { PrefName } from '@/lib/prefectures'
+
+export default function PrefPage({ params }: { params: { pref: string } }) {
+  const pref = decodeURIComponent(params.pref) as PrefName
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">{pref}</h1>
+        <Link href="/map" className="rounded-md border px-3 py-2 text-sm">← Back to map</Link>
+      </div>
+
+      {/* 上下に流れるギャラリー */}
+      <PrefGallery pref={pref} />
+
+      <div className="text-xs text-gray-500">
+        Google Drive の「地図コレ / {pref}」に入っている写真が自動で表示されます。
+      </div>
+    </div>
+  )
+}

--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import Link from 'next/link'
 import { usePublishStore } from '@/stores/publish'
 import { buildMotionFromStatus, computeBgColor } from '@/lib/status-engine'
 import { runMotionEffects } from '@/lib/runMotion'
@@ -14,7 +15,10 @@ export default function MapPage() {
         {nodes.map((n: any) => {
           const statusEff = buildMotionFromStatus(n.id, n.status ?? { base:'notVisited', overlays:[] })
           const bg = computeBgColor(n.status ?? { base:'notVisited', overlays:[] })
-          return (
+          const label = n.title ?? n.prefecture ?? n.id
+          const href = n.prefecture ? `/map/${encodeURIComponent(n.prefecture)}` : undefined
+
+          const card = (
             <div
               key={n.id}
               data-node-id={n.id}
@@ -24,9 +28,14 @@ export default function MapPage() {
               onMouseLeave={(e)=> runMotionEffects(statusEff.hoverLeave, 'hoverLeave', e.currentTarget as HTMLElement)}
               ref={(el)=>{ if (el) queueMicrotask(()=> runMotionEffects(statusEff.mount, 'mount', el!)) }}
             >
-              {n.title ?? n.prefecture ?? n.id}
+              {label}
+              {n.prefecture && <div className="mt-1 text-[10px] text-gray-600">ギャラリーを見る →</div>}
             </div>
           )
+
+          return href ? (
+            <Link key={n.id} href={href} className="block">{card}</Link>
+          ) : card
         })}
       </div>
     </div>

--- a/web/components/gallery/PrefGallery.tsx
+++ b/web/components/gallery/PrefGallery.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import ScrollingRibbon from './ScrollingRibbon'
+import type { PrefName } from '@/lib/prefectures'
+import { listPrefImages, downloadFileBlob, ensureAuth } from '@/lib/google-drive'
+
+function usePrefObjectUrls(pref: PrefName, limit = 40) {
+  const [urls, setUrls] = useState<string[]>([])
+  const abortRef = useRef(false)
+
+  useEffect(() => {
+    abortRef.current = false
+    let revoke: string[] = []
+    ;(async () => {
+      try {
+        await ensureAuth()
+        const files = await listPrefImages(pref)
+        const pick = files.slice(0, limit)
+        const out: string[] = []
+        // 取りすぎると重いので直列/軽い並列にする
+        for (const f of pick) {
+          if (abortRef.current) break
+          const blob = await downloadFileBlob(f.id)
+          const url = URL.createObjectURL(blob)
+          revoke.push(url)
+          out.push(url)
+          if (abortRef.current) break
+          setUrls([...out]) // 漸進表示
+        }
+      } catch (e) {
+        console.error('[usePrefObjectUrls]', e)
+        setUrls([])
+      }
+    })()
+    return () => {
+      abortRef.current = true
+      revoke.forEach(u => URL.revokeObjectURL(u))
+    }
+  }, [pref, limit])
+
+  return urls
+}
+
+export default function PrefGallery({ pref }: { pref: PrefName }) {
+  const urls = usePrefObjectUrls(pref, 60)
+  const half = Math.ceil(urls.length / 2) || 1
+  const top = useMemo(() => urls.slice(0, half), [urls, half])
+  const bottom = useMemo(() => urls.slice(half), [urls, half])
+
+  return (
+    <div className="space-y-3">
+      <ScrollingRibbon images={top} direction="left" durationSec={40} height={160} />
+      <ScrollingRibbon images={bottom.length ? bottom : top} direction="right" durationSec={36} height={160} />
+    </div>
+  )
+}

--- a/web/components/gallery/ScrollingRibbon.tsx
+++ b/web/components/gallery/ScrollingRibbon.tsx
@@ -1,0 +1,59 @@
+'use client'
+import Image from 'next/image'
+
+type RibbonProps = {
+  images: string[]            // 画像URL（objectURL推奨）
+  height?: number             // px
+  durationSec?: number        // アニメ時間（長いほどゆっくり）
+  direction?: 'left' | 'right'
+  gap?: number                // 画像間ギャップpx
+  rounded?: string            // 角丸クラス（例 'rounded-xl')
+}
+
+/** 画像を2回連結して 200% 幅にし、左右に無限スクロール */
+export default function ScrollingRibbon({
+  images, height = 140, durationSec = 30, direction = 'left', gap = 8, rounded = 'rounded-lg',
+}: RibbonProps) {
+  if (!images?.length) {
+    return (
+      <div className="grid place-items-center rounded-xl border bg-white/50 p-4 text-xs text-gray-500" style={{ height }}>
+        画像がありません
+      </div>
+    )
+  }
+
+  // つなぎ目を消すために2倍化
+  const srcs = [...images, ...images]
+
+  return (
+    <div className={`relative overflow-hidden ${rounded}`} style={{ height }}>
+      <div
+        className="absolute left-0 top-0 flex"
+        style={{
+          width: '200%',
+          gap,
+          animationName: direction === 'left' ? 'marquee-left' : 'marquee-right',
+          animationDuration: `${durationSec}s`,
+          animationTimingFunction: 'linear',
+          animationIterationCount: 'infinite',
+        }}
+      >
+        {srcs.map((src, i) => (
+          <div key={i} className="relative shrink-0" style={{ height, aspectRatio: '16 / 10' }}>
+            {/* next/image を使うと自然に最適化される */}
+            <Image
+              src={src}
+              alt=""
+              fill
+              className="object-cover"
+              sizes={`${height * 2}px`}
+              priority={i < 4}
+            />
+          </div>
+        ))}
+      </div>
+      {/* 上に薄いグラデで端フェード */}
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-white/50 via-transparent to-white/50" />
+    </div>
+  )
+}

--- a/web/lib/paths.ts
+++ b/web/lib/paths.ts
@@ -1,3 +1,4 @@
+export const map = (pref: string) => `/map/${encodeURIComponent(pref)}`;
 export const s = (pe: string) => `/s/${encodeURIComponent(pe)}`;
 export const s_p = (p: string) => `/s/p/${encodeURIComponent(p)}`;
 export const u = (uid: string) => `/u/${encodeURIComponent(uid)}`;


### PR DESCRIPTION
## Summary
- add marquee keyframes for horizontal ribbon animation
- introduce `ScrollingRibbon` and `PrefGallery` components
- link prefecture map cards to new image galleries

## Testing
- `pnpm routes:gen`
- `pnpm routes:check`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91d1ab0a8832c9e8dca80b44d750b