### PR TITLE
feat: record history for position saves

### DIFF
--- a/web/app/dev/arrange/page.tsx
+++ b/web/app/dev/arrange/page.tsx
@@ -67,6 +67,7 @@ export default function ArrangePage() {
   }
 
   const savePositionsToBuilder = () => {
+    record()
     for (const n of nodes) {
       const p = nodePos[n.id]
       if (p) builderStore.getState().updateNode(n.id, (prev: any) => ({


### PR DESCRIPTION
## Summary
- capture canvas state before persisting node positions to builder store

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b954d8c02c832cb82730f5e18b9a79