### PR TITLE
ci: add minimal build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm -C web install --frozen-lockfile
+      - run: pnpm -C web build
+      # typecheck スクリプトがあれば以下を追加（なければスキップ可）
+      # - run: pnpm -C web typecheck


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install and build `web` package on push/PR to main

## Testing
- `pnpm -C web install --frozen-lockfile`
- `pnpm -C web build`


------
https://chatgpt.com/codex/tasks/task_e_68b97c130574832c88aab0e8e9e33001