### PR TITLE
feat: add theme provider and store

### DIFF
--- a/web/components/theme/ThemeProvider.tsx
+++ b/web/components/theme/ThemeProvider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { createContext, useContext, useEffect } from 'react';
+import { useThemeStore, type ThemeTokens } from '@/stores/themeStore';
+
+export type ThemeContextValue = {
+  themeId: string;
+  themeTokens: ThemeTokens;
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  themeId: '',
+  themeTokens: { color: {}, radius: {}, spacing: {}, font: {} },
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const themeId = useThemeStore((s) => s.themeId);
+  const tokens = useThemeStore((s) => s.themeTokens);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    Object.entries(tokens.color).forEach(([k, v]) => root.style.setProperty(`--color-${k}`, v));
+    Object.entries(tokens.radius).forEach(([k, v]) => root.style.setProperty(`--radius-${k}`, `${v}px`));
+    Object.entries(tokens.spacing).forEach(([k, v]) => root.style.setProperty(`--spacing-${k}`, `${v}px`));
+    Object.entries(tokens.font).forEach(([k, v]) => root.style.setProperty(`--font-${k}`, v));
+  }, [tokens]);
+
+  return (
+    <ThemeContext.Provider value={{ themeId, themeTokens: tokens }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/web/stores/themeStore.ts
+++ b/web/stores/themeStore.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { create } from 'zustand';
+
+export type ThemeTokens = {
+  color: Record<string, string>;
+  radius: Record<string, number>;
+  spacing: Record<string, number>;
+  font: Record<string, string>;
+};
+
+export type ThemeState = {
+  themeId: string;
+  themeTokens: ThemeTokens;
+  setTheme: (id: string) => void;
+  applyUserSkin: (tokens: Partial<ThemeTokens>) => void;
+};
+
+const THEMES: Record<string, ThemeTokens> = {
+  geokore: {
+    color: { primary: '#2563eb' },
+    radius: { sm: 4, md: 8 },
+    spacing: { md: 8, lg: 16 },
+    font: { base: 'Inter, sans-serif' },
+  },
+  tamadigi: {
+    color: { primary: '#7c3aed' },
+    radius: { sm: 6, md: 12 },
+    spacing: { md: 10, lg: 20 },
+    font: { base: 'Noto Sans JP, sans-serif' },
+  },
+  tamalogi: {
+    color: { primary: '#059669' },
+    radius: { sm: 2, md: 4 },
+    spacing: { md: 6, lg: 12 },
+    font: { base: 'Roboto, sans-serif' },
+  },
+};
+
+function detectInitialTheme(): string {
+  if (typeof window === 'undefined') return 'geokore';
+  const host = window.location.hostname;
+  if (host.includes('tamadigi')) return 'tamadigi';
+  if (host.includes('tamalogi')) return 'tamalogi';
+  return 'geokore';
+}
+
+export const useThemeStore = create<ThemeState>((set) => {
+  const id = detectInitialTheme();
+  return {
+    themeId: id,
+    themeTokens: THEMES[id],
+    setTheme: (nextId) => {
+      const tokens = THEMES[nextId] ?? THEMES.geokore;
+      set({ themeId: nextId, themeTokens: tokens });
+    },
+    applyUserSkin: (tokens) =>
+      set((s) => ({
+        themeTokens: {
+          color: { ...s.themeTokens.color, ...tokens.color },
+          radius: { ...s.themeTokens.radius, ...tokens.radius },
+          spacing: { ...s.themeTokens.spacing, ...tokens.spacing },
+          font: { ...s.themeTokens.font, ...tokens.font },
+        },
+      })),
+  };
+});


### PR DESCRIPTION
## Summary
- add ThemeProvider to inject theme tokens via CSS variables
- create Zustand themeStore with domain-based defaults and user skin support

## Testing
- `pnpm --filter ./web lint` *(fails: Unknown options: useEslintrc, extensions...)*
- `pnpm --filter ./web typecheck` *(fails: Property 'setCamera' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ea8bbd0832caa0da3ce633704f7