### PR TITLE
feat: show version and commit hash on dev pages

### DIFF
--- a/web/app/dev/pages/page.tsx
+++ b/web/app/dev/pages/page.tsx
@@ -13,8 +13,7 @@ export default function DevPages() {
   ] as const;
 
   const version = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.13.0';
-  const commitHash =
-    process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? process.env.GIT_COMMIT_HASH ?? '開発中';
+  const commitHash = process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? '開発中';
 
   return (
     <div className="p-6 space-y-6">


### PR DESCRIPTION
## Summary
- display app version and commit hash at the bottom of /dev/pages
- only read commit hash from NEXT_PUBLIC_GIT_COMMIT_HASH in client component

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9883ac0f0832cbf003c7afc7c6302