### PR TITLE
feat: add multi-select canvas with grid snapping

### DIFF
--- a/web/app/dev/arrange/page.tsx
+++ b/web/app/dev/arrange/page.tsx
@@ -1,46 +1,161 @@
 'use client'
 import ZoomPanCanvas from '@/components/canvas/ZoomPanCanvas'
 import DraggableNode from '@/components/canvas/DraggableNode'
+import SelectionMarquee from '@/components/canvas/SelectionMarquee'
 import { useCanvasStore } from '@/stores/canvas'
-import { useBuilderStore } from '@/store/builderStore'
+import { useBuilderStore } from '@/store/builderStore' // adjust to existing path
 import Link from 'next/link'
+import { useEffect, useRef } from 'react'
 
 const builderStore = useBuilderStore as any
 
 export default function ArrangePage() {
-  const selectedIds = useBuilderStore(s => (s as any).selectedIds)
   const nodes = useBuilderStore(s => Object.values((s as any).nodes ?? {}))
-  const setNodePos = useCanvasStore(s => s.setNodePos)
+  const selectedIds = useCanvasStore(s => s.selectedIds)
+  const { nodePos, setNodePos, moveNodes, snapEnabled, gridSize, snapThreshold } = useCanvasStore()
+  const setSelectedIds = useCanvasStore(s => s.setSelectedIds)
+  const setTransform = useCanvasStore(s => s.setTransform)
 
-  // Builder のノードモデルに position を保存する（Publishに乗るように）
-  const commit = (id: string) => (xy: { x: number; y: number }) => {
-    builderStore.getState?.().updateNode?.(id, (prev: any) => ({ ...prev, position: xy }))
+  // キーボード微調整
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!selectedIds.length) return
+      const step = e.shiftKey ? 10 : 1
+      if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.key)) e.preventDefault()
+      if (e.key === 'ArrowLeft') moveNodes(selectedIds, -step, 0)
+      if (e.key === 'ArrowRight') moveNodes(selectedIds, step, 0)
+      if (e.key === 'ArrowUp') moveNodes(selectedIds, 0, -step)
+      if (e.key === 'ArrowDown') moveNodes(selectedIds, 0, step)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [selectedIds])
+
+  // 整列・等間隔
+  const align = (dir: 'left'|'right'|'top'|'bottom'|'hcenter'|'vcenter') => {
+    const sels = nodes.filter((n: any) => selectedIds.includes(n.id))
+    if (sels.length < 2) return
+    const pos = (id: string) => nodePos[id] ?? { x: 0, y: 0 }
+    const size = { w: 160, h: 96 }
+
+    const xs = sels.map((n: any) => pos(n.id).x)
+    const ys = sels.map((n: any) => pos(n.id).y)
+
+    const minX = Math.min(...xs), maxX = Math.max(...xs)
+    const minY = Math.min(...ys), maxY = Math.max(...ys)
+
+    sels.forEach((n: any) => {
+      const p = pos(n.id)
+      if (dir === 'left') setNodePos(n.id, { x: minX, y: p.y })
+      if (dir === 'right') setNodePos(n.id, { x: maxX, y: p.y })
+      if (dir === 'top') setNodePos(n.id, { x: p.x, y: minY })
+      if (dir === 'bottom') setNodePos(n.id, { x: p.x, y: maxY })
+      if (dir === 'hcenter') setNodePos(n.id, { x: (minX + maxX)/2, y: p.y })
+      if (dir === 'vcenter') setNodePos(n.id, { x: p.x, y: (minY + maxY)/2 })
+    })
   }
 
