### PR TITLE
feat: add snapshot history page

### DIFF
--- a/web/app/dev/snapshots/page.tsx
+++ b/web/app/dev/snapshots/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useBuilderStore } from '@/stores/builder';
+import { loadSnapshots, saveSnapshots, type Snapshot } from '@/lib/snapshots';
+
+export default function DevSnapshotsPage() {
+  const {
+    publishedSnapshot,
+    updateMany,
+    setNodeStatus,
+    setStatusConfig,
+  } = useBuilderStore((s) => ({
+    publishedSnapshot: s.publishedSnapshot,
+    updateMany: s.updateMany,
+    setNodeStatus: s.setNodeStatus,
+    setStatusConfig: s.setStatusConfig,
+  }));
+
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+
+  useEffect(() => {
+    setSnapshots(loadSnapshots());
+  }, []);
+
+  const saveCurrent = () => {
+    if (!publishedSnapshot) return;
+    const next = [...snapshots, publishedSnapshot].slice(-10);
+    setSnapshots(next);
+    saveSnapshots(next);
+  };
+
+  const restore = (snap: Snapshot) => {
+    updateMany(
+      snap.nodes.map((n) => ({ id: n.id, x: n.x, y: n.y, w: n.w, h: n.h }))
+    );
+    Object.entries(snap.statuses).forEach(([id, st]) => setNodeStatus(id, st));
+    setStatusConfig((draft) => Object.assign(draft, snap.statusConfig));
+  };
+
+  const list = [...snapshots].reverse();
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">/dev/snapshots</h1>
+        <Link href="/dev/pages" className="text-sm text-blue-500 underline">
+          /dev/pages
+        </Link>
+      </div>
+
+      <div className="space-y-4 max-w-md">
+        <button
+          type="button"
+          onClick={saveCurrent}
+          disabled={!publishedSnapshot}
+          className="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          現在の publishedSnapshot を履歴に保存
+        </button>
+
+        <ul className="space-y-3">
+          {list.map((snap, i) => (
+            <li
+              key={snap.at + '-' + i}
+              className="p-4 rounded-xl border flex items-center justify-between"
+            >
+              <div>
+                <div className="font-medium">
+                  {new Date(snap.at).toLocaleString()}
+                </div>
+                <div className="text-xs text-zinc-500">{snap.nodes.length} 件</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => restore(snap)}
+                className="px-3 py-1 text-xs rounded bg-green-600 text-white hover:bg-green-700"
+              >
+                この履歴を復元
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/web/lib/snapshots.ts
+++ b/web/lib/snapshots.ts
@@ -1,0 +1,41 @@
+export type SnapshotNode = {
+  id: string;
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+};
+
+import type { NodeStatus, StatusConfig } from '@/types/status';
+
+export type Snapshot = {
+  nodes: SnapshotNode[];
+  statuses: Record<string, NodeStatus>;
+  statusConfig: StatusConfig;
+  at: number;
+};
+
+const KEY = 'snapshots';
+
+export function loadSnapshots(): Snapshot[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as Snapshot[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveSnapshots(snaps: Snapshot[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(KEY, JSON.stringify(snaps));
+  } catch {
+    // ignore
+  }
+}
+


### PR DESCRIPTION
## Summary
- add localStorage snapshot history utilities
- create /dev/snapshots page for save/list/restore published snapshots

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b977232588832c92c4cd6449e6baab