### PR TITLE
fix: statically reference runtime flags

### DIFF
--- a/web/lib/flags.ts
+++ b/web/lib/flags.ts
@@ -1,12 +1,21 @@
 export const ENABLE_DYNAMIC_ELM_IMPORT = false
 export const ENABLE_UNIFIED_PREVIEW = true
 
-export function isFlagOn(key: string): boolean {
+const envFlags = {
+  glowOff: process.env.NEXT_PUBLIC_FLAG_GLOWOFF === 'true',
+  heavyAnimationOff:
+    process.env.NEXT_PUBLIC_FLAG_HEAVYANIMATIONOFF === 'true',
+  legendOff: process.env.NEXT_PUBLIC_FLAG_LEGENDOFF === 'true',
+  tooltipOff: process.env.NEXT_PUBLIC_FLAG_TOOLTIPOFF === 'true',
+} as const
+
+export type RuntimeFlag = keyof typeof envFlags
+
+export function isFlagOn(key: RuntimeFlag): boolean {
   if (typeof window !== 'undefined') {
     const v = localStorage.getItem(`flags.${key}`)
     if (v === 'true') return true
     if (v === 'false') return false
   }
-  const env = process.env[`NEXT_PUBLIC_FLAG_${key.toUpperCase()}`]
-  return env === 'true'
+  return envFlags[key]
 }


### PR DESCRIPTION
## Summary
- avoid dynamic environment lookup for runtime flags
- type runtime flag helper and reference flag env vars directly

## Testing
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b988b8dab0832cba88afbb7d39c775