-  // 初期位置：ノードに position があればそれを使う
+  const distribute = (axis: 'h'|'v') => {
+    const sels = nodes.filter((n: any) => selectedIds.includes(n.id))
+    if (sels.length < 3) return
+    const pos = (id: string) => nodePos[id] ?? { x: 0, y: 0 }
+    const sorted = [...sels].sort((a: any,b: any)=> axis==='h' ? pos(a.id).x - pos(b.id).x : pos(a.id).y - pos(b.id).y)
+    const coords = sorted.map((n: any) => axis==='h' ? pos(n.id).x : pos(n.id).y)
+    const min = coords[0], max = coords[coords.length-1]
+    const step = (max - min) / (coords.length - 1)
+    sorted.forEach((n: any, i: number) => {
+      const p = pos(n.id)
+      if (axis==='h') setNodePos(n.id, { x: Math.round(min + step*i), y: p.y })
+      else setNodePos(n.id, { x: p.x, y: Math.round(min + step*i) })
+    })
+  }
+
+  // Fit-to-Content：全ノードの外接矩形をビューポートにフィット
+  const fitRef = useRef<HTMLDivElement | null>(null)
+  const onFit = () => {
+    const el = fitRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const padding = 40
+    const positions = nodes.map((n: any) => nodePos[n.id] ?? n.position ?? { x: 0, y: 0 })
+    if (!positions.length) return
+    const xs = positions.map((p: any) => p.x)
+    const ys = positions.map((p: any) => p.y)
+    const minX = Math.min(...xs), maxX = Math.max(...xs)
+    const minY = Math.min(...ys), maxY = Math.max(...ys)
+    const contentW = (maxX - minX) + 160 /*仮の幅*/
+    const contentH = (maxY - minY) + 96  /*仮の高*/
+    const scaleX = (rect.width - padding*2) / contentW
+    const scaleY = (rect.height - padding*2) / contentH
+    const scale = Math.max(0.3, Math.min(3, Math.min(scaleX, scaleY)))
+    const tx = (rect.width - contentW*scale)/2 - minX*scale
+    const ty = (rect.height - contentH*scale)/2 - minY*scale
+    setTransform({ scale, tx, ty })
+  }
+
+  // Builder に位置を反映
+  const savePositionsToBuilder = () => {
+    for (const n of nodes as any[]) {
+      const p = nodePos[n.id]
+      if (p) builderStore.getState().updateNode?.(n.id, (prev: any) => ({ ...prev, position: p }))
+    }
+  }
+
   return (
     <div className="space-y-3 p-4">
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-gray-600">Arrange prefectures (Zoom / Pan / Drag)</div>
-        <div className="flex gap-2">
-          <Link href="/builder" className="rounded-md border px-3 py-2 text-sm">← Builder</Link>
-          <Link href="/map" className="rounded-md border px-3 py-2 text-sm">Open /map</Link>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm text-gray-600">Arrange prefectures (Zoom / Pan / Drag / Select)</div>
+        <div className="flex flex-wrap items-center gap-2">
+          {/* 整列 */}
+          <div className="flex items-center gap-1">
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>align('left')}>⟸ 左揃え</button>
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>align('hcenter')}>┼ 中央(横)</button>
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>align('right')}>右揃え ⟹</button>
+          </div>
+          <div className="flex items-center gap-1">
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>align('top')}>⟰ 上揃え</button>
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>align('vcenter')}>┼ 中央(縦)</button>
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>align('bottom')}>下揃え ⟱</button>
+          </div>
+          {/* 等間隔 */}
+          <div className="flex items-center gap-1">
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>distribute('h')}>等間隔(横)</button>
+            <button className="rounded-md border px-2 py-1 text-sm" onClick={()=>distribute('v')}>等間隔(縦)</button>
+          </div>
+          {/* スナップ */}
+          <label className="ml-2 inline-flex items-center gap-2 text-xs text-gray-600">
+            <input
+              type="checkbox"
+              checked={snapEnabled}
+              onChange={(e)=> useCanvasStore.setState({ snapEnabled: e.target.checked })}
+            />
+            Grid Snap
+          </label>
+
+          <button className="rounded-md border px-2 py-1 text-sm" onClick={savePositionsToBuilder}>位置を保存</button>
+          <Link href="/builder" className="rounded-md border px-3 py-1 text-sm">← Builder</Link>
+          <Link href="/map" className="rounded-md border px-3 py-1 text-sm">Open /map</Link>
         </div>
       </div>
 
-      <ZoomPanCanvas>
-        {/* ワールド内にノードを並べる */}
-        {nodes.map((n: any, i: number) => (
-          <DraggableNode
-            key={n.id}
-            id={n.id}
-            label={n.title ?? n.prefecture ?? `node ${i + 1}`}
-            initial={n.position ?? { x: (i % 8) * 160, y: Math.floor(i / 8) * 120 }}
-            status={n.status}
-            onCommit={commit(n.id)}
-          />
-        ))}
-      </ZoomPanCanvas>
+      <div ref={fitRef}>
+        <ZoomPanCanvas onFitRequest={onFit}>
+          {/* 背景マーキー（範囲選択） */}
+          <SelectionMarquee nodes={nodes as any[]} />
+
+          {/* ノード群 */}
+          {nodes.map((n: any, i: number) => (
+            <DraggableNode
+              key={n.id}
+              id={n.id}
+              label={n.title ?? n.prefecture ?? `node ${i + 1}`}
+              initial={n.position ?? { x: (i % 8) * 160, y: Math.floor(i / 8) * 120 }}
+              status={n.status}
+              onCommit={(xy)=> builderStore.getState().updateNode?.(n.id, (prev: any) => ({ ...prev, position: xy })) }
+            />
+          ))}
+        </ZoomPanCanvas>
+      </div>
     </div>
   )
 }

