### PR TITLE
feat: add zoom-pan canvas with draggable nodes

### DIFF
--- a/web/app/dev/arrange/page.tsx
+++ b/web/app/dev/arrange/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+import ZoomPanCanvas from '@/components/canvas/ZoomPanCanvas'
+import DraggableNode from '@/components/canvas/DraggableNode'
+import { useCanvasStore } from '@/stores/canvas'
+import { useBuilderStore } from '@/store/builderStore'
+import Link from 'next/link'
+
+const builderStore = useBuilderStore as any
+
+export default function ArrangePage() {
+  const selectedIds = useBuilderStore(s => (s as any).selectedIds)
+  const nodes = useBuilderStore(s => Object.values((s as any).nodes ?? {}))
+  const setNodePos = useCanvasStore(s => s.setNodePos)
+
+  // Builder のノードモデルに position を保存する（Publishに乗るように）
+  const commit = (id: string) => (xy: { x: number; y: number }) => {
+    builderStore.getState?.().updateNode?.(id, (prev: any) => ({ ...prev, position: xy }))
+  }
+
+  // 初期位置：ノードに position があればそれを使う
+  return (
+    <div className="space-y-3 p-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-gray-600">Arrange prefectures (Zoom / Pan / Drag)</div>
+        <div className="flex gap-2">
+          <Link href="/builder" className="rounded-md border px-3 py-2 text-sm">← Builder</Link>
+          <Link href="/map" className="rounded-md border px-3 py-2 text-sm">Open /map</Link>
+        </div>
+      </div>
+
+      <ZoomPanCanvas>
+        {/* ワールド内にノードを並べる */}
+        {nodes.map((n: any, i: number) => (
+          <DraggableNode
+            key={n.id}
+            id={n.id}
+            label={n.title ?? n.prefecture ?? `node ${i + 1}`}
+            initial={n.position ?? { x: (i % 8) * 160, y: Math.floor(i / 8) * 120 }}
+            status={n.status}
+            onCommit={commit(n.id)}
+          />
+        ))}
+      </ZoomPanCanvas>
+    </div>
+  )
+}

