### PR TITLE
feat: add status legend to map page

### DIFF
--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'next/navigation';
 import { useBuilderStore } from '@/stores/builder';
 import { computeBgColor } from '@/lib/status-engine';
 import ZoomPanCanvas from '@/components/canvas/ZoomPanCanvas';
+import type { BaseKind, OverlayKind } from '@/types/status';
 
 type MapNode = {
   id: string;
@@ -11,6 +12,17 @@ type MapNode = {
   y?: number;
   w?: number;
   h?: number;
+};
+
+const BASE_LABELS: Record<BaseKind, string> = {
+  visited: '🏠 行った',
+  live: '🧍‍♂️ 住んでる',
+  notVisited: '❌ 行ってない',
+};
+
+const OVERLAY_LABELS: Record<OverlayKind, string> = {
+  want: '✈️ 行きたい',
+  photo: '📷 写真あり',
 };
 
 function NodeCard({ node }: { node: MapNode }) {
@@ -42,6 +54,7 @@ export default function MapPage() {
   const preview = sp.get('preview') === '1';
   const getMapNodes = useBuilderStore((s) => s.getMapNodes);
   const nodes = getMapNodes(preview);
+  const cfg = useBuilderStore((s) => s.statusConfig);
 
   return (
     <div className="p-6 space-y-4">
@@ -53,6 +66,26 @@ export default function MapPage() {
           <NodeCard key={n.id} node={n} />
         ))}
       </ZoomPanCanvas>
+      <div className="fixed bottom-4 left-4 bg-white/80 p-4 rounded-xl shadow text-sm space-y-1">
+        {Object.entries(cfg.base).map(([k, v]) => (
+          <div key={k} className="flex items-center gap-1">
+            <span
+              className="inline-block w-3 h-3 rounded-full"
+              style={{ backgroundColor: v.color }}
+            />
+            <span>{BASE_LABELS[k as BaseKind]}</span>
+          </div>
+        ))}
+        {cfg.overlays.map((o) => (
+          <div key={o.key} className="flex items-center gap-1">
+            <span
+              className="inline-block w-3 h-3 rounded-full"
+              style={{ backgroundColor: o.color }}
+            />
+            <span>{OVERLAY_LABELS[o.key]}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show current status colors on the map view via a fixed legend
- list base and overlay statuses with color swatches and labels

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96fd53f9c832cb90e11716de32b25