### PR TITLE
feat: add global theme provider and hook

### DIFF
--- a/web/lib/builder/themes/ThemeProvider.tsx
+++ b/web/lib/builder/themes/ThemeProvider.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React, { createContext, useContext, useEffect } from 'react';
+import { create } from 'zustand';
+import type { ThemeTokens } from './themeTokens';
+import { defaultTheme } from './themeTokens';
+
+export type ThemeState = {
+  theme: ThemeTokens;
+  setTheme: (tokens: ThemeTokens) => void;
+};
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  theme: defaultTheme,
+  setTheme: (tokens) => set({ theme: tokens }),
+}));
+
+const ThemeContext = createContext<ThemeState | null>(null);
+
+export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const state = useThemeStore();
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const { colors, radius, fontSize } = state.theme;
+    const vars: Record<string, string> = {
+      '--color-primary': colors.primary,
+      '--color-secondary': colors.secondary,
+      '--color-background': colors.background,
+      '--color-surface': colors.surface,
+      '--color-text': colors.text,
+      '--radius-sm': radius.sm,
+      '--radius-md': radius.md,
+      '--radius-lg': radius.lg,
+      '--font-size-sm': fontSize.sm,
+      '--font-size-base': fontSize.base,
+      '--font-size-lg': fontSize.lg,
+      '--font-size-xl': fontSize.xl,
+    };
+
+    Object.entries(vars).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
+  }, [state.theme]);
+
+  return <ThemeContext.Provider value={state}>{children}</ThemeContext.Provider>;
+};
+
+export const useThemeContext = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return ctx;
+};

--- a/web/lib/builder/themes/themeTokens.ts
+++ b/web/lib/builder/themes/themeTokens.ts
@@ -1,0 +1,43 @@
+export type ThemeTokens = {
+  colors: {
+    primary: string;
+    secondary: string;
+    background: string;
+    surface: string;
+    text: string;
+  };
+  radius: {
+    sm: string;
+    md: string;
+    lg: string;
+  };
+  fontSize: {
+    sm: string;
+    base: string;
+    lg: string;
+    xl: string;
+  };
+};
+
+export const defaultTheme: ThemeTokens = {
+  colors: {
+    primary: '#1d4ed8',
+    secondary: '#9333ea',
+    background: '#ffffff',
+    surface: '#f3f4f6',
+    text: '#111827',
+  },
+  radius: {
+    sm: '4px',
+    md: '8px',
+    lg: '16px',
+  },
+  fontSize: {
+    sm: '0.875rem',
+    base: '1rem',
+    lg: '1.125rem',
+    xl: '1.25rem',
+  },
+};
+
+export default defaultTheme;

--- a/web/lib/builder/themes/useTheme.ts
+++ b/web/lib/builder/themes/useTheme.ts
@@ -1,0 +1,38 @@
+import { useEffect, useMemo } from 'react';
+import type { ThemeTokens } from './themeTokens';
+import { defaultTheme } from './themeTokens';
+import { useThemeContext } from './ThemeProvider';
+
+const mergeTheme = (base: ThemeTokens, override?: Partial<ThemeTokens>): ThemeTokens => {
+  if (!override) return base;
+  return {
+    colors: { ...base.colors, ...override.colors },
+    radius: { ...base.radius, ...override.radius },
+    fontSize: { ...base.fontSize, ...override.fontSize },
+  };
+};
+
+const resolveTheme = (
+  current: ThemeTokens,
+  override?: Partial<ThemeTokens>
+): ThemeTokens => mergeTheme(current, override);
+
+export const useTheme = (options?: {
+  override?: Partial<ThemeTokens>;
+  scope?: 'global' | 'local';
+}): ThemeTokens => {
+  const { theme, setTheme } = useThemeContext();
+
+  useEffect(() => {
+    if (options?.override && options.scope === 'global') {
+      setTheme(resolveTheme(theme, options.override));
+    }
+  }, [options?.override, options?.scope, setTheme, theme]);
+
+  return useMemo(() => {
+    const merged = resolveTheme(theme, options?.override);
+    return mergeTheme(defaultTheme, merged);
+  }, [theme, options?.override]);
+};
+
+export default useTheme;


### PR DESCRIPTION
## Summary
- add theme token types and defaults
- create ThemeProvider with Zustand and CSS variable injection
- expose useTheme hook supporting local and global overrides

## Testing
- ⚠️ `pnpm -C web lint` (failed: Invalid Options - Unknown options)
- ⚠️ `pnpm -C web typecheck` (failed: lib/vector/flatten.ts(79,84): error TS2345: Argument of type '{ x: number; y: number; }' is not assignable to parameter of type 'PathPoint'.)


------
https://chatgpt.com/codex/tasks/task_e_68b99cdd623c832ca033d86e8aa65b6d