### PR TITLE
feat: add runtime feature flag helper

### DIFF
--- a/web/lib/flags.ts
+++ b/web/lib/flags.ts
@@ -1,2 +1,12 @@
 export const ENABLE_DYNAMIC_ELM_IMPORT = false
 export const ENABLE_UNIFIED_PREVIEW = true
+
+export function isFlagOn(key: string): boolean {
+  if (typeof window !== 'undefined') {
+    const v = localStorage.getItem(`flags.${key}`)
+    if (v === 'true') return true
+    if (v === 'false') return false
+  }
+  const env = process.env[`NEXT_PUBLIC_FLAG_${key.toUpperCase()}`]
+  return env === 'true'
+}


### PR DESCRIPTION
## Summary
- add `isFlagOn` helper to read runtime feature flags

## Testing
- `CI=1 pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68b97f038078832cb5c908e2f52477d2