### PR TITLE
feat: add devtools toggle page

### DIFF
--- a/web/app/dev/devtools/page.tsx
+++ b/web/app/dev/devtools/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+const ReactQueryDevtools = dynamic(
+  () => import('@tanstack/react-query-devtools').then((mod) => mod.ReactQueryDevtools),
+  { ssr: false }
+);
+
+export default function DevtoolsPage() {
+  const [showRQ, setShowRQ] = useState(false);
+  const [showZustand, setShowZustand] = useState(false);
+
+  useEffect(() => {
+    if (showRQ) {
+      const isDark = document.documentElement.classList.contains('dark');
+      try {
+        localStorage.setItem(
+          'TanstackQueryDevtools.theme_preference',
+          isDark ? 'dark' : 'light'
+        );
+      } catch (_) {
+        // ignore
+      }
+    }
+  }, [showRQ]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Devtools</h1>
+        <Link href="/dev/pages" className="text-sm text-blue-600 hover:underline">
+          ← /dev/pages
+        </Link>
+      </div>
+
+      <p className="text-sm text-zinc-500">React Query Devtools や Zustand Devtools を表示します。</p>
+
+      <div className="space-y-4">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showRQ}
+            onChange={(e) => setShowRQ(e.target.checked)}
+          />
+          <span>React Query Devtools</span>
+        </label>
+        {showRQ && <ReactQueryDevtools initialIsOpen={false} />}
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showZustand}
+            onChange={(e) => setShowZustand(e.target.checked)}
+          />
+          <span>Zustand Devtools</span>
+        </label>
+        {showZustand && (
+          <div className="text-xs text-zinc-500">後日追加</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -31,14 +31,10 @@ export default function DevPages() {
       <section className="space-y-3">
         <h2 className="text-lg font-semibold">Devtools / Mock</h2>
         <div className="grid sm:grid-cols-2 gap-3">
-          <div className="p-4 rounded-xl border">
-            <div className="text-sm font-medium mb-2">React Query Devtools</div>
-            <div className="text-xs text-zinc-500">(placeholder) トグル/マウントを後日追加</div>
-          </div>
-          <div className="p-4 rounded-xl border">
-            <div className="text-sm font-medium mb-2">Zustand Devtools</div>
-            <div className="text-xs text-zinc-500">(placeholder) トグル/マウントを後日追加</div>
-          </div>
+          <Link href="/dev/devtools" className="p-4 rounded-xl border hover:bg-zinc-50 dark:hover:bg-zinc-900">
+            <div className="text-sm font-medium mb-2">Devtools</div>
+            <div className="text-xs text-zinc-500">React Query / Zustand Devtools</div>
+          </Link>
           <div className="p-4 rounded-xl border">
             <div className="text-sm font-medium mb-2">Mock 切替</div>
             <div className="text-xs text-zinc-500">(placeholder) API モック/実データ切替</div>

--- a/web/providers/DataProvider.tsx
+++ b/web/providers/DataProvider.tsx
@@ -1,14 +1,10 @@
 "use client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { PropsWithChildren, useState } from "react";
 
 export default function DataProvider({ children }: PropsWithChildren) {
   const [client] = useState(() => new QueryClient());
   return (
-    <QueryClientProvider client={client}>
-      {children}
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add `/dev/devtools` page with checkboxes to toggle React Query and placeholder Zustand devtools
- link to the devtools page from `/dev/pages`
- remove global React Query Devtools from `DataProvider`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9686fa98c832c8880001a0b881cee