--- a/web/components/canvas/DraggableNode.tsx
+++ b/web/components/canvas/DraggableNode.tsx
@@ -2,65 +2,87 @@
 import { useRef, useState } from 'react'
 import { useCanvasStore } from '@/stores/canvas'
 import type { XY } from '@/stores/canvas'
+import { snapToGrid } from '@/lib/snap'
 import { buildMotionFromStatus, computeBgColor } from '@/lib/status-engine'
 import { runMotionEffects } from '@/lib/runMotion'
 
 export default function DraggableNode({
-  id, label, initial, status,
-  onCommit,
+  id, label, initial, status, size = { w: 160, h: 96 }, onCommit,
 }: {
   id: string
   label: string
   initial?: XY
   status?: any
+  size?: { w: number; h: number }
   onCommit?: (xy: XY) => void
 }) {
-  const { nodePos, setNodePos, scale } = useCanvasStore()
+  const { nodePos, setNodePos, moveNodes, scale, selectedIds, toggleSelect, snapEnabled, gridSize, snapThreshold } = useCanvasStore()
   const pos = nodePos[id] ?? initial ?? { x: 0, y: 0 }
-  const [drag, setDrag] = useState<XY | null>(null)
-  const ref = useRef<HTMLDivElement | null>(null)
+  const selected = selectedIds.includes(id)
+  const [dragStart, setDragStart] = useState<{ x: number; y: number; base: XY } | null>(null)
 
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
     e.currentTarget.setPointerCapture(e.pointerId)
-    setDrag({ x: e.clientX, y: e.clientY })
-  }
-  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    if (!drag) return
-    const dx = (e.clientX - drag.x) / scale
-    const dy = (e.clientY - drag.y) / scale
-    setNodePos(id, { x: pos.x + dx, y: pos.y + dy })
-  }
-  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    if (!drag) return
-    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch {}
-    setDrag(null)
-    onCommit?.(useCanvasStore.getState().nodePos[id] ?? pos)
+    const multi = e.metaKey || e.ctrlKey
+    toggleSelect(id, multi)
+    setDragStart({ x: e.clientX, y: e.clientY, base: pos })
   }
 
-  // ステータス色とホバー演出（任意）
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!dragStart) return
+    const dx = (e.clientX - dragStart.x) / scale
+    const dy = (e.clientY - dragStart.y) / scale
+
+    // 単体ドラッグ → グリッドスナップ
+    if (selectedIds.length <= 1) {
+      const raw = { x: dragStart.base.x + dx, y: dragStart.base.y + dy }
+      const next = snapEnabled ? snapToGrid(raw, gridSize, snapThreshold) : raw
+      setNodePos(id, next)
+    } else {
+      // 複数選択 → 相対移動（スナップは最後の確定時に委ねる）
+      moveNodes(selectedIds, dx, dy)
+      setDragStart({ ...dragStart, x: e.clientX, y: e.clientY })
+    }
+  }
+
+  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!dragStart) return
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch {}
+    setDragStart(null)
+
+    // 複数移動の最終スナップ（代表だけスナップ→相対差分を全体適用）
+    if (selectedIds.length > 1) {
+      const rep = useCanvasStore.getState().nodePos[id] ?? pos
+      const snapped = snapEnabled ? snapToGrid(rep, gridSize, snapThreshold) : rep
+      const ddx = snapped.x - rep.x
+      const ddy = snapped.y - rep.y
+      if (ddx || ddy) useCanvasStore.getState().moveNodes(selectedIds, ddx, ddy)
+      // Commit は代表のみ呼ぶ（任意）
+      onCommit?.(snapped)
+    } else {
+      const cur = useCanvasStore.getState().nodePos[id] ?? pos
+      onCommit?.(cur)
+    }
+  }
+
   const bg = computeBgColor(status ?? { base: 'notVisited', overlays: [] })
   const eff = buildMotionFromStatus(id, status ?? { base: 'notVisited', overlays: [] })
 
