### PR TITLE
feat: add canvas history and group selection

### DIFF
--- a/web/app/dev/arrange/page.tsx
+++ b/web/app/dev/arrange/page.tsx
@@ -5,20 +5,23 @@ import SelectionMarquee from '@/components/canvas/SelectionMarquee'
 import SmartGuides from '@/components/canvas/SmartGuides'
 import { useCanvasStore } from '@/stores/canvas'
 import { useBuilderStore, builderStore } from '@/stores/builder'
+import { useHistoryStore } from '@/stores/history'
 import Link from 'next/link'
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 
 export default function ArrangePage() {
   const nodes = useBuilderStore(s => Object.values(s.nodes ?? {}))
   const selectedIds = useCanvasStore(s => s.selectedIds)
-  const { nodePos } = useCanvasStore()
+  const { nodePos, createGroup, ungroup, memberOf, groups, groupSelectEnabled, setGroupSelectEnabled } = useCanvasStore()
   const setTransform = useCanvasStore(s => s.setTransform)
+  const { canUndo, canRedo, undo, redo, record } = useHistoryStore()
 
   // 矢印キーは前ステップのまま…
 
   // レイヤー操作
   const bringToFront = () => {
     if (!selectedIds.length) return
+    record()
     const maxZ = Math.max(0, ...nodes.map(n => n.z ?? 0))
     for (const id of selectedIds) {
       builderStore.getState().updateNode(id, (prev:any)=> ({ ...prev, z: maxZ + 1 }))
@@ -26,12 +29,15 @@ export default function ArrangePage() {
   }
   const sendToBack = () => {
     if (!selectedIds.length) return
+    record()
     const minZ = Math.min(0, ...nodes.map(n => n.z ?? 0))
     for (const id of selectedIds) {
       builderStore.getState().updateNode(id, (prev:any)=> ({ ...prev, z: minZ - 1 }))
     }
   }
   const lockToggle = (lock: boolean) => {
+    if (!selectedIds.length) return
+    record()
     for (const id of selectedIds) {
       builderStore.getState().updateNode(id, (prev:any)=> ({ ...prev, locked: lock }))
     }
@@ -56,6 +62,7 @@ export default function ArrangePage() {
     const scale = Math.max(0.3, Math.min(3, Math.min(scaleX, scaleY)))
     const tx = (rect.width - contentW*scale)/2 - minX*scale
     const ty = (rect.height - contentH*scale)/2 - minY*scale
+    record()
     setTransform({ scale, tx, ty })
   }
 
@@ -70,11 +77,61 @@ export default function ArrangePage() {
     }
   }
 
+  // キーボード: Undo/Redo
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Ctrl/Cmd + Z / Shift+Z / Y
+      const mod = e.metaKey || e.ctrlKey
+      if (!mod) return
+      if (e.key.toLowerCase() === 'z') {
+        e.preventDefault()
+        if (e.shiftKey) redo()
+        else undo()
+      } else if (e.key.toLowerCase() === 'y') {
+        e.preventDefault()
+        redo()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [undo, redo])
+
   return (
     <div className="space-y-3 p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="text-sm text-gray-600">Arrange prefectures (Smart guides / Resize / Layers)</div>
         <div className="flex flex-wrap items-center gap-2">
+          <button className="rounded-md border px-2 py-1 text-sm" onClick={()=> undo()} disabled={!canUndo}>↶ Undo</button>
+          <button className="rounded-md border px-2 py-1 text-sm" onClick={()=> redo()} disabled={!canRedo}>↷ Redo</button>
+
+          <div className="mx-2 h-5 w-px bg-gray-300" />
+
+          <button
+            className="rounded-md border px-2 py-1 text-sm"
+            onClick={() => { if (selectedIds.length >= 2) createGroup(selectedIds) }}
+            disabled={selectedIds.length < 2}
+          >
+            Group
+          </button>
+
+          <button
+            className="rounded-md border px-2 py-1 text-sm"
+            onClick={() => {
+              const gid = memberOf[selectedIds[0] ?? '']
+              if (gid) ungroup(gid)
+            }}
+            disabled={!memberOf[selectedIds[0] ?? '']}
+          >
+            Ungroup
+          </button>
+
+          <label className="ml-2 inline-flex items-center gap-2 text-xs text-gray-600">
+            <input type="checkbox" checked={groupSelectEnabled} onChange={(e)=> setGroupSelectEnabled(e.target.checked)} />
+            Group click-select
+          </label>
+
+          <div className="mx-2 h-5 w-px bg-gray-300" />
+
           <button className="rounded-md border px-2 py-1 text-sm" onClick={sendToBack}>⤓ 背面へ</button>
           <button className="rounded-md border px-2 py-1 text-sm" onClick={bringToFront}>⤒ 前面へ</button>
           <button className="rounded-md border px-2 py-1 text-sm" onClick={()=> lockToggle(true)}>🔒 ロック</button>

--- a/web/components/canvas/DraggableNode.tsx
+++ b/web/components/canvas/DraggableNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useCanvasStore } from '@/stores/canvas'
+import { useHistoryStore } from '@/stores/history'
 import type { XY, Size } from '@/stores/canvas'
 import { snapToGrid } from '@/lib/snap'
 import { computeSnapWithGuides } from '@/lib/guides'
@@ -23,9 +24,12 @@ export default function DraggableNode({
 }: Props) {
   const {
     nodePos, setNodePos, moveNodes, nodeSize, setNodeSize, scale,
-    selectedIds, toggleSelect, snapEnabled, gridSize, snapThreshold,
+    selectedIds, toggleSelect, setSelectedIds,
+    getGroupMembers, groupSelectEnabled,
+    snapEnabled, gridSize, snapThreshold,
     setGuides, clearGuides,
   } = useCanvasStore()
+  const record = useHistoryStore(s => s.record)
 
   // サイズをストアに同期（ガイド用）
   useEffect(() => { useCanvasStore.getState().setNodeSize(id, size) }, [id, size.w, size.h])
@@ -39,8 +43,26 @@ export default function DraggableNode({
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
     if (locked || resizing) return
     e.currentTarget.setPointerCapture(e.pointerId)
+    // ★ まず履歴を記録（ドラッグ操作の前に）
+    record()
+
     const multi = e.metaKey || e.ctrlKey
-    toggleSelect(id, multi)
+    const alreadySelected = selectedIds.includes(id)
+
+    // ★ グループ選択（有効時）
+    if (!multi && groupSelectEnabled) {
+      const members = getGroupMembers(id)
+      if (members.length > 1) {
+        setSelectedIds(members)
+      } else if (!alreadySelected) {
+        setSelectedIds([id])
+      }
+    } else {
+      // 従来挙動
+      if (multi) toggleSelect(id, true)
+      else if (!alreadySelected) setSelectedIds([id])
+    }
+
     setDragStart({ x: e.clientX, y: e.clientY, base: pos })
   }
 

--- a/web/stores/canvas.ts
+++ b/web/stores/canvas.ts
@@ -18,6 +18,15 @@ type CanvasState = {
   toggleSelect: (id: string, multi?: boolean) => void
   clearSelection: () => void
 
+  // グループ
+  groups: Record<string, string[]>
+  memberOf: Record<string, string | undefined>
+  createGroup: (ids: string[]) => string
+  ungroup: (groupId: string) => void
+  getGroupMembers: (nodeId: string) => string[]
+  groupSelectEnabled: boolean
+  setGroupSelectEnabled: (v: boolean) => void
+
   // スナップ
   snapEnabled: boolean
   gridSize: number
@@ -52,6 +61,32 @@ export const useCanvasStore = create<CanvasState>()(
       },
       clearSelection: () => set({ selectedIds: [] }),
 
+      groups: {},
+      memberOf: {},
+      groupSelectEnabled: true,
+      setGroupSelectEnabled: (v) => set({ groupSelectEnabled: v }),
+      createGroup: (ids) => {
+        const gid = `g_${Date.now().toString(36)}_${Math.random().toString(36).slice(2,6)}`
+        const groups = { ...get().groups, [gid]: Array.from(new Set(ids)) }
+        const memberOf = { ...get().memberOf }
+        for (const id of ids) memberOf[id] = gid
+        set({ groups, memberOf })
+        return gid
+      },
+      ungroup: (groupId) => {
+        const groups = { ...get().groups }
+        const members = groups[groupId] ?? []
+        delete groups[groupId]
+        const memberOf = { ...get().memberOf }
+        for (const m of members) if (memberOf[m] === groupId) delete memberOf[m]
+        set({ groups, memberOf })
+      },
+      getGroupMembers: (nodeId) => {
+        const gid = get().memberOf[nodeId]
+        if (!gid) return [nodeId]
+        return get().groups[gid] ?? [nodeId]
+      },
+
       snapEnabled: true,
       gridSize: 20,
       snapThreshold: 6,
@@ -74,6 +109,6 @@ export const useCanvasStore = create<CanvasState>()(
       setNodeSize: (id, sz) => set({ nodeSize: { ...get().nodeSize, [id]: sz } }),
       resetView: () => set({ scale: 1, tx: 0, ty: 0 }),
     }),
-    { name: 'geokore-canvas-v3' }
+    { name: 'geokore-canvas-v5' }
   )
 )

--- a/web/stores/history.ts
+++ b/web/stores/history.ts
@@ -1,0 +1,93 @@
+'use client'
+import { create } from 'zustand'
+import { useCanvasStore, type XY } from '@/stores/canvas'
+
+type Snapshot = {
+  nodePos: Record<string, XY>
+  nodeSize?: Record<string, { w: number; h: number }>
+  tx: number
+  ty: number
+  scale: number
+}
+
+type HistoryState = {
+  past: Snapshot[]
+  future: Snapshot[]
+  canUndo: boolean
+  canRedo: boolean
+  record: () => void
+  undo: () => void
+  redo: () => void
+  clear: () => void
+}
+
+function takeSnapshot(): Snapshot {
+  const s = useCanvasStore.getState()
+  // できるだけ浅いコピーで十分（構造はプリミティブ）
+  return {
+    nodePos: { ...s.nodePos },
+    // nodeSize を使っていなければコメントアウトでOK
+    // @ts-ignore
+    nodeSize: s.nodeSize ? { ...s.nodeSize } : undefined,
+    tx: s.tx,
+    ty: s.ty,
+    scale: s.scale,
+  }
+}
+
+function applySnapshot(ss: Snapshot) {
+  // CanvasStore に反映
+  const st = useCanvasStore.getState()
+  useCanvasStore.setState({
+    nodePos: ss.nodePos,
+    // @ts-ignore
+    nodeSize: ss.nodeSize ?? st.nodeSize,
+    tx: ss.tx,
+    ty: ss.ty,
+    scale: ss.scale,
+  })
+}
+
+export const useHistoryStore = create<HistoryState>()((set, get) => ({
+  past: [],
+  future: [],
+  canUndo: false,
+  canRedo: false,
+
+  record: () => {
+    const snap = takeSnapshot()
+    const nextPast = [...get().past, snap]
+    set({ past: nextPast, future: [], canUndo: nextPast.length > 0, canRedo: false })
+  },
+
+  undo: () => {
+    const past = get().past
+    if (!past.length) return
+    const current = takeSnapshot()
+    const prev = past[past.length - 1]
+    applySnapshot(prev)
+    set({
+      past: past.slice(0, -1),
+      future: [current, ...get().future],
+      canUndo: past.length - 1 > 0,
+      canRedo: true,
+    })
+  },
+
+  redo: () => {
+    const future = get().future
+    if (!future.length) return
+    const current = takeSnapshot()
+    const next = future[0]
+    applySnapshot(next)
+    set({
+      past: [...get().past, current],
+      future: future.slice(1),
+      canUndo: true,
+      canRedo: future.length - 1 > 0,
+    })
+  },
+
+  clear: () => set({ past: [], future: [], canUndo: false, canRedo: false }),
+}))
+


### PR DESCRIPTION
## Summary
- add history store to support undo/redo of canvas state
- enable grouping of nodes and group click-selection
- update draggable nodes and arrange dev page with history integration and shortcuts

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9530ed2b4832c91539704626ab6b3