### PR TITLE
fix: guard missing statuses in snapshot diff viewer

### DIFF
--- a/web/app/dev/snapshot-diff/page.tsx
+++ b/web/app/dev/snapshot-diff/page.tsx
@@ -31,9 +31,11 @@ function arrayEqual(a: readonly string[] = [], b: readonly string[] = []) {
 }
 
 function diffStatuses(a: Snapshot, b: Snapshot) {
+  const statusesA = a.statuses || {};
+  const statusesB = b.statuses || {};
   const ids = new Set([
-    ...Object.keys(a.statuses || {}),
-    ...Object.keys(b.statuses || {}),
+    ...Object.keys(statusesA),
+    ...Object.keys(statusesB),
   ]);
   const res: {
     id: string;
@@ -44,8 +46,8 @@ function diffStatuses(a: Snapshot, b: Snapshot) {
     type: string;
   }[] = [];
   ids.forEach((id) => {
-    const sa = a.statuses[id];
-    const sb = b.statuses[id];
+    const sa = statusesA[id];
+    const sb = statusesB[id];
     if (!sa && sb) {
       res.push({
         id,


### PR DESCRIPTION
## Summary
- avoid crashes when comparing snapshots with missing status data

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b988afac54832c9a821c61a9b749e7