### PR TITLE
feat: add draggable node wrapper

### DIFF
--- a/web/components/canvas/DraggableNode.tsx
+++ b/web/components/canvas/DraggableNode.tsx
@@ -1,13 +1,11 @@
 'use client'
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { useCanvasStore } from '@/stores/canvas'
 import { useHistoryStore } from '@/stores/history'
 import type { XY, Size } from '@/stores/canvas'
 import { snapToGrid } from '@/lib/snap'
 import { computeSnapWithGuides } from '@/lib/guides'
-import { computeBgColor, buildMotionFromStatus } from '@/lib/status-engine'
-import { useBuilderStore } from '@/stores/builder'
-import { animate } from 'animejs'
+import DraggableNodeWrapper from './DraggableNodeWrapper'
 
 type Props = {
   id: string
@@ -17,39 +15,6 @@ type Props = {
   z?: number
   locked?: boolean
   onCommit?: (xy: XY, sz?: Size) => void
-}
-
-export function DraggableNodeWrapper(
-  {
-    id,
-    style,
-    className,
-    children,
-    ...rest
-  }: {
-    id: string
-    style?: React.CSSProperties
-    className?: string
-    children: React.ReactNode
-  } & React.HTMLAttributes<HTMLDivElement>,
-) {
-  const cfg = useBuilderStore((s) => s.statusConfig)
-  const status = useBuilderStore((s) => s.getNodeStatus(id))
-  const ref = useRef<HTMLDivElement>(null)
-  const { bg, filter } = computeBgColor(status, cfg)
-  const motion = buildMotionFromStatus(status, cfg)
-
-  useEffect(() => {
-    if (!ref.current || !motion) return
-    const a = animate({ targets: ref.current, ...motion })
-    return () => a.pause()
-  }, [motion])
-
-  return (
-    <div ref={ref} data-node-id={id} style={{ background: bg, filter, ...style }} className={className} {...rest}>
-      {children}
-    </div>
-  )
 }
 
 export default function DraggableNode({

--- a/web/components/canvas/DraggableNodeWrapper.tsx
+++ b/web/components/canvas/DraggableNodeWrapper.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type React from 'react'
+import { useBuilderStore } from '@/stores/builder'
+import { computeBgColor, buildMotionFromStatus } from '@/lib/status-engine'
+import { animate } from 'animejs'
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  id: string
+  children: React.ReactNode
+}
+
+export default function DraggableNodeWrapper({ id, style, className, children, ...rest }: Props) {
+  const cfg = useBuilderStore((s) => s.statusConfig)
+  const status = useBuilderStore((s) => s.getNodeStatus(id))
+  const ref = useRef<HTMLDivElement>(null)
+  const { bg, filter } = computeBgColor(status, cfg)
+  const motion = buildMotionFromStatus(id, status, cfg)
+
+  // pulse animation
+  useEffect(() => {
+    if (!ref.current || !motion) return
+    const inst = animate({ targets: ref.current, loop: true, ...motion })
+    return () => inst.pause()
+  }, [motion])
+
+  // flash animation on status change
+  const prev = useRef<{ base: string; overlays: string }>()
+  useEffect(() => {
+    const cur = { base: status.base, overlays: status.overlays.join(',') }
+    let a: ReturnType<typeof animate> | undefined
+    if (ref.current && prev.current) {
+      if (prev.current.base !== cur.base || prev.current.overlays !== cur.overlays) {
+        a = animate({
+          targets: ref.current,
+          scale: [1, 1.05],
+          opacity: [1, 0.6],
+          direction: 'alternate',
+          duration: 200,
+          easing: 'easeOutSine',
+        })
+      }
+    }
+    prev.current = cur
+    return () => a?.pause()
+  }, [status.base, status.overlays.join(',')])
+
+  return (
+    <div
+      ref={ref}
+      data-node-id={id}
+      style={{ background: bg, filter, ...style }}
+      className={className}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+}
+

--- a/web/lib/status-engine.ts
+++ b/web/lib/status-engine.ts
@@ -78,12 +78,35 @@ function applyOverlay(baseHex: string, oc: OverlayConfig, glows: { color: string
   }
 }
 
-export function buildMotionFromStatus(status: NodeStatus, cfg: StatusConfig) {
+export function buildMotionFromStatus(
+  id: string,
+  status: NodeStatus,
+  cfg?: StatusConfig,
+): { scale: number[]; duration: number; direction: 'alternate'; easing: 'easeInOutSine'; loop: true } | undefined
+export function buildMotionFromStatus(
+  status: NodeStatus,
+  cfg?: StatusConfig,
+): { scale: number[]; duration: number; direction: 'alternate'; easing: 'easeInOutSine'; loop: true } | undefined
+export function buildMotionFromStatus(
+  idOrStatus: string | NodeStatus,
+  statusOrCfg?: NodeStatus | StatusConfig,
+  maybeCfg?: StatusConfig,
+) {
+  let status: NodeStatus
+  let cfg: StatusConfig = DEFAULT_STATUS_CONFIG
+  if (typeof idOrStatus === 'string') {
+    status = statusOrCfg as NodeStatus
+    cfg = maybeCfg ?? DEFAULT_STATUS_CONFIG
+  } else {
+    status = idOrStatus
+    cfg = (statusOrCfg as StatusConfig) ?? DEFAULT_STATUS_CONFIG
+  }
+
   const overlays = status.overlays
     .map((k) => cfg.overlays.find((o) => o.key === k))
-    .filter(Boolean) as OverlayConfig[];
-  const hasGlow = overlays.some((o) => o.mode === 'glow');
-  if (!hasGlow) return undefined;
+    .filter(Boolean) as OverlayConfig[]
+  const hasGlow = overlays.some((o) => o.mode === 'glow')
+  if (!hasGlow) return undefined
   // anime.js 用：軽い鼓動
   return {
     scale: [1, 1.03],
@@ -91,6 +114,6 @@ export function buildMotionFromStatus(status: NodeStatus, cfg: StatusConfig) {
     direction: 'alternate' as const,
     easing: 'easeInOutSine' as const,
     loop: true,
-  };
+  }
 }
 


### PR DESCRIPTION
## Summary
- add DraggableNodeWrapper component to handle node status styling and animations
- wrap DraggableNode root element with new wrapper
- extend status engine motion helper to accept node id

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b968642974832c91727c52acb90fea