### PR TITLE
feat: improve StatusConfigPanel UI

### DIFF
--- a/web/components/panels/StatusConfigPanel.tsx
+++ b/web/components/panels/StatusConfigPanel.tsx
@@ -1,42 +1,37 @@
-'use client';
-import { useBuilderStore } from '@/stores/builder';
-import type { ComposeMode } from '@/types/status';
+"use client";
+import { useBuilderStore } from "@/stores/builder";
+import type { BaseKind, ComposeMode, OverlayKind } from "@/types/status";
+
+const BASE_LABELS: Record<BaseKind, string> = {
+  visited: "🏠 行った",
+  live: "🧍‍♂️ 住んでる",
+  notVisited: "❌ 行ってない",
+};
+
+const OVERLAY_LABELS: Record<OverlayKind, string> = {
+  want: "✈️ 行きたい",
+  photo: "📷 写真あり",
+};
 
 export default function StatusConfigPanel() {
   const cfg = useBuilderStore((s) => s.statusConfig);
   const setStatusConfig = useBuilderStore((s) => s.setStatusConfig);
 
   return (
-    <div className="space-y-4 p-4 rounded-xl border bg-white/70 dark:bg-zinc-900/70">
-      {/* Base configs */}
-      <section className="space-y-2">
-        <div className="text-xs text-zinc-500">Base</div>
-        <div className="flex flex-col gap-2">
-          {Object.entries(cfg.base).map(([k, v]) => (
-            <div key={k} className="flex items-center gap-2">
-              <div className="text-sm w-20">{v.label}</div>
-              <input
-                type="color"
-                value={v.color}
-                onChange={(e) =>
-                  setStatusConfig((draft) => {
-                    draft.base[k as keyof typeof cfg.base].color = e.target.value;
-                  })
-                }
-                className="h-8 w-12 p-0 border rounded"
-              />
-            </div>
-          ))}
-        </div>
-      </section>
-
+    <div className="p-4 rounded-xl border bg-white/70 dark:bg-zinc-900/70">
       {/* Overlay configs */}
-      <section className="space-y-2">
-        <div className="text-xs text-zinc-500">Overlays</div>
+      <section className="mb-4">
+        <div className="text-xs text-zinc-500 mb-2">Overlays</div>
         <div className="space-y-3">
           {cfg.overlays.map((o, idx) => (
             <div key={o.key} className="grid grid-cols-12 items-center gap-2">
-              <div className="col-span-2 text-sm">{o.label}</div>
+              <div className="col-span-3 text-sm flex items-center gap-1">
+                <span
+                  className="inline-block h-3 w-3 rounded-full"
+                  style={{ backgroundColor: o.color }}
+                />
+                {OVERLAY_LABELS[o.key]}
+              </div>
               <div className="col-span-2">
                 <input
                   type="color"
@@ -62,7 +57,7 @@ export default function StatusConfigPanel() {
                   className="h-8 px-2 w-full rounded border bg-white/60 dark:bg-zinc-800"
                 />
               </div>
-              <div className="col-span-5">
+              <div className="col-span-4">
                 <label className="text-xs text-zinc-500 block">mode</label>
                 <select
                   value={o.mode}
@@ -82,7 +77,34 @@ export default function StatusConfigPanel() {
           ))}
         </div>
       </section>
+
+      {/* Base configs */}
+      <section className="mt-6">
+        <div className="text-xs text-zinc-500 mb-2">Base</div>
+        <div className="flex flex-col gap-2">
+          {Object.entries(cfg.base).map(([k, v]) => (
+            <div key={k} className="flex items-center gap-2">
+              <div className="text-sm w-28 flex items-center gap-1">
+                <span
+                  className="inline-block h-3 w-3 rounded-full"
+                  style={{ backgroundColor: v.color }}
+                />
+                {BASE_LABELS[k as BaseKind]}
+              </div>
+              <input
+                type="color"
+                value={v.color}
+                onChange={(e) =>
+                  setStatusConfig((draft) => {
+                    draft.base[k as BaseKind].color = e.target.value;
+                  })
+                }
+                className="h-8 w-12 p-0 border rounded"
+              />
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Reorder status configuration to show overlay options before base settings
- Add emoji and color badges to status labels for better clarity
- Tweak spacing between sections for improved readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96e9474dc832c861950e34ee2aa70