-  const setRef = (el: HTMLDivElement | null) => {
-    ref.current = el
-    if (el) queueMicrotask(() => runMotionEffects(eff.mount, 'mount', el))
-  }
-
   return (
     <div
-      ref={setRef}
-      className="absolute h-24 w-40 select-none rounded-xl border p-3 text-sm shadow-sm"
-      style={{ transform: `translate(${pos.x}px, ${pos.y}px)`, backgroundColor: bg, touchAction: 'none' }}
+      className={`absolute select-none rounded-xl border p-3 text-sm shadow-sm ${selected ? 'ring-2 ring-indigo-400' : ''}`}
+      style={{ width: size.w, height: size.h, transform: `translate(${pos.x}px, ${pos.y}px)`, backgroundColor: bg, touchAction: 'none' }}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       onMouseEnter={(e)=> runMotionEffects(eff.hoverEnter, 'hoverEnter', e.currentTarget as HTMLElement)}
       onMouseLeave={(e)=> runMotionEffects(eff.hoverLeave, 'hoverLeave', e.currentTarget as HTMLElement)}
+      ref={(el)=>{ if (el) queueMicrotask(()=> el && runMotionEffects(eff.mount, 'mount', el)) }}
       data-node-id={id}
     >
       {label}
-      <div className="mt-1 text-[10px] text-gray-700/80">drag to move</div>
+      <div className="mt-1 text-[10px] text-gray-700/80">{selected ? 'multi-drag: OK / ⌘(Ctrl)+Click: toggle' : 'drag to move'}</div>
     </div>
   )
 }

