### PR TITLE
feat(dev): add builder state export page

### DIFF
--- a/web/app/dev/export/page.tsx
+++ b/web/app/dev/export/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { useBuilderStore } from '@/stores/builder';
+import { downloadJson } from '@/lib/download';
+
+export default function DevExportPage() {
+  const { nodes, statuses, statusConfig, publishedSnapshot } = useBuilderStore((s) => ({
+    nodes: s.nodes,
+    statuses: s.statuses,
+    statusConfig: s.statusConfig,
+    publishedSnapshot: s.publishedSnapshot,
+  }));
+
+  const saveDraft = () => {
+    downloadJson(`draft-${Date.now()}.json`, {
+      nodes,
+      statuses,
+      statusConfig,
+    });
+  };
+
+  const savePublished = () => {
+    if (!publishedSnapshot) return;
+    downloadJson(`published-${Date.now()}.json`, publishedSnapshot);
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">/dev/export</h1>
+        <Link href="/dev/pages" className="text-sm text-blue-500 underline">
+          /dev/pages
+        </Link>
+      </div>
+
+      <div className="max-w-sm p-4 rounded-xl border space-y-4">
+        <button
+          type="button"
+          onClick={saveDraft}
+          className="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Draft を保存
+        </button>
+        <button
+          type="button"
+          onClick={savePublished}
+          disabled={!publishedSnapshot}
+          className="px-4 py-2 text-sm font-medium rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+        >
+          Published を保存
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/web/lib/download.ts
+++ b/web/lib/download.ts
@@ -1,0 +1,11 @@
+export function downloadJson(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add /dev/export page to download builder draft and published JSON
- add small downloadJson helper

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97415a314832c9b5c0a7184cc3eb2