### PR TITLE
feat: add categorized component library

### DIFF
--- a/components/ContainerBox.tsx
+++ b/components/ContainerBox.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ContainerBox: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  return <div className="p-4 border-2 border-dashed">{children}</div>;
+};
+
+export default ContainerBox;

--- a/components/FormBox.tsx
+++ b/components/FormBox.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const FormBox: React.FC = () => {
+  return (
+    <form className="p-2 border rounded">
+      <input className="border p-1" placeholder="Input" />
+    </form>
+  );
+};
+
+export default FormBox;

--- a/components/TextBlock.tsx
+++ b/components/TextBlock.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TextBlock: React.FC<{ text?: string }> = ({ text = 'Text block' }) => {
+  return <div className="p-2">{text}</div>;
+};
+
+export default TextBlock;

--- a/src/features/uibuilder/editor/Canvas.tsx
+++ b/src/features/uibuilder/editor/Canvas.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { useEditorStore, EditorNode } from './useEditorStore';
-import { getComponentByName } from './componentRegistry';
+import { getComponentById } from './componentRegistry';
 
 function buildClass(node: EditorNode): string {
   const classes = [node.props.className || ''];
@@ -16,7 +16,7 @@ function buildClass(node: EditorNode): string {
 const RenderNode: React.FC<{ node: EditorNode }> = ({ node }) => {
   const select = useEditorStore((s) => s.select);
   const selectedId = useEditorStore((s) => s.selectedId);
-  const Tag = getComponentByName(node.type) || (node.type as any) || 'div';
+  const Tag = getComponentById(node.type) || (node.type as any) || 'div';
   return (
     <Tag
       className={`${buildClass(node)} ${selectedId === node.id ? 'outline outline-blue-500' : ''}`}

--- a/src/features/uibuilder/editor/ComponentLibrary.tsx
+++ b/src/features/uibuilder/editor/ComponentLibrary.tsx
@@ -1,31 +1,60 @@
 import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
-import { getRegisteredComponents } from './componentRegistry';
+import { getRegisteredComponents, RegisteredComponent, ComponentCategory } from './componentRegistry';
+import { useEditorStore } from './useEditorStore';
 
-const builtin = ['Header', 'Section', 'Button'];
+const categories: (ComponentCategory | 'all')[] = ['all', 'action', 'visual', 'functional', 'layout'];
 
-const LibraryItem: React.FC<{ type: string }> = ({ type }) => {
-  const { attributes, listeners, setNodeRef } = useDraggable({ id: `lib-${type}`, data: { type } });
+const LibraryItem: React.FC<{ comp: RegisteredComponent }> = ({ comp }) => {
+  const { attributes, listeners, setNodeRef } = useDraggable({ id: `lib-${comp.id}`, data: { type: comp.id } });
+  const addNode = useEditorStore((s) => s.addNode);
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
-      className="p-2 border rounded bg-white cursor-move"
+      onClick={() => addNode(comp.id)}
+      className="p-2 border rounded bg-white cursor-move flex items-center gap-2"
     >
-      {type}
+      <span>{comp.icon}</span>
+      <span>{comp.name}</span>
     </div>
   );
 };
 
 export const ComponentLibrary: React.FC = () => {
-  const registered = getRegisteredComponents().map((c) => c.name);
-  const items = [...builtin, ...registered];
+  const [category, setCategory] = React.useState<(ComponentCategory | 'all')>('all');
+  const [search, setSearch] = React.useState('');
+  const components = getRegisteredComponents(category === 'all' ? undefined : category).filter((c) =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  );
   return (
-    <div className="p-2 space-y-2 overflow-y-auto h-full bg-gray-50">
-      {items.map((t) => (
-        <LibraryItem key={t} type={t} />
-      ))}
+    <div className="p-2 h-full bg-gray-50 flex flex-col">
+      <div className="flex gap-2 mb-2">
+        <select
+          className="border p-1 flex-1"
+          value={category}
+          onChange={(e) => setCategory(e.target.value as any)}
+        >
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat === 'all' ? 'All' : cat.charAt(0).toUpperCase() + cat.slice(1)}
+            </option>
+          ))}
+        </select>
+        <input
+          className="border p-1 flex-1"
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2 overflow-y-auto">
+        {components.map((c) => (
+          <LibraryItem key={c.id} comp={c} />
+        ))}
+        {!components.length && <div className="text-gray-400">No components</div>}
+      </div>
     </div>
   );
 };

