### PR TITLE
feat: add status reset button to builder

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 
 export default function BuilderPage() {
   const nodes = useBuilderStore((s) => s.nodes);
+  const setNodeStatus = useBuilderStore((s) => s.setNodeStatus);
   const publishAll = useBuilderStore((s) => s.publishAll);
   const publishedAt = useBuilderStore((s) => s.publishedSnapshot?.at);
   const usePublished = useBuilderStore((s) => s.usePublishedOnMap);
@@ -14,6 +15,12 @@ export default function BuilderPage() {
   const redo = useBuilderStore((s) => s.redo);
   const canUndo = useBuilderStore((s) => s.undoStack.length > 0);
   const canRedo = useBuilderStore((s) => s.redoStack.length > 0);
+
+  const resetStatuses = () => {
+    nodes.forEach((n) =>
+      setNodeStatus(n.id, { base: "notVisited", overlays: [] })
+    );
+  };
 
   return (
     <div className="p-6 space-y-6">
@@ -41,6 +48,12 @@ export default function BuilderPage() {
             className="px-3 py-2 rounded-lg border disabled:text-zinc-400 disabled:border-zinc-200"
           >
             ↪ Redo
+          </button>
+          <button
+            onClick={resetStatuses}
+            className="px-3 py-2 rounded-lg border"
+          >
+            ステータス初期化
           </button>
           <div className="flex flex-col items-end gap-1">
             <button


### PR DESCRIPTION
## Summary
- add `ステータス初期化` button to reset all node statuses to notVisited

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96e82f238832ca6fda5d2667f901e