--- a/web/components/canvas/SelectionMarquee.tsx
+++ b/web/components/canvas/SelectionMarquee.tsx
@@ -1,0 +1,63 @@
+'use client'
+import { useRef, useState } from 'react'
+import { useCanvasStore } from '@/stores/canvas'
+
+type NodeBox = { id: string; x: number; y: number; w: number; h: number }
+
+export default function SelectionMarquee({
+  nodes, size = { w: 160, h: 96 },
+}: {
+  nodes: Array<{ id: string; position?: { x: number; y: number } }>
+  size?: { w: number; h: number }
+}) {
+  const { scale, tx, ty, nodePos, setSelectedIds, clearSelection } = useCanvasStore()
+  const [rect, setRect] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
+  const start = useRef<{ sx: number; sy: number } | null>(null)
+
+  const screenToWorld = (sx: number, sy: number) => ({ x: (sx - tx) / scale, y: (sy - ty) / scale })
+
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    // 背景でドラッグ開始（子要素のドラッグは DraggableNode 側が処理）
+    if (e.currentTarget !== e.target) return
+    e.currentTarget.setPointerCapture(e.pointerId)
+    start.current = { sx: e.clientX, sy: e.clientY }
+    setRect({ x: e.clientX, y: e.clientY, w: 0, h: 0 })
+    clearSelection()
+  }
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!start.current) return
+    const w = e.clientX - start.current.sx
+    const h = e.clientY - start.current.sy
+    setRect({ x: Math.min(start.current.sx, e.clientX), y: Math.min(start.current.sy, e.clientY), w: Math.abs(w), h: Math.abs(h) })
+
+    // ヒットテスト
+    const r1 = { x: rect?.x ?? start.current.sx, y: rect?.y ?? start.current.sy, w: rect?.w ?? 0, h: rect?.h ?? 0 }
+    const worldMin = screenToWorld(r1.x, r1.y)
+    const worldMax = screenToWorld(r1.x + r1.w, r1.y + r1.h)
+    const sel: string[] = []
+    for (const n of nodes) {
+      const p = (nodePos[n.id] ?? n.position ?? { x: 0, y: 0 })
+      const nb = { x: p.x, y: p.y, w: size.w, h: size.h }
+      const hit = nb.x < worldMax.x && nb.x + nb.w > worldMin.x && nb.y < worldMax.y && nb.y + nb.h > worldMin.y
+      if (hit) sel.push(n.id)
+    }
+    setSelectedIds(sel)
+  }
+  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!start.current) return
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch {}
+    start.current = null
+    setRect(null)
+  }
+
+  return (
+    <div className="absolute inset-0" onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} onPointerCancel={onPointerUp}>
+      {rect && (
+        <div
+          className="pointer-events-none absolute rounded border border-indigo-400/70 bg-indigo-400/10"
+          style={{ left: rect.x, top: rect.y, width: rect.w, height: rect.h }}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/components/canvas/ZoomPanCanvas.tsx
+++ b/web/components/canvas/ZoomPanCanvas.tsx
@@ -5,17 +5,16 @@ import { useCanvasStore } from '@/stores/canvas'
 type Props = {
   className?: string
   children: React.ReactNode
-  /** キーボード: +/-= でズーム、0でリセット（デフォルトON） */
   hotkeys?: boolean
+  onFitRequest?: () => void   // ★ 追加：外からFit実行
 }
 
-export default function ZoomPanCanvas({ className, children, hotkeys = true }: Props) {
-  const { scale, tx, ty, setTransform, resetView } = useCanvasStore()
+export default function ZoomPanCanvas({ className, children, hotkeys = true, onFitRequest }: Props) {
+  const { scale, tx, ty, setTransform, resetView, snapEnabled } = useCanvasStore()
   const ref = useRef<HTMLDivElement | null>(null)
   const [panning, setPanning] = useState(false)
   const panStart = useRef<{ x: number; y: number; tx: number; ty: number } | null>(null)
 
-  // ホイールでズーム（Ctrl+wheel はOS拡大と衝突しやすいので通常wheelに割当）
   const onWheel: React.WheelEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault()
     const el = ref.current
@@ -23,26 +22,18 @@ export default function ZoomPanCanvas({ className, children, hotkeys = true }: P
     const rect = el.getBoundingClientRect()
     const mouseX = e.clientX - rect.left
     const mouseY = e.clientY - rect.top
-
     const delta = -e.deltaY
-    const factor = Math.exp(delta * 0.0015) // スムーズ対数ズーム
+    const factor = Math.exp(delta * 0.0015)
     const newScale = Math.max(0.3, Math.min(3, scale * factor))
-
-    // ポインタ位置を軸にズーム（世界座標を保つ）
     const wx = (mouseX - tx) / scale
     const wy = (mouseY - ty) / scale
     const nTx = mouseX - wx * newScale
     const nTy = mouseY - wy * newScale
-
     setTransform({ scale: newScale, tx: nTx, ty: nTy })
   }
 
-  // 背景ドラッグでパン（Space押しながら、または中ボタン）
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    if (!(e.button === 1 || e.buttons === 4 || e.shiftKey || e.altKey || e.metaKey || e.ctrlKey || e.currentTarget === e.target)) {
-      // 背景 or 修飾キーでのみパン開始（子要素ドラッグとは区別）
-      return
-    }
+    if (!(e.button === 1 || e.buttons === 4 || e.shiftKey || e.altKey || e.metaKey || e.ctrlKey || e.currentTarget === e.target)) return
     e.currentTarget.setPointerCapture(e.pointerId)
     panStart.current = { x: e.clientX, y: e.clientY, tx, ty }
     setPanning(true)
@@ -60,27 +51,17 @@ export default function ZoomPanCanvas({ className, children, hotkeys = true }: P
     panStart.current = null
   }
 
-  // キー操作
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
     if (!hotkeys) return
-    if (e.key === '+' || e.key === '=') {
-      const newScale = Math.min(3, scale * 1.1)
-      setTransform({ scale: newScale })
-    } else if (e.key === '-' || e.key === '_') {
-      const newScale = Math.max(0.3, scale / 1.1)
-      setTransform({ scale: newScale })
-    } else if (e.key === '0') {
-      resetView()
-    } else if (e.key === ' ') {
-      // Space でパン・カーソル変更
-      e.preventDefault()
-    }
+    if (e.key === '+' || e.key === '=' ) setTransform({ scale: Math.min(3, scale * 1.1) })
+    else if (e.key === '-' || e.key === '_') setTransform({ scale: Math.max(0.3, scale / 1.1) })
+    else if (e.key === '0') resetView()
   }
 
   return (
     <div
       ref={ref}
-      className={`relative h-[calc(100vh-140px)] touch-none select-none overflow-hidden rounded-2xl border bg-[radial-gradient(circle_at_25px_25px,#f3f4f6_2px,transparent_0)] [background-size:50px_50px] ${className ?? ''}`}
+      className={`relative h-[calc(100vh-140px)] touch-none select-none overflow-hidden rounded-2xl border ${className ?? ''}`}
       tabIndex={0}
       onWheel={onWheel}
       onPointerDown={onPointerDown}
@@ -89,21 +70,23 @@ export default function ZoomPanCanvas({ className, children, hotkeys = true }: P
       onPointerCancel={endPan}
       onKeyDown={onKeyDown}
       aria-label="zoom-pan-canvas"
-      style={{ cursor: panning ? 'grabbing' : 'default' }}
+      style={{
+        cursor: panning ? 'grabbing' : 'default',
+        backgroundImage: 'radial-gradient(circle at 25px 25px,#f3f4f6 2px,transparent 0)',
+        backgroundSize: snapEnabled ? '50px 50px' : '0 0',
+      }}
     >
-      {/* ワールド：ここにノードを置く */}
-      <div
-        className="absolute left-0 top-0 origin-top-left"
-        style={{ transform: `translate(${tx}px, ${ty}px) scale(${scale})` }}
-      >
+      <div className="absolute left-0 top-0 origin-top-left" style={{ transform: `translate(${tx}px, ${ty}px) scale(${scale})` }}>
         {children}
       </div>
 
-      {/* ツールバー */}
       <div className="pointer-events-auto absolute right-3 top-3 flex gap-2">
-        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => setTransform({ scale: Math.min(3, scale * 1.1) })}>＋</button>
-        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => setTransform({ scale: Math.max(0.3, scale / 1.1) })}>－</button>
-        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => resetView()}>リセット</button>
+        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => useCanvasStore.getState().setTransform({ scale: Math.min(3, scale * 1.1) })}>＋</button>
+        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => useCanvasStore.getState().setTransform({ scale: Math.max(0.3, scale / 1.1) })}>－</button>
+        <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={() => useCanvasStore.getState().resetView()}>リセット</button>
+        {!!onFitRequest && (
+          <button className="rounded-md border bg-white/90 px-3 py-1 text-sm shadow" onClick={onFitRequest}>Fit</button>
+        )}
       </div>
     </div>
   )

