### PR TITLE
feat: show version and commit hash on dev pages

### DIFF
--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -12,6 +12,10 @@ export default function DevPages() {
     { href: '/map?preview=1', label: 'Map (preview)' },
   ] as const;
 
+  const version = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.13.0';
+  const commitHash =
+    process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? process.env.GIT_COMMIT_HASH ?? '開発中';
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
@@ -48,6 +52,10 @@ export default function DevPages() {
           </Link>
         </div>
       </section>
+
+      <div className="mt-8 text-xs text-gray-500 text-right">
+        ver. {version} ({commitHash})
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display app version and commit hash at the bottom of /dev/pages

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96fdb982c832c991e0ac64294c2a7