--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -11,19 +11,20 @@ export default function MapPage() {
   return (
     <div className="p-4">
       <div className="mb-3 text-sm text-gray-600">Published nodes: {nodes.length}</div>
-      <div className="relative grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
+      <div className="relative h-[calc(100vh-120px)] overflow-hidden rounded-2xl border bg-white">
         {nodes.map((n: any) => {
           const statusEff = buildMotionFromStatus(n.id, n.status ?? { base:'notVisited', overlays:[] })
           const bg = computeBgColor(n.status ?? { base:'notVisited', overlays:[] })
           const label = n.title ?? n.prefecture ?? n.id
           const href = n.prefecture ? `/map/${encodeURIComponent(n.prefecture)}` : undefined
+          const xy = n.position ?? { x: 0, y: 0 }
 
           const card = (
             <div
               key={n.id}
               data-node-id={n.id}
-              className="h-28 rounded-xl border p-3 text-sm"
-              style={{ backgroundColor: bg }}
+              className="h-28 w-40 rounded-xl border p-3 text-sm"
+              style={{ transform: `translate(${xy.x}px, ${xy.y}px)`, backgroundColor: bg, position: 'absolute' }}
               onMouseEnter={(e)=> runMotionEffects(statusEff.hoverEnter, 'hoverEnter', e.currentTarget as HTMLElement)}
               onMouseLeave={(e)=> runMotionEffects(statusEff.hoverLeave, 'hoverLeave', e.currentTarget as HTMLElement)}
               ref={(el)=>{ if (el) queueMicrotask(()=> runMotionEffects(statusEff.mount, 'mount', el!)) }}

--- a/web/components/canvas/DraggableNode.tsx
+++ b/web/components/canvas/DraggableNode.tsx
@@ -1,0 +1,66 @@
+'use client'
+import { useRef, useState } from 'react'
+import { useCanvasStore } from '@/stores/canvas'
+import type { XY } from '@/stores/canvas'
+import { buildMotionFromStatus, computeBgColor } from '@/lib/status-engine'
+import { runMotionEffects } from '@/lib/runMotion'
+
+export default function DraggableNode({
+  id, label, initial, status,
+  onCommit,
+}: {
+  id: string
+  label: string
+  initial?: XY
+  status?: any
+  onCommit?: (xy: XY) => void
+}) {
+  const { nodePos, setNodePos, scale } = useCanvasStore()
+  const pos = nodePos[id] ?? initial ?? { x: 0, y: 0 }
+  const [drag, setDrag] = useState<XY | null>(null)
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    e.currentTarget.setPointerCapture(e.pointerId)
+    setDrag({ x: e.clientX, y: e.clientY })
+  }
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!drag) return
+    const dx = (e.clientX - drag.x) / scale
+    const dy = (e.clientY - drag.y) / scale
+    setNodePos(id, { x: pos.x + dx, y: pos.y + dy })
+  }
+  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!drag) return
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch {}
+    setDrag(null)
+    onCommit?.(useCanvasStore.getState().nodePos[id] ?? pos)
+  }
+
+  // ステータス色とホバー演出（任意）
+  const bg = computeBgColor(status ?? { base: 'notVisited', overlays: [] })
+  const eff = buildMotionFromStatus(id, status ?? { base: 'notVisited', overlays: [] })
+
+  const setRef = (el: HTMLDivElement | null) => {
+    ref.current = el
+    if (el) queueMicrotask(() => runMotionEffects(eff.mount, 'mount', el))
+  }
+
+  return (
+    <div
+      ref={setRef}
+      className="absolute h-24 w-40 select-none rounded-xl border p-3 text-sm shadow-sm"
+      style={{ transform: `translate(${pos.x}px, ${pos.y}px)`, backgroundColor: bg, touchAction: 'none' }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onMouseEnter={(e)=> runMotionEffects(eff.hoverEnter, 'hoverEnter', e.currentTarget as HTMLElement)}
+      onMouseLeave={(e)=> runMotionEffects(eff.hoverLeave, 'hoverLeave', e.currentTarget as HTMLElement)}
+      data-node-id={id}
+    >
+      {label}
+      <div className="mt-1 text-[10px] text-gray-700/80">drag to move</div>
+    </div>
+  )
+}

--- a/web/components/canvas/ZoomPanCanvas.tsx
+++ b/web/components/canvas/ZoomPanCanvas.tsx
@@ -1,0 +1,110 @@
+'use client'
+import { useRef, useState } from 'react'
+import { useCanvasStore } from '@/stores/canvas'
+
+type Props = {
+  className?: string
+  children: React.ReactNode
+  /** キーボード: +/-= でズーム、0でリセット（デフォルトON） */
+  hotkeys?: boolean
+}
+
+export default function ZoomPanCanvas({ className, children, hotkeys = true }: Props) {
+  const { scale, tx, ty, setTransform, resetView } = useCanvasStore()
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [panning, setPanning] = useState(false)
+  const panStart = useRef<{ x: number; y: number; tx: number; ty: number } | null>(null)
+
+  // ホイールでズーム（Ctrl+wheel はOS拡大と衝突しやすいので通常wheelに割当）
+  const onWheel: React.WheelEventHandler<HTMLDivElement> = (e) => {
+    e.preventDefault()
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const mouseX = e.clientX - rect.left
+    const mouseY = e.clientY - rect.top
+
+    const delta = -e.deltaY
+    const factor = Math.exp(delta * 0.0015) // スムーズ対数ズーム
+    const newScale = Math.max(0.3, Math.min(3, scale * factor))
+
+    // ポインタ位置を軸にズーム（世界座標を保つ）
+    const wx = (mouseX - tx) / scale
+    const wy = (mouseY - ty) / scale
+    const nTx = mouseX - wx * newScale
+    const nTy = mouseY - wy * newScale
+
+    setTransform({ scale: newScale, tx: nTx, ty: nTy })
+  }
+
+  // 背景ドラッグでパン（Space押しながら、または中ボタン）
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!(e.button === 1 || e.buttons === 4 || e.shiftKey || e.altKey || e.metaKey || e.ctrlKey || e.currentTarget === e.target)) {
+      // 背景 or 修飾キーでのみパン開始（子要素ドラッグとは区別）
+      return
+    }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    panStart.current = { x: e.clientX, y: e.clientY, tx, ty }
+    setPanning(true)
+  }
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!panning || !panStart.current) return
+    const dx = e.clientX - panStart.current.x
+    const dy = e.clientY - panStart.current.y
+    setTransform({ tx: panStart.current.tx + dx, ty: panStart.current.ty + dy })
+  }
+  const endPan = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!panning) return
+    setPanning(false)
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch {}
+    panStart.current = null
+  }
+
+  // キー操作
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (!hotkeys) return
+    if (e.key === '+' || e.key === '=') {
+      const newScale = Math.min(3, scale * 1.1)
+      setTransform({ scale: newScale })
+    } else if (e.key === '-' || e.key === '_') {
+      const newScale = Math.max(0.3, scale / 1.1)
+      setTransform({ scale: newScale })
+    } else if (e.key === '0') {
+      resetView()
+    } else if (e.key === ' ') {
+      // Space でパン・カーソル変更
+      e.preventDefault()
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={`relative h-[calc(100vh-140px)] touch-none select-none overflow-hidden rounded-2xl border bg-[radial-gradient(circle_at_25px_25px,#f3f4f6_2px,transparent_0)] [background-size:50px_50px] ${className ?? ''}`}
+      tabIndex={0}
+      onWheel={onWheel}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endPan}
+      onPointerCancel={endPan}
+      onKeyDown={onKeyDown}
+      aria-label="zoom-pan-canvas"
+      style={{ cursor: panning ? 'grabbing' : 'default' }}
+    >
+      {/* ワールド：ここにノードを置く */}
+      <div
+        className="absolute left-0 top-0 origin-top-left"
+        style={{ transform: `translate(${tx}px, ${ty}px) scale(${scale})` }}
+      >
+        {children}
+      </div>
+
+      {/* ツールバー */}
+      <div className="pointer-events-auto absolute right-3 top-3 flex gap-2">
+        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => setTransform({ scale: Math.min(3, scale * 1.1) })}>＋</button>
+        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => setTransform({ scale: Math.max(0.3, scale / 1.1) })}>－</button>
+        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => resetView()}>リセット</button>
+      </div>
+    </div>
+  )
+}

--- a/web/stores/canvas.ts
+++ b/web/stores/canvas.ts
@@ -1,0 +1,30 @@
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type XY = { x: number; y: number }
+
+type CanvasState = {
+  scale: number
+  tx: number
+  ty: number
+  nodePos: Record<string, XY>
+  setTransform: (p: Partial<Pick<CanvasState, 'scale' | 'tx' | 'ty'>>) => void
+  setNodePos: (id: string, xy: XY) => void
+  resetView: () => void
+}
+
+export const useCanvasStore = create<CanvasState>()(
+  persist(
+    (set, get) => ({
+      scale: 1,
+      tx: 0,
+      ty: 0,
+      nodePos: {},
+      setTransform: (p) => set({ ...get(), ...p }),
+      setNodePos: (id, xy) => set({ nodePos: { ...get().nodePos, [id]: xy } }),
+      resetView: () => set({ scale: 1, tx: 0, ty: 0 }),
+    }),
+    { name: 'geokore-canvas-v1' }
+  )
+)


### PR DESCRIPTION
## Summary
- add Zustand canvas store for zoom, pan, and node positions
- create ZoomPanCanvas and DraggableNode components
- allow arranging nodes and rendering positions on /map

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91e1ba070832ca5546409245f63bb