--- a/web/lib/snap.ts
+++ b/web/lib/snap.ts
@@ -1,0 +1,11 @@
+import type { XY } from '@/stores/canvas'
+
+export function snapToGrid(xy: XY, grid = 20, threshold = 6): XY {
+  const snap = (v: number) => {
+    const g = Math.round(v / grid) * grid
+    return Math.abs(g - v) <= threshold ? g : v
+  }
+  const nx = snap(xy.x)
+  const ny = snap(xy.y)
+  return { x: nx, y: ny }
+}

--- a/web/stores/canvas.ts
+++ b/web/stores/canvas.ts
@@ -9,8 +9,21 @@ type CanvasState = {
   tx: number
   ty: number
   nodePos: Record<string, XY>
+
+  // 選択
+  selectedIds: string[]
+  setSelectedIds: (ids: string[]) => void
+  toggleSelect: (id: string, multi?: boolean) => void
+  clearSelection: () => void
+
+  // スナップ設定
+  snapEnabled: boolean
+  gridSize: number
+  snapThreshold: number
+
   setTransform: (p: Partial<Pick<CanvasState, 'scale' | 'tx' | 'ty'>>) => void
   setNodePos: (id: string, xy: XY) => void
+  moveNodes: (ids: string[], dx: number, dy: number) => void
   resetView: () => void
 }
 
@@ -21,10 +34,36 @@ export const useCanvasStore = create<CanvasState>()(
       tx: 0,
       ty: 0,
       nodePos: {},
+
+      selectedIds: [],
+      setSelectedIds: (ids) => set({ selectedIds: ids }),
+      toggleSelect: (id, multi) => {
+        const cur = get().selectedIds
+        const has = cur.includes(id)
+        if (multi) {
+          set({ selectedIds: has ? cur.filter(x => x !== id) : [...cur, id] })
+        } else {
+          set({ selectedIds: has ? [] : [id] })
+        }
+      },
+      clearSelection: () => set({ selectedIds: [] }),
+
+      snapEnabled: true,
+      gridSize: 20,
+      snapThreshold: 6,
+
       setTransform: (p) => set({ ...get(), ...p }),
       setNodePos: (id, xy) => set({ nodePos: { ...get().nodePos, [id]: xy } }),
+      moveNodes: (ids, dx, dy) => {
+        const next = { ...get().nodePos }
+        for (const id of ids) {
+          const cur = next[id] ?? { x: 0, y: 0 }
+          next[id] = { x: cur.x + dx, y: cur.y + dy }
+        }
+        set({ nodePos: next })
+      },
       resetView: () => set({ scale: 1, tx: 0, ty: 0 }),
     }),
-    { name: 'geokore-canvas-v1' }
+    { name: 'geokore-canvas-v2' }
   )
 )


### PR DESCRIPTION
## Summary
- extend canvas store with selection state and snap settings
- add grid snap util and marquee selection component
- support fit-to-content and group dragging in arrange dev page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b924363d98832c93dd9caed3b6e196