### PR TITLE
feat: add developer registry page

### DIFF
--- a/web/app/dev/registry/page.tsx
+++ b/web/app/dev/registry/page.tsx
@@ -1,22 +1,146 @@
 "use client";
-import { useState, useEffect } from "react";
-import type { ComponentNode } from "@domain-components";
-import { Palette } from "@/components/Palette";
-import { CanvasRenderer } from "@/components/CanvasRenderer";
-import { ActionBus } from "@core/action-bus";
+import { useState, useMemo } from "react";
+import { registry } from "@/lib/registry";
+import { themePresets } from "@/lib/themePresets";
+import { hoverActionPresets } from "@/lib/hoverActionPresets";
+import { animationPresets } from "@/lib/animationPresets";
 
-export default function Page() {
-  const [tree, setTree] = useState<ComponentNode[]>([]);
-  useEffect(() => {
-    const off = ActionBus.on((e) => console.log("ActionBus", e));
-    return off;
-  }, []);
+ type Tab = "components" | "themes" | "hover" | "animations";
+
+export default function DevRegistryPage() {
+  const [tab, setTab] = useState<Tab>("components");
   return (
-    <div className="flex h-[100dvh]">
-      <Palette onAdd={(node) => setTree((t) => [...t, node])} />
-      <div className="flex-1 overflow-auto">
-        <CanvasRenderer tree={tree} />
+    <div className="p-4 space-y-4">
+      <div className="flex gap-2">
+        {[{ key: "components", label: "Components" }, { key: "themes", label: "Themes" }, { key: "hover", label: "Hover Actions" }, { key: "animations", label: "Animations" }].map(t => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key as Tab)}
+            className={`px-2 py-1 rounded border text-sm ${tab === t.key ? "bg-zinc-200 dark:bg-zinc-700" : "bg-transparent"}`}
+          >
+            {t.label}
+          </button>
+        ))}
       </div>
+
+      {tab === "components" && <ComponentsSection />}
+      {tab === "themes" && <ThemesSection />}
+      {tab === "hover" && <HoverSection />}
+      {tab === "animations" && <AnimationSection />}
+    </div>
+  );
+}
+
+function ComponentsSection() {
+  const comps = useMemo(() => Object.values(registry), []);
+  const categories = useMemo(() => {
+    const set = new Set(comps.map(c => c.meta.group || "misc"));
+    return Array.from(set);
+  }, [comps]);
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("all");
+  const filtered = comps.filter(c =>
+    (!search || c.meta.displayName.toLowerCase().includes(search.toLowerCase())) &&
+    (category === "all" || (c.meta.group || "misc") === category)
+  );
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search"
+          className="border px-2 py-1 rounded flex-1 text-sm"
+        />
+        <select
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+          className="border px-2 py-1 rounded text-sm"
+        >
+          <option value="all">All</option>
+          {categories.map(c => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </div>
+      <div className="grid gap-2">
+        {filtered.map(item => (
+          <details key={item.meta.id} className="border rounded p-2">
+            <summary className="cursor-pointer">{item.meta.displayName}</summary>
+            <div className="mt-2 space-y-2 text-sm">
+              <div>Props: {item.meta.props.map(p => p.name).join(", ") || "none"}</div>
+              <div className="border rounded p-2">
+                <item.Render />
+              </div>
+            </div>
+          </details>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ThemesSection() {
+  return (
+    <div className="grid gap-2">
+      {themePresets.map(t => (
+        <details key={t.id} className="border rounded p-2">
+          <summary className="cursor-pointer">{t.name}</summary>
+          <div className="mt-2 space-y-2">
+            <div className="flex gap-2">
+              {Object.entries(t.colors).map(([k, v]) => (
+                <div
+                  key={k}
+                  className="w-6 h-6 rounded"
+                  style={{ backgroundColor: v }}
+                  title={k}
+                />
+              ))}
+            </div>
+            <pre className="text-xs bg-neutral-100 dark:bg-neutral-800 p-2 rounded">{JSON.stringify(t.colors, null, 2)}</pre>
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function HoverSection() {
+  return (
+    <div className="grid gap-2">
+      {hoverActionPresets.map(p => (
+        <details key={p.id} className="border rounded p-2">
+          <summary className="cursor-pointer">{p.name}</summary>
+          <div className="mt-2">
+            <pre className="text-xs bg-neutral-100 dark:bg-neutral-800 p-2 rounded">{JSON.stringify(p.effects, null, 2)}</pre>
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function AnimationSection() {
+  return (
+    <div className="grid gap-2">
+      {animationPresets.map(p => {
+        const sample = p.build(0.5);
+        return (
+          <details key={p.key} className="border rounded p-2">
+            <summary className="cursor-pointer">{p.name}</summary>
+            <div className="mt-2 space-y-2">
+              {p.defaults && (
+                <pre className="text-xs bg-neutral-100 dark:bg-neutral-800 p-2 rounded">
+                  {JSON.stringify(p.defaults, null, 2)}
+                </pre>
+              )}
+              <pre className="text-xs bg-neutral-100 dark:bg-neutral-800 p-2 rounded">
+                {JSON.stringify(sample, null, 2)}
+              </pre>
+            </div>
+          </details>
+        );
+      })}
     </div>
   );
 }

--- a/web/lib/animationPresets.ts
+++ b/web/lib/animationPresets.ts
@@ -1,0 +1,4 @@
+import { MOTION_PRESETS, type MotionPresetDef } from './motion-presets';
+
+export type { MotionPresetDef };
+export const animationPresets: MotionPresetDef[] = Object.values(MOTION_PRESETS);

--- a/web/lib/hoverActionPresets.ts
+++ b/web/lib/hoverActionPresets.ts
@@ -1,0 +1,23 @@
+import type { InteractionPreset } from '@/types/interactions';
+
+export const hoverActionPresets: InteractionPreset[] = [
+  {
+    id: 'hover.lift',
+    name: 'Hover Lift',
+    triggers: ['hover'],
+    effects: [
+      { kind: 'translate', y: -4 },
+      { kind: 'shadow', value: 'lg' },
+    ],
+    transitionMs: 120,
+    updatedAt: 0,
+  },
+  {
+    id: 'hover.fade',
+    name: 'Fade',
+    triggers: ['hover'],
+    effects: [{ kind: 'opacity', value: 0.8 }],
+    transitionMs: 120,
+    updatedAt: 0,
+  },
+];

--- a/web/lib/themePresets.ts
+++ b/web/lib/themePresets.ts
@@ -1,0 +1,33 @@
+export type ThemePreset = {
+  id: string;
+  name: string;
+  colors: {
+    primary: string;
+    secondary: string;
+    background: string;
+    text: string;
+  };
+};
+
+export const themePresets: ThemePreset[] = [
+  {
+    id: 'light',
+    name: 'Light',
+    colors: {
+      primary: '#1d4ed8',
+      secondary: '#9333ea',
+      background: '#ffffff',
+      text: '#111827',
+    },
+  },
+  {
+    id: 'dark',
+    name: 'Dark',
+    colors: {
+      primary: '#3b82f6',
+      secondary: '#f472b6',
+      background: '#111827',
+      text: '#ffffff',
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- add developer registry page with tabs for components, themes, hover actions, and animations
- include search and category filtering for components
- add theme, hover action, and animation preset modules

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a13c2580832c9d3cdb77d12506ba