--- a/src/features/uibuilder/editor/componentRegistry.ts
+++ b/src/features/uibuilder/editor/componentRegistry.ts
@@ -1,21 +1,35 @@
 import React from 'react';
 
+export type ComponentCategory = 'action' | 'visual' | 'functional' | 'layout';
+
 export interface RegisteredComponent {
+  id: string;
   name: string;
+  type: ComponentCategory;
+  icon: React.ReactNode;
+  props?: Record<string, any>;
   component: React.ComponentType<any>;
 }
 
 const registry: Record<string, RegisteredComponent> = {};
 
-export function registerComponent(component: React.ComponentType<any>, meta: { name: string }) {
-  registry[meta.name] = { name: meta.name, component };
+export function registerComponent(
+  component: React.ComponentType<any>,
+  meta: Omit<RegisteredComponent, 'component'>
+) {
+  registry[meta.id] = { ...meta, component };
 }
 
-export function getRegisteredComponents(): RegisteredComponent[] {
-  return Object.values(registry);
+export function getRegisteredComponents(type?: ComponentCategory): RegisteredComponent[] {
+  const comps = Object.values(registry);
+  return type ? comps.filter((c) => c.type === type) : comps;
 }
 
-export function getComponentByName(name: string): React.ComponentType<any> | undefined {
-  return registry[name]?.component;
+export function getRegisteredComponent(id: string): RegisteredComponent | undefined {
+  return registry[id];
+}
+
+export function getComponentById(id: string): React.ComponentType<any> | undefined {
+  return registry[id]?.component;
 }
 

--- a/src/features/uibuilder/editor/registerComponents.ts
+++ b/src/features/uibuilder/editor/registerComponents.ts
@@ -1,5 +1,38 @@
 import PublishButton from '../../../../components/PublishButton';
+import TextBlock from '../../../../components/TextBlock';
+import FormBox from '../../../../components/FormBox';
+import ContainerBox from '../../../../components/ContainerBox';
 import { registerComponent } from './componentRegistry';
 
-registerComponent(PublishButton, { name: 'PublishButton' });
+registerComponent(PublishButton, {
+  id: 'publish-button',
+  name: 'Publish Button',
+  type: 'action',
+  icon: '🚀',
+  props: {},
+});
+
+registerComponent(TextBlock, {
+  id: 'text-block',
+  name: 'Text Block',
+  type: 'visual',
+  icon: '📝',
+  props: { text: 'Sample text' },
+});
+
+registerComponent(FormBox, {
+  id: 'form-box',
+  name: 'Form',
+  type: 'functional',
+  icon: '📋',
+  props: {},
+});
+
+registerComponent(ContainerBox, {
+  id: 'container-box',
+  name: 'Container',
+  type: 'layout',
+  icon: '📦',
+  props: {},
+});
 

--- a/src/features/uibuilder/editor/useEditorStore.ts
+++ b/src/features/uibuilder/editor/useEditorStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { getRegisteredComponent } from './componentRegistry';
 
 export interface EditorNode {
   id: string;
@@ -73,7 +74,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       const root = cloneTree(state.root);
       const parent = findNode(root, parentId);
       if (parent) {
-        parent.children.push(createNode(type));
+        const meta = getRegisteredComponent(type);
+        const props = meta?.props || {};
+        parent.children.push(
+          createNode(type, { props: { text: meta?.name || type, ...props } })
+        );
       }
       return { root, history: pushHistory(state.history, state.root), future: [] };
     }),


### PR DESCRIPTION
## Summary
- categorize components with metadata registry
- add category dropdown and search to library sidebar
- include basic components and default props for canvas

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a12361c8832cb98d06c9bd42fe2c