### PR TITLE
feat(builder): enable preview-to-publish flow

### DIFF
--- a/web/app/builder/pages/[id]/edit/page.tsx
+++ b/web/app/builder/pages/[id]/edit/page.tsx
@@ -1,11 +1,19 @@
-import Link from 'next/link'
+"use client"
+import { useRouter } from 'next/navigation'
 
 export default function PageEditor({ params }: { params: { id: string } }) {
+  const router = useRouter()
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Page Editor</h1>
-        <Link href={`/builder/pages/${params.id}/preview`} className="px-3 py-2 rounded-lg border">Preview</Link>
+        <button
+          onClick={() => router.push(`/builder/pages/${params.id}/preview`)}
+          className="px-3 py-2 rounded-lg border"
+        >
+          Preview
+        </button>
       </div>
       <p className="text-sm text-zinc-500">Editing page: {params.id}</p>
     </div>

--- a/web/app/builder/pages/[id]/preview/page.tsx
+++ b/web/app/builder/pages/[id]/preview/page.tsx
@@ -1,15 +1,22 @@
 'use client'
 import { useState } from 'react'
-import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 export default function PagePreview({ params }: { params: { id: string } }) {
+  const router = useRouter()
   const [published, setPublished] = useState(false)
+
+  const handlePublish = () => {
+    console.log('Publishing page:', params.id)
+    setPublished(true)
+  }
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Page Preview</h1>
         <button
-          onClick={() => setPublished(true)}
+          onClick={handlePublish}
           className="px-3 py-2 rounded-lg border bg-black text-white"
         >
           Publish
@@ -19,9 +26,12 @@ export default function PagePreview({ params }: { params: { id: string } }) {
       {published && (
         <p className="text-sm text-green-600">Published!</p>
       )}
-      <Link href={`/builder/pages/${params.id}/edit`} className="text-blue-600 underline">
+      <button
+        onClick={() => router.push(`/builder/pages/${params.id}/edit`)}
+        className="text-blue-600 underline"
+      >
         Back to edit
-      </Link>
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add client-side Preview button in editor to navigate to preview page
- add Publish action and router navigation from preview back to edit

## Testing
- `pnpm --filter ./web lint`
- `pnpm --filter ./web typecheck` *(fails: hooks/useTheme.ts: error TS1005: '>' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a131f250832cb1924db0144f1244