### PR TITLE
feat(dev): add unused components page

### DIFF
--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -43,10 +43,13 @@ export default function DevPages() {
             <div className="text-sm font-medium mb-2">Mock 切替</div>
             <div className="text-xs text-zinc-500">(placeholder) API モック/実データ切替</div>
           </div>
-          <div className="p-4 rounded-xl border">
+          <Link
+            href="/dev/unused"
+            className="p-4 rounded-xl border hover:bg-zinc-50 dark:hover:bg-zinc-900"
+          >
             <div className="text-sm font-medium mb-2">未使用コンポ一覧</div>
-            <div className="text-xs text-zinc-500">(placeholder) 自動検出 UI</div>
-          </div>
+            <div className="text-xs text-zinc-500">自動検出 UI</div>
+          </Link>
         </div>
       </section>
     </div>

--- a/web/app/dev/unused/page.tsx
+++ b/web/app/dev/unused/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+import { registry } from '@/lib/registry';
+import { useBuilderStore } from '@/store/builderStore';
+
+export default function DevUnusedPage() {
+  const elements = useBuilderStore((s) => s.elements);
+  const allIds = Object.keys(registry);
+  const usedIds = new Set(
+    elements.map((el) => el.componentId).filter((id): id is string => Boolean(id))
+  );
+  const unusedIds = allIds.filter((id) => !usedIds.has(id));
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">/dev/unused</h1>
+      {unusedIds.length > 0 ? (
+        <ul className="list-disc pl-5 space-y-1">
+          {unusedIds.map((id) => (
+            <li key={id}>{id}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>未使用なし</p>
+      )}
+      <Link href="/dev/pages" className="text-blue-500 underline">
+        戻る
+      </Link>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- list unused components by comparing builder store elements with registry
- link unused components page from dev tools hub

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96880fb50832c82ed80ae5fbaaf06