### PR TITLE
feat: add feature flag checks for heavy effects

### DIFF
--- a/web/components/canvas/DraggableNodeWrapper.tsx
+++ b/web/components/canvas/DraggableNodeWrapper.tsx
@@ -5,6 +5,7 @@ import type React from 'react'
 import { useBuilderStore } from '@/stores/builder'
 import { computeBgColor, buildMotionFromStatus } from '@/lib/status-engine'
 import { animate } from 'animejs'
+import { isFlagOn } from '@/lib/flags'
 
 interface Props {
   id: string
@@ -23,24 +24,41 @@ const DraggableNodeWrapper = memo(
     })
     const cfg = useBuilderStore((s) => s.statusConfig)
     const ref = useRef<HTMLDivElement>(null)
-    const { bg, filter } = useMemo(() => computeBgColor(status, cfg), [status, cfg])
-    const motion = useMemo(() => buildMotionFromStatus(id, status, cfg), [id, status, cfg])
+
+    const renderStatus = useMemo(() => {
+      if (!isFlagOn('glowOff')) return status
+      const glowKeys = new Set(
+        cfg.overlays.filter((o) => o.mode === 'glow').map((o) => o.key),
+      )
+      const overlays = status.overlays.filter((k) => !glowKeys.has(k))
+      return overlays.length === status.overlays.length
+        ? status
+        : { ...status, overlays }
+    }, [status])
+
+    const { bg, filter } = useMemo(
+      () => computeBgColor(renderStatus, cfg),
+      [renderStatus],
+    )
 
     // pulse animation
     useEffect(() => {
-      if (!ref.current || !motion) return
+      if (!ref.current || isFlagOn('heavyAnimationOff')) return
+      const motion = buildMotionFromStatus(id, renderStatus, cfg)
+      if (!motion) return
       const inst = animate({ targets: ref.current, loop: true, ...motion })
       return () => inst.pause()
-    }, [motion])
+    }, [renderStatus])
 
     // flash animation on status change
-    const prev = useRef<typeof status>()
+    const prev = useRef<typeof renderStatus>()
     useEffect(() => {
       let a: ReturnType<typeof animate> | undefined
       if (
         ref.current &&
         prev.current &&
-        (prev.current.base !== status.base || prev.current.overlays !== status.overlays)
+        (prev.current.base !== renderStatus.base ||
+          prev.current.overlays !== renderStatus.overlays)
       ) {
         a = animate({
           targets: ref.current,
@@ -51,9 +69,9 @@ const DraggableNodeWrapper = memo(
           easing: 'easeOutSine',
         })
       }
-      prev.current = status
+      prev.current = renderStatus
       return () => a?.pause()
-    }, [status])
+    }, [renderStatus])
 
     const child = Children.only(children)
     return cloneElement(child, {


### PR DESCRIPTION
## Summary
- use feature flags to disable glow overlays and drop-shadow
- skip heavy loop animations when `heavyAnimationOff` flag is enabled

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b97f0b2f94832cbcfcde0f1b985d66