### PR TITLE
feat: add root error boundary

### DIFF
--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/Button'
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  const router = useRouter()
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h2 className="text-lg font-semibold">問題が発生しました</h2>
+      <div className="flex gap-2">
+        <Button onClick={() => reset()}>再読み込み</Button>
+        <Button onClick={() => router.push('/dev/pages')}>/dev/pages へ</Button>
+      </div>
+      <details className="mt-4 w-full max-w-lg text-left">
+        <summary className="cursor-pointer text-sm opacity-70">詳細</summary>
+        <pre className="mt-2 max-h-[50vh] overflow-auto whitespace-pre-wrap text-xs">{String(error.stack || error.message)}</pre>
+      </details>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add root error boundary with reload and /dev/pages link
- show collapsible error details for debugging

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b97973e620832ca9c37c8112f22489