### PR TITLE
docs(web): add minimal operation guide

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,3 +1,36 @@
+## 最小運用ガイド
+
+### 起動 / ビルド
+
+- 起動: `pnpm -C web dev`
+- ビルド: `pnpm -C web build`
+
+### 主要URL
+
+- `/builder`（編集 → Publish）
+- `/map`（published） / `/map?preview=1`（draft）
+- `/share?id=<nodeId>`（共有用単体ビュー）
+- `/dev/pages`（索引・テーマ・ユーティリティ）
+
+### 操作フロー（3ステップ）
+
+1. `/builder` で編集（ステータス/配置）
+2. **Publish** → 最終公開日時が更新
+3. `/map` で確認、必要に応じて `/share` を共有
+
+### Export / Import
+
+- `/dev/export` でエクスポート
+- `/dev/import` でインポート
+
+### 既知の注意
+
+- クライアント専用 UI は `'use client'` 付きの分離コンポーネントにします
+- `Link` の `href` は静的文字列のみ使用可
+- `dynamic import` は `ssr: false` が必要な場合があります
+- StatusConfig の `compose.order === 'priority'` のとき、Overlay は priority 降順で合成します
+- `mode: glow` は drop-shadow + 微少スケールアニメ を適用します（anime.js）
+
 ## Builder → Map 反映フロー
 
 - `/builder` で各ノードの **Base/Overlay** を編集（`StatusDropdown`）。
@@ -13,12 +46,4 @@ pnpm -C web i
 pnpm -C web dev
 pnpm -C web build
 ```
-
-注意
-
-App Router の都合で、クライアント専用 UI は 'use client' 付きの分離コンポーネントにしています。
-
-StatusConfig の compose.order === 'priority' のとき、Overlay は priority 降順 で合成します。
-
-mode: glow は drop-shadow + 微少スケールアニメ を適用します（anime.js）。
 


### PR DESCRIPTION
## Summary
- add quick-start startup/build commands and main URLs to `web/README.md`
- document basic editing -> publish -> share flow and export/import endpoints
- note known caveats for client components, static links, and ssr-disabled imports

## Testing
- `pnpm -C web build`


------
https://chatgpt.com/codex/tasks/task_e_68b97c095050832c8bf27fd9e6698219