### PR TITLE
feat: add mock toggle dev page

### DIFF
--- a/web/app/dev/mock/page.tsx
+++ b/web/app/dev/mock/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { isMockEnabled } from '@/lib/mock';
+
+export default function MockPage() {
+  const [useMock, setUseMock] = useState(false);
+
+  useEffect(() => {
+    const enabled = isMockEnabled();
+    console.log('mock enabled', enabled);
+    setUseMock(enabled);
+  }, []);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    localStorage.setItem('useMock', checked ? 'true' : 'false');
+    setUseMock(checked);
+    location.reload();
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Mock 切替</h1>
+      <div>現在の mock 有効状態: {String(useMock)}</div>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={useMock} onChange={onChange} />
+        <span>useMock</span>
+      </label>
+      <Link href="/dev/pages" className="text-blue-600 underline">
+        &larr; /dev/pages
+      </Link>
+    </div>
+  );
+}
+

--- a/web/lib/mock.ts
+++ b/web/lib/mock.ts
@@ -1,0 +1,6 @@
+export function isMockEnabled(): boolean {
+  const local = typeof localStorage !== 'undefined' && localStorage.getItem('useMock');
+  if (local === 'true') return true;
+  if (local === 'false') return false;
+  return process.env.NEXT_PUBLIC_USE_MOCK === 'true';
+}


### PR DESCRIPTION
## Summary
- add helper to read mock API flag from localStorage or env
- add /dev/mock page with toggle and link back to /dev/pages

## Testing
- `pnpm test`
- `pnpm -C web build`


------
https://chatgpt.com/codex/tasks/task_e_68b96879a634832cb141d103d894b65a