### PR TITLE
fix: subscribe map nodes and emit motion effects

### DIFF
--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -6,9 +6,8 @@ import { computeBgColor, buildMotionFromStatus } from '@/lib/status-engine'
 export default function MapPage() {
   const sp = useSearchParams()
   const preview = sp.get('preview') === '1'
-  const getMapNodes = useBuilderStore(s=> s.getMapNodes)
+  const nodes = useBuilderStore(s => Object.values(s.getMapNodes(preview)))
   const cfg = useBuilderStore(s=> s.statusConfig)
-  const nodes = Object.values(getMapNodes(preview))
 
   return (
     <div className="p-4">

--- a/web/components/panels/StatusConfigPanel.tsx
+++ b/web/components/panels/StatusConfigPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useBuilderStore } from '@/stores/builder'
-import type { BaseStatus, Overlay, MotionPresetId } from '@/types/status'
+import type { BaseStatus, Overlay, MotionPresetId, StatusConfig } from '@/types/status'
 
 const BASES: BaseStatus[] = ['visited','resident','notVisited']
 const OVERS: Overlay[] = ['want','hasPhotos']
@@ -15,7 +15,7 @@ export default function StatusConfigPanel() {
   const setBaseEffects = (k: BaseStatus, arr: MotionPresetId[]) =>
     setCfg(prev => ({ ...prev, base: { ...prev.base, [k]: { ...prev.base[k], effects: arr } } }))
 
-  const setOv = (k: Overlay, patch: Partial<typeof cfg.overlay[Overlay]>) =>
+  const setOv = (k: Overlay, patch: Partial<StatusConfig['overlay'][Overlay]>) =>
     setCfg(prev => ({ ...prev, overlay: { ...prev.overlay, [k]: { ...prev.overlay[k], ...patch } } }))
 
   return (

--- a/web/lib/status-engine.ts
+++ b/web/lib/status-engine.ts
@@ -1,4 +1,5 @@
 import type { NodeStatus, StatusConfig, MotionPresetId } from '@/types/status'
+import type { MotionEffect } from '@/types/motion'
 import { defaultStatusConfig } from '@/types/status'
 
 // 簡易ブレンド（alpha 0.35 固定の乗算風）
@@ -42,11 +43,23 @@ export function buildMotionFromStatus(id: string, status: NodeStatus, cfg?: Stat
   const conf = cfg ?? defaultStatusConfig
   const baseFx = conf.base[status.base]?.effects ?? []
   const overlayFx = status.overlays.flatMap(o => conf.overlay[o]?.effects ?? [])
-  const all: MotionPresetId[] = [...new Set([...baseFx, ...overlayFx])].filter(x => x !== 'none')
+  const mountPresets: MotionPresetId[] = [...new Set([...baseFx, ...overlayFx])].filter(x => x !== 'none')
+  const hoverPresets: MotionPresetId[] = overlayFx.filter(x => x !== 'none')
+
+  const mount: MotionEffect[] = mountPresets.map((p, i) => ({
+    id: `${id}-status-mount-${p}-${i}`,
+    preset: p,
+    runWhen: ['mount'],
+  }))
+  const hoverEnter: MotionEffect[] = hoverPresets.map((p, i) => ({
+    id: `${id}-status-hover-${p}-${i}`,
+    preset: p,
+    runWhen: ['hoverEnter'],
+  }))
 
   return {
-    mount: all,
-    hoverEnter: overlayFx, // 「行きたい」「写真登録」などをホバーで強調したいとき
-    hoverLeave: [],
+    mount,
+    hoverEnter, // 「行きたい」「写真登録」などをホバーで強調したいとき
+    hoverLeave: [] as MotionEffect[],
   }
 }


### PR DESCRIPTION
## Summary
- subscribe MapPage to node data so map updates reactively
- use StatusConfig types for overlay updates
- return MotionEffect descriptors from buildMotionFromStatus

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b962096ecc832cab42564b7a520e81