### PR TITLE
feat: add useTheme hook

### DIFF
--- a/web/hooks/useTheme.ts
+++ b/web/hooks/useTheme.ts
@@ -1,0 +1,67 @@
+'use client'
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+
+export type ThemeToken = {
+  color: string
+  radius: string
+  spacing: string
+  fontSize: string
+}
+
+const defaultTheme: ThemeToken = {
+  color: '#000',
+  radius: '0.25rem',
+  spacing: '0.5rem',
+  fontSize: '1rem',
+}
+
+const DomainThemeContext = createContext<Partial<ThemeToken>>({})
+const LayoutThemeContext = createContext<Partial<ThemeToken>>({})
+
+export const DomainThemeProvider = ({
+  value,
+  children,
+}: {
+  value?: Partial<ThemeToken>
+  children: ReactNode
+}) => {
+  const parent = useContext(DomainThemeContext)
+  const merged = useMemo(() => ({ ...parent, ...value }), [parent, value])
+  return (
+    <DomainThemeContext.Provider value={merged}>
+      {children}
+    </DomainThemeContext.Provider>
+  )
+}
+
+export const LayoutThemeProvider = ({
+  value,
+  children,
+}: {
+  value?: Partial<ThemeToken>
+  children: ReactNode
+}) => {
+  const parent = useContext(LayoutThemeContext)
+  const merged = useMemo(() => ({ ...parent, ...value }), [parent, value])
+  return (
+    <LayoutThemeContext.Provider value={merged}>
+      {children}
+    </LayoutThemeContext.Provider>
+  )
+}
+
+export function useTheme(overrides?: Partial<ThemeToken>): ThemeToken {
+  const domain = useContext(DomainThemeContext)
+  const layout = useContext(LayoutThemeContext)
+  return {
+    color: overrides?.color ?? layout.color ?? domain.color ?? defaultTheme.color,
+    radius: overrides?.radius ?? layout.radius ?? domain.radius ?? defaultTheme.radius,
+    spacing: overrides?.spacing ?? layout.spacing ?? domain.spacing ?? defaultTheme.spacing,
+    fontSize:
+      overrides?.fontSize ?? layout.fontSize ?? domain.fontSize ?? defaultTheme.fontSize,
+  }
+}
+
+export default useTheme
+


### PR DESCRIPTION
## Summary
- add ThemeToken type and default theme values
- provide DomainThemeProvider and LayoutThemeProvider with hierarchical overrides
- implement useTheme hook with priority: props > layout > domain > default

## Testing
- `npm test` *(fails: network connectivity ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b99eae6d0c832ca8146d979d7d046c