### PR TITLE
feat(builder): add undo/redo history for nodes

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -10,6 +10,10 @@ export default function BuilderPage() {
   const publishedAt = useBuilderStore((s) => s.publishedSnapshot?.at);
   const usePublished = useBuilderStore((s) => s.usePublishedOnMap);
   const setUsePublished = useBuilderStore((s) => s.setUsePublishedOnMap);
+  const undo = useBuilderStore((s) => s.undo);
+  const redo = useBuilderStore((s) => s.redo);
+  const canUndo = useBuilderStore((s) => s.undoStack.length > 0);
+  const canRedo = useBuilderStore((s) => s.redoStack.length > 0);
 
   return (
     <div className="p-6 space-y-6">
@@ -24,6 +28,20 @@ export default function BuilderPage() {
             />
             <span>/map は公開版を使用</span>
           </label>
+          <button
+            onClick={undo}
+            disabled={!canUndo}
+            className="px-3 py-2 rounded-lg border disabled:text-zinc-400 disabled:border-zinc-200"
+          >
+            ↩ Undo
+          </button>
+          <button
+            onClick={redo}
+            disabled={!canRedo}
+            className="px-3 py-2 rounded-lg border disabled:text-zinc-400 disabled:border-zinc-200"
+          >
+            ↪ Redo
+          </button>
           <div className="flex flex-col items-end gap-1">
             <button
               onClick={publishAll}

--- a/web/stores/builder.ts
+++ b/web/stores/builder.ts
@@ -27,11 +27,18 @@ type BuilderState = {
   publishedSnapshot: PublishedSnapshot | null;
   usePublishedOnMap: boolean;
 
+  undoStack: BuilderNode[][];
+  redoStack: BuilderNode[][];
+
+  setNodes: (nodes: BuilderNode[]) => void;
+
   updateMany: (patches: Array<Partial<BuilderNode> & { id: string }>) => void;
   setNodeStatus: (id: string, status: NodeStatus) => void;
   setStatusConfig: (updater: (draft: StatusConfig) => StatusConfig | void) => void;
   publishAll: () => void;
   setUsePublishedOnMap: (v: boolean) => void;
+  undo: () => void;
+  redo: () => void;
   getMapNodes: (preview?: boolean) => BuilderNode[];
   getNodeStatus: (id: string) => NodeStatus;
 };
@@ -44,6 +51,15 @@ export const useBuilderStore = create<BuilderState>()(
       statusConfig: DEFAULT_STATUS_CONFIG,
       publishedSnapshot: null,
       usePublishedOnMap: true,
+      undoStack: [],
+      redoStack: [],
+
+      setNodes: (nodes) =>
+        set((s) => ({
+          nodes,
+          undoStack: [...s.undoStack, structuredClone(s.nodes)].slice(-20),
+          redoStack: [],
+        })),
 
       updateMany: (patches) =>
         set((s) => ({
@@ -51,6 +67,8 @@ export const useBuilderStore = create<BuilderState>()(
             const p = patches.find((pp) => pp.id === n.id);
             return p ? { ...n, ...p } : n;
           }),
+          undoStack: [...s.undoStack, structuredClone(s.nodes)].slice(-20),
+          redoStack: [],
         })),
 
       setNodeStatus: (id, status) =>
@@ -76,6 +94,28 @@ export const useBuilderStore = create<BuilderState>()(
         })),
 
       setUsePublishedOnMap: (v) => set({ usePublishedOnMap: v }),
+
+      undo: () =>
+        set((s) => {
+          if (s.undoStack.length === 0) return {};
+          const previous = s.undoStack[s.undoStack.length - 1];
+          return {
+            nodes: previous,
+            undoStack: s.undoStack.slice(0, -1),
+            redoStack: [...s.redoStack, structuredClone(s.nodes)].slice(-20),
+          };
+        }),
+
+      redo: () =>
+        set((s) => {
+          if (s.redoStack.length === 0) return {};
+          const next = s.redoStack[s.redoStack.length - 1];
+          return {
+            nodes: next,
+            redoStack: s.redoStack.slice(0, -1),
+            undoStack: [...s.undoStack, structuredClone(s.nodes)].slice(-20),
+          };
+        }),
 
       getMapNodes: (preview) => {
         const s = get();


### PR DESCRIPTION
## Summary
- track node state history with undo and redo stacks
- expose undo/redo APIs in builder store
- add Undo/Redo buttons to Builder page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96db0cfc0832c89669dab2a4010b6