### PR TITLE
fix: build status MotionEffect descriptors and overlay typing

### DIFF
--- a/web/components/panels/StatusConfigPanel.tsx
+++ b/web/components/panels/StatusConfigPanel.tsx
@@ -1,45 +1,82 @@
-'use client'
-import { useBuilderStore } from '@/stores/builder'
-import type { BaseStatus, Overlay, MotionPresetId } from '@/types/status'
+"use client";
+import { useBuilderStore } from "@/stores/builder";
+import type {
+  BaseStatus,
+  Overlay,
+  MotionPresetId,
+  StatusConfig,
+} from "@/types/status";
 
-const BASES: BaseStatus[] = ['visited','resident','notVisited']
-const OVERS: Overlay[] = ['want','hasPhotos']
-const EFFECTS: MotionPresetId[] = ['none','pulse-glow','bounce','float','trail','arc-zoom-fade','shuffle-cards']
+const BASES: BaseStatus[] = ["visited", "resident", "notVisited"];
+const OVERS: Overlay[] = ["want", "hasPhotos"];
+const EFFECTS: MotionPresetId[] = [
+  "none",
+  "pulse-glow",
+  "bounce",
+  "float",
+  "trail",
+  "arc-zoom-fade",
+  "shuffle-cards",
+];
 
 export default function StatusConfigPanel() {
-  const cfg = useBuilderStore(s=> s.statusConfig)
-  const setCfg = useBuilderStore(s=> s.setStatusConfig)
+  const cfg = useBuilderStore((s) => s.statusConfig);
+  const setCfg = useBuilderStore((s) => s.setStatusConfig);
 
   const setBaseColor = (k: BaseStatus, color: string) =>
-    setCfg(prev => ({ ...prev, base: { ...prev.base, [k]: { ...prev.base[k], color } } }))
+    setCfg((prev) => ({
+      ...prev,
+      base: { ...prev.base, [k]: { ...prev.base[k], color } },
+    }));
   const setBaseEffects = (k: BaseStatus, arr: MotionPresetId[]) =>
-    setCfg(prev => ({ ...prev, base: { ...prev.base, [k]: { ...prev.base[k], effects: arr } } }))
+    setCfg((prev) => ({
+      ...prev,
+      base: { ...prev.base, [k]: { ...prev.base[k], effects: arr } },
+    }));
 
-  const setOv = (k: Overlay, patch: Partial<typeof cfg.overlay[Overlay]>) =>
-    setCfg(prev => ({ ...prev, overlay: { ...prev.overlay, [k]: { ...prev.overlay[k], ...patch } } }))
+  const setOv = (
+    k: Overlay,
+    patch: Partial<StatusConfig["overlay"][Overlay]>,
+  ) =>
+    setCfg((prev) => ({
+      ...prev,
+      overlay: { ...prev.overlay, [k]: { ...prev.overlay[k], ...patch } },
+    }));
 
   return (
     <div className="space-y-4 rounded-2xl border bg-white p-4">
       <h3 className="text-sm font-semibold">ステータス設定</h3>
 
       <section>
-        <div className="mb-2 text-xs font-medium text-gray-500">基底（ベース）</div>
+        <div className="mb-2 text-xs font-medium text-gray-500">
+          基底（ベース）
+        </div>
         <div className="grid gap-3 sm:grid-cols-3">
-          {BASES.map(k => (
+          {BASES.map((k) => (
             <div key={k} className="rounded-lg border p-3">
               <div className="mb-2 text-xs">{k}</div>
-              <input type="color" value={cfg.base[k].color} onChange={(e)=> setBaseColor(k, e.target.value)} />
+              <input
+                type="color"
+                value={cfg.base[k].color}
+                onChange={(e) => setBaseColor(k, e.target.value)}
+              />
               <div className="mt-2 text-xs text-gray-500">エフェクト</div>
               <select
                 multiple
                 className="mt-1 w-full rounded border px-2 py-1 text-xs"
                 value={cfg.base[k].effects}
-                onChange={(e)=> {
-                  const arr = Array.from(e.currentTarget.selectedOptions).map(o => o.value as MotionPresetId)
-                  setBaseEffects(k, arr)
+                onChange={(e) => {
+                  const arr = Array.from(e.currentTarget.selectedOptions).map(
+                    (o) => o.value as MotionPresetId,
+                  );
+                  setBaseEffects(k, arr);
                 }}
               >
-                {EFFECTS.map(id => <option key={id} value={id}>{id}</option>)}
+                {EFFECTS.map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
               </select>
             </div>
           ))}
@@ -47,27 +84,40 @@ export default function StatusConfigPanel() {
       </section>
 
       <section>
-        <div className="mb-2 text-xs font-medium text-gray-500">オーバーレイ（重ね効果）</div>
+        <div className="mb-2 text-xs font-medium text-gray-500">
+          オーバーレイ（重ね効果）
+        </div>
         <div className="grid gap-3 sm:grid-cols-2">
-          {OVERS.map(k => (
+          {OVERS.map((k) => (
             <div key={k} className="rounded-lg border p-3">
               <div className="mb-2 text-xs">{k}</div>
               <label className="block text-xs">
                 カラー
-                <input type="color" className="ml-2 align-middle" value={cfg.overlay[k].color}
-                  onChange={(e)=> setOv(k, { color: e.target.value })}/>
+                <input
+                  type="color"
+                  className="ml-2 align-middle"
+                  value={cfg.overlay[k].color}
+                  onChange={(e) => setOv(k, { color: e.target.value })}
+                />
               </label>
               <label className="mt-2 block text-xs">
                 優先度
-                <input type="number" className="ml-2 w-20 rounded border px-1 py-0.5 text-xs"
+                <input
+                  type="number"
+                  className="ml-2 w-20 rounded border px-1 py-0.5 text-xs"
                   value={cfg.overlay[k].priority}
-                  onChange={(e)=> setOv(k, { priority: Number(e.target.value) })}/>
+                  onChange={(e) =>
+                    setOv(k, { priority: Number(e.target.value) })
+                  }
+                />
               </label>
               <label className="mt-2 block text-xs">
                 モード
-                <select className="ml-2 rounded border px-1 py-0.5 text-xs"
+                <select
+                  className="ml-2 rounded border px-1 py-0.5 text-xs"
                   value={cfg.overlay[k].mode}
-                  onChange={(e)=> setOv(k, { mode: e.target.value as any })}>
+                  onChange={(e) => setOv(k, { mode: e.target.value as any })}
+                >
                   <option value="blend">blend</option>
                   <option value="override">override</option>
                   <option value="glow">glow</option>
@@ -78,12 +128,18 @@ export default function StatusConfigPanel() {
                 multiple
                 className="mt-1 w-full rounded border px-2 py-1 text-xs"
                 value={cfg.overlay[k].effects}
-                onChange={(e)=> {
-                  const arr = Array.from(e.currentTarget.selectedOptions).map(o => o.value) as MotionPresetId[]
-                  setOv(k, { effects: arr })
+                onChange={(e) => {
+                  const arr = Array.from(e.currentTarget.selectedOptions).map(
+                    (o) => o.value,
+                  ) as MotionPresetId[];
+                  setOv(k, { effects: arr });
                 }}
               >
-                {EFFECTS.map(id => <option key={id} value={id}>{id}</option>)}
+                {EFFECTS.map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
               </select>
             </div>
           ))}
@@ -93,23 +149,37 @@ export default function StatusConfigPanel() {
       <section className="flex items-center gap-3">
         <label className="text-xs">
           合成色モード
-          <select className="ml-2 rounded border px-2 py-1 text-xs"
+          <select
+            className="ml-2 rounded border px-2 py-1 text-xs"
             value={cfg.compose.colorMode}
-            onChange={(e)=> setCfg(p=> ({ ...p, compose: { ...p.compose, colorMode: e.target.value as any } }))}>
+            onChange={(e) =>
+              setCfg((p) => ({
+                ...p,
+                compose: { ...p.compose, colorMode: e.target.value as any },
+              }))
+            }
+          >
             <option value="blend">blend</option>
             <option value="override">override</option>
           </select>
         </label>
         <label className="text-xs">
           適用順
-          <select className="ml-2 rounded border px-2 py-1 text-xs"
+          <select
+            className="ml-2 rounded border px-2 py-1 text-xs"
             value={cfg.compose.order}
-            onChange={(e)=> setCfg(p=> ({ ...p, compose: { ...p.compose, order: e.target.value as any } }))}>
+            onChange={(e) =>
+              setCfg((p) => ({
+                ...p,
+                compose: { ...p.compose, order: e.target.value as any },
+              }))
+            }
+          >
             <option value="priority">priority（優先度順）</option>
             <option value="fixed">fixed（チェック順）</option>
           </select>
         </label>
       </section>
     </div>
-  )
+  );
 }

--- a/web/lib/status-engine.ts
+++ b/web/lib/status-engine.ts
@@ -1,52 +1,81 @@
-import type { NodeStatus, StatusConfig, MotionPresetId } from '@/types/status'
-import { defaultStatusConfig } from '@/types/status'
+import type { NodeStatus, StatusConfig, MotionPresetId } from "@/types/status";
+import type { MotionEffect } from "@/types/motion";
+import { defaultStatusConfig } from "@/types/status";
 
 // 簡易ブレンド（alpha 0.35 固定の乗算風）
 function blend(base: string, over: string): string {
   const toRgb = (c: string) => {
-    const ctx = document.createElement('canvas').getContext('2d')!
-    ctx.fillStyle = c; const m = ctx.fillStyle as string
+    const ctx = document.createElement("canvas").getContext("2d")!;
+    ctx.fillStyle = c;
+    const m = ctx.fillStyle as string;
     // ブラウザに任せて正規化 → rgb(r, g, b)
-    const nums = m.match(/\d+/g)?.map(Number) ?? [0,0,0]
-    return { r: nums[0], g: nums[1], b: nums[2] }
-  }
-  const b = toRgb(base), o = toRgb(over)
-  const a = 0.35
-  const r = Math.round((1-a)*b.r + a*o.r)
-  const g = Math.round((1-a)*b.g + a*o.g)
-  const v = Math.round((1-a)*b.b + a*o.b)
-  return `rgb(${r}, ${g}, ${v})`
+    const nums = m.match(/\d+/g)?.map(Number) ?? [0, 0, 0];
+    return { r: nums[0], g: nums[1], b: nums[2] };
+  };
+  const b = toRgb(base),
+    o = toRgb(over);
+  const a = 0.35;
+  const r = Math.round((1 - a) * b.r + a * o.r);
+  const g = Math.round((1 - a) * b.g + a * o.g);
+  const v = Math.round((1 - a) * b.b + a * o.b);
+  return `rgb(${r}, ${g}, ${v})`;
 }
 
 export function computeBgColor(status: NodeStatus, cfg?: StatusConfig): string {
-  const conf = cfg ?? defaultStatusConfig
-  let color = conf.base[status.base].color
-  const overlays = [...status.overlays]
+  const conf = cfg ?? defaultStatusConfig;
+  let color = conf.base[status.base].color;
+  const overlays = [...status.overlays];
 
-  const ordered = conf.compose.order === 'priority'
-    ? overlays.sort((a,b)=> (conf.overlay[b]?.priority ?? 0) - (conf.overlay[a]?.priority ?? 0))
-    : overlays
+  const ordered =
+    conf.compose.order === "priority"
+      ? overlays.sort(
+          (a, b) =>
+            (conf.overlay[b]?.priority ?? 0) - (conf.overlay[a]?.priority ?? 0),
+        )
+      : overlays;
 
   for (const ov of ordered) {
-    const rule = conf.overlay[ov]; if (!rule) continue
-    const mode = rule.mode ?? conf.compose.colorMode
-    if (mode === 'override') color = rule.color
-    else if (mode === 'blend') color = blend(color, rule.color)
-    else if (mode === 'glow')  color = blend(color, rule.color) // 実際の発光はエフェクトで付与
+    const rule = conf.overlay[ov];
+    if (!rule) continue;
+    const mode = rule.mode ?? conf.compose.colorMode;
+    if (mode === "override") color = rule.color;
+    else if (mode === "blend") color = blend(color, rule.color);
+    else if (mode === "glow") color = blend(color, rule.color); // 実際の発光はエフェクトで付与
   }
-  return color
+  return color;
 }
 
 // 既存の runMotion と接続するための形に変換
-export function buildMotionFromStatus(id: string, status: NodeStatus, cfg?: StatusConfig) {
-  const conf = cfg ?? defaultStatusConfig
-  const baseFx = conf.base[status.base]?.effects ?? []
-  const overlayFx = status.overlays.flatMap(o => conf.overlay[o]?.effects ?? [])
-  const all: MotionPresetId[] = [...new Set([...baseFx, ...overlayFx])].filter(x => x !== 'none')
+export function buildMotionFromStatus(
+  id: string,
+  status: NodeStatus,
+  cfg?: StatusConfig,
+) {
+  const conf = cfg ?? defaultStatusConfig;
+  const baseFx = conf.base[status.base]?.effects ?? [];
+  const overlayFx = status.overlays.flatMap(
+    (o) => conf.overlay[o]?.effects ?? [],
+  );
+
+  const unique = (arr: MotionPresetId[]) =>
+    [...new Set(arr)].filter((x) => x !== "none");
+  const toEffect = (
+    preset: MotionPresetId,
+    when: "mount" | "hoverEnter",
+  ): MotionEffect => ({
+    id: `${id}-${preset}-${when}`,
+    preset,
+    runWhen: [when],
+  });
+
+  const mountFx = unique([...baseFx, ...overlayFx]).map((p) =>
+    toEffect(p, "mount"),
+  );
+  const hoverFx = unique(overlayFx).map((p) => toEffect(p, "hoverEnter"));
 
   return {
-    mount: all,
-    hoverEnter: overlayFx, // 「行きたい」「写真登録」などをホバーで強調したいとき
+    mount: mountFx,
+    hoverEnter: hoverFx, // 「行きたい」「写真登録」などをホバーで強調したいとき
     hoverLeave: [],
-  }
+  };
 }


### PR DESCRIPTION
## Summary
- convert status motion IDs into MotionEffect descriptors
- use StatusConfig type when patching overlay rules

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b961f97880832c8f05da24f855491d