### PR TITLE
feat: memoize draggable node wrapper

### DIFF
--- a/web/components/canvas/DraggableNodeWrapper.tsx
+++ b/web/components/canvas/DraggableNodeWrapper.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, memo, useMemo } from 'react'
 import type React from 'react'
 import { useBuilderStore } from '@/stores/builder'
 import { computeBgColor, buildMotionFromStatus } from '@/lib/status-engine'
@@ -11,51 +11,64 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
 }
 
-export default function DraggableNodeWrapper({ id, style, className, children, ...rest }: Props) {
-  const cfg = useBuilderStore((s) => s.statusConfig)
-  const status = useBuilderStore((s) => s.getNodeStatus(id))
-  const ref = useRef<HTMLDivElement>(null)
-  const { bg, filter } = computeBgColor(status, cfg)
-  const motion = buildMotionFromStatus(id, status, cfg)
+const DEFAULT_STATUS = { base: 'notVisited', overlays: [] as string[] }
 
-  // pulse animation
-  useEffect(() => {
-    if (!ref.current || !motion) return
-    const inst = animate({ targets: ref.current, loop: true, ...motion })
-    return () => inst.pause()
-  }, [motion])
+const DraggableNodeWrapper = memo(
+  function DraggableNodeWrapper({ id, style, className, children, ...rest }: Props) {
+    const cfg = useBuilderStore((s) => s.statusConfig)
+    const base = useBuilderStore((s) => s.statuses[id]?.base ?? DEFAULT_STATUS.base)
+    const overlays = useBuilderStore((s) => s.statuses[id]?.overlays ?? DEFAULT_STATUS.overlays)
+    const status = useMemo(() => ({ base, overlays }), [base, overlays])
+    const ref = useRef<HTMLDivElement>(null)
+    const { bg, filter } = useMemo(() => computeBgColor(status, cfg), [status, cfg])
+    const motion = useMemo(() => buildMotionFromStatus(id, status, cfg), [id, status, cfg])
 
-  // flash animation on status change
-  const prev = useRef<{ base: string; overlays: string }>()
-  useEffect(() => {
-    const cur = { base: status.base, overlays: status.overlays.join(',') }
-    let a: ReturnType<typeof animate> | undefined
-    if (ref.current && prev.current) {
-      if (prev.current.base !== cur.base || prev.current.overlays !== cur.overlays) {
-        a = animate({
-          targets: ref.current,
-          scale: [1, 1.05],
-          opacity: [1, 0.6],
-          direction: 'alternate',
-          duration: 200,
-          easing: 'easeOutSine',
-        })
+    // pulse animation
+    useEffect(() => {
+      if (!ref.current || !motion) return
+      const inst = animate({ targets: ref.current, loop: true, ...motion })
+      return () => inst.pause()
+    }, [motion])
+
+    // flash animation on status change
+    const prev = useRef<{ base: string; overlays: string[] }>()
+    useEffect(() => {
+      const cur = { base, overlays }
+      let a: ReturnType<typeof animate> | undefined
+      if (ref.current && prev.current) {
+        if (prev.current.base !== cur.base || prev.current.overlays !== cur.overlays) {
+          a = animate({
+            targets: ref.current,
+            scale: [1, 1.05],
+            opacity: [1, 0.6],
+            direction: 'alternate',
+            duration: 200,
+            easing: 'easeOutSine',
+          })
+        }
       }
-    }
-    prev.current = cur
-    return () => a?.pause()
-  }, [status.base, status.overlays.join(',')])
+      prev.current = cur
+      return () => a?.pause()
+    }, [base, overlays])
 
-  return (
-    <div
-      ref={ref}
-      data-node-id={id}
-      style={{ background: bg, filter, ...style }}
-      className={className}
-      {...rest}
-    >
-      {children}
-    </div>
-  )
-}
+    return (
+      <div
+        ref={ref}
+        data-node-id={id}
+        style={{ background: bg, filter, ...style }}
+        className={className}
+        {...rest}
+      >
+        {children}
+      </div>
+    )
+  },
+  (prev, next) =>
+    prev.id === next.id &&
+    prev.children === next.children &&
+    prev.className === next.className &&
+    prev.style === next.style,
+)
+
+export default DraggableNodeWrapper
 


### PR DESCRIPTION
## Summary
- memoize DraggableNodeWrapper to cut down needless re-renders
- subscribe to only needed builder store slices and memoize status-dependent calculations
- limit animation effects to run only when status actually changes

## Testing
- `pnpm -C web build`

------
https://chatgpt.com/codex/tasks/task_e_68b9774459c8832cab204911fb5930ba