### PR TITLE
feat: add dynamic preview page

### DIFF
--- a/web/app/preview/[pageId]/page.tsx
+++ b/web/app/preview/[pageId]/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+export const dynamic = 'force-dynamic'
+import React, { useEffect, useMemo } from 'react'
+import { useParams } from 'next/navigation'
+import { motion } from 'framer-motion'
+import { usePageStore } from '@/store/pageStore'
+import { NodeRendererCompat } from '@/components/NodeRendererCompat'
+import TokenStyle from '@/components/theme/TokenStyle'
+import { mountLiveSync } from '@/store/liveSync'
+
+export default function PreviewByPageId() {
+  const { pageId } = useParams<{ pageId: string }>()
+  const page = usePageStore((s) => s.pages.find((p) => p.id === pageId))
+  const elements = page?.tree || []
+
+  useEffect(() => {
+    mountLiveSync('preview')
+  }, [])
+
+  const roots = useMemo(() => (elements as any[]).filter((e: any) => !e.parentId), [elements])
+
+  if (!page) return <div className="p-4">Page not found</div>
+
+  return (
+    <>
+      <TokenStyle />
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2 }}
+        className="w-full h-screen relative bg-black"
+      >
+        {roots.map((n: any) => (
+          <NodeRendererCompat key={String(n.id)} node={n} />
+        ))}
+      </motion.div>
+    </>
+  )
+}

--- a/web/components/builder/ShareMenu.tsx
+++ b/web/components/builder/ShareMenu.tsx
@@ -1,16 +1,18 @@
 'use client'
 import React, { useRef, useState } from 'react'
 import { useBuilderStore } from '@/store/builderStore'
-import { encodeShare, serializeProject } from '@/lib/share'
+import { usePageStore } from '@/store/pageStore'
+import { serializeProject } from '@/lib/share'
 
 export function ShareMenu() {
-  const state = useBuilderStore(s => ({ elements: s.elements, meta: s.meta }))
+  const state = useBuilderStore((s) => ({ elements: s.elements, meta: s.meta }))
+  const currentPageId = usePageStore((s) => s.currentPageId)
   const [msg, setMsg] = useState<string>('')
   const fileRef = useRef<HTMLInputElement | null>(null)
 
   function currentUrl() {
     const base = typeof window !== 'undefined' ? window.location.origin : ''
-    return base + '/preview?d=' + encodeShare(serializeProject(state))
+    return base + '/preview/' + currentPageId
   }
 
   async function copyUrl() {


### PR DESCRIPTION
## Summary
- add dynamic `/preview/[pageId]` route for real-time page preview
- hook preview button to open current pageId

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99eb9e228832c8eed902ed661e1c5