### PR TITLE
fix: use builder store APIs and restore drag baseline

### DIFF
--- a/web/app/dev/arrange/page.tsx
+++ b/web/app/dev/arrange/page.tsx
@@ -11,7 +11,7 @@ import { useRef } from 'react'
 export default function ArrangePage() {
   const nodes = useBuilderStore(s => Object.values(s.nodes ?? {}))
   const selectedIds = useCanvasStore(s => s.selectedIds)
-  const { nodePos } = useCanvasStore()
+  const { nodePos, nodeSize } = useCanvasStore()
   const setTransform = useCanvasStore(s => s.setTransform)
 
   // 矢印キーは前ステップのまま…
@@ -19,21 +19,19 @@ export default function ArrangePage() {
   // レイヤー操作
   const bringToFront = () => {
     if (!selectedIds.length) return
-    const maxZ = Math.max(0, ...nodes.map(n => n.z ?? 0))
     for (const id of selectedIds) {
-      builderStore.getState().updateNode(id, (prev:any)=> ({ ...prev, z: maxZ + 1 }))
+      builderStore.getState().bringToFront(id)
     }
   }
   const sendToBack = () => {
     if (!selectedIds.length) return
-    const minZ = Math.min(0, ...nodes.map(n => n.z ?? 0))
     for (const id of selectedIds) {
-      builderStore.getState().updateNode(id, (prev:any)=> ({ ...prev, z: minZ - 1 }))
+      builderStore.getState().sendToBack(id)
     }
   }
   const lockToggle = (lock: boolean) => {
     for (const id of selectedIds) {
-      builderStore.getState().updateNode(id, (prev:any)=> ({ ...prev, locked: lock }))
+      builderStore.getState().setLocked(id, lock)
     }
   }
 
@@ -60,13 +58,12 @@ export default function ArrangePage() {
   }
 
   const savePositionsToBuilder = () => {
+    const store = builderStore.getState()
     for (const n of nodes) {
       const p = nodePos[n.id]
-      if (p) builderStore.getState().updateNode(n.id, (prev: any) => ({
-        ...prev,
-        position: p,
-        size: prev.size ?? { w: 160, h: 96 }, // 既存に無ければ初期値
-      }))
+      const s = nodeSize[n.id]
+      if (p) store.move(n.id, p)
+      if (s) store.resize(n.id, s)
     }
   }
 
@@ -104,7 +101,11 @@ export default function ArrangePage() {
               size={n.size ?? { w: 160, h: 96 }}
               z={n.z ?? 0}
               locked={!!n.locked}
-              onCommit={(xy, sz)=> builderStore.getState().updateNode(n.id, (prev:any)=> ({ ...prev, position: xy, size: sz ?? prev.size })) }
+              onCommit={(xy, sz)=> {
+                const st = builderStore.getState()
+                st.move(n.id, xy)
+                if (sz) st.resize(n.id, sz)
+              }}
             />
           ))}
         </ZoomPanCanvas>

--- a/web/components/canvas/DraggableNode.tsx
+++ b/web/components/canvas/DraggableNode.tsx
@@ -24,7 +24,7 @@ export default function DraggableNode({
   const {
     nodePos, setNodePos, moveNodes, nodeSize, setNodeSize, scale,
     selectedIds, toggleSelect, snapEnabled, gridSize, snapThreshold,
-    setGuides, clearGuides,
+    setGuides, clearGuides, clearInitialPos,
   } = useCanvasStore()
 
   // サイズをストアに同期（ガイド用）
@@ -89,6 +89,7 @@ export default function DraggableNode({
       setResizing(null)
       clearGuides()
       onCommit?.(useCanvasStore.getState().nodePos[id] ?? pos, useCanvasStore.getState().nodeSize[id] ?? curSize)
+      clearInitialPos()
       return
     }
     if (!dragStart) return
@@ -96,6 +97,7 @@ export default function DraggableNode({
     clearGuides()
     const cur = useCanvasStore.getState().nodePos[id] ?? pos
     onCommit?.(cur, useCanvasStore.getState().nodeSize[id] ?? curSize)
+    clearInitialPos()
   }
 
   // リサイズハンドル

--- a/web/stores/canvas.ts
+++ b/web/stores/canvas.ts
@@ -1,6 +1,7 @@
 'use client'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { builderStore } from '@/stores/builder'
 
 export type XY = { x: number; y: number }
 export type Size = { w: number; h: number }
@@ -11,6 +12,7 @@ type CanvasState = {
   ty: number
   nodePos: Record<string, XY>
   nodeSize: Record<string, Size>
+  initialPos: Record<string, XY>
 
   // 選択
   selectedIds: string[]
@@ -32,6 +34,7 @@ type CanvasState = {
   setTransform: (p: Partial<Pick<CanvasState, 'scale' | 'tx' | 'ty'>>) => void
   setNodePos: (id: string, xy: XY) => void
   moveNodes: (ids: string[], dx: number, dy: number) => void
+  clearInitialPos: () => void
   setNodeSize: (id: string, sz: Size) => void
   resetView: () => void
 }
@@ -42,6 +45,7 @@ export const useCanvasStore = create<CanvasState>()(
       scale: 1, tx: 0, ty: 0,
       nodePos: {},
       nodeSize: {},
+      initialPos: {},
 
       selectedIds: [],
       setSelectedIds: (ids) => set({ selectedIds: ids }),
@@ -65,12 +69,23 @@ export const useCanvasStore = create<CanvasState>()(
       setNodePos: (id, xy) => set({ nodePos: { ...get().nodePos, [id]: xy } }),
       moveNodes: (ids, dx, dy) => {
         const next = { ...get().nodePos }
+        const base = { ...get().initialPos }
+        const b = builderStore.getState() as any
         for (const id of ids) {
-          const cur = next[id] ?? { x: 0, y: 0 }
-          next[id] = { x: cur.x + dx, y: cur.y + dy }
+          if (!base[id]) {
+            const p = next[id]
+              ?? b.nodes?.[id]?.position
+              ?? (() => {
+                const el = b.elements?.find((e: any) => e.id === id)
+                return el ? { x: el.x, y: el.y } : { x: 0, y: 0 }
+              })()
+            base[id] = p
+          }
+          next[id] = { x: base[id].x + dx, y: base[id].y + dy }
         }
-        set({ nodePos: next })
+        set({ nodePos: next, initialPos: base })
       },
+      clearInitialPos: () => set({ initialPos: {} }),
       setNodeSize: (id, sz) => set({ nodeSize: { ...get().nodeSize, [id]: sz } }),
       resetView: () => set({ scale: 1, tx: 0, ty: 0 }),
     }),


### PR DESCRIPTION
## Summary
- replace undefined `updateNode` calls with existing builder store actions
- persist initial positions to prevent multi-node drag from jumping

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94ef9d598832cbd3c4fd8ee86fef0