### PR TITLE
feat: add publish action and theme overrides

### DIFF
--- a/src/features/uibuilder/editor/ComponentLibrary.tsx
+++ b/src/features/uibuilder/editor/ComponentLibrary.tsx
@@ -16,8 +16,14 @@ const LibraryItem: React.FC<{ comp: RegisteredComponent }> = ({ comp }) => {
       onClick={() => addNode(comp.id)}
       className="p-2 border rounded bg-white cursor-move flex items-center gap-2"
     >
-      <span>{comp.icon}</span>
-      <span>{comp.name}</span>
+      <div className="w-8 h-8 flex items-center justify-center">
+        {comp.preview ? <comp.preview /> : <span>{comp.icon}</span>}
+      </div>
+      <div className="flex flex-col">
+        <span>{comp.name}</span>
+        <span className="text-xs text-gray-500">{comp.description}</span>
+        <span className="text-[10px] text-gray-400">{comp.tags.join(', ')}</span>
+      </div>
     </div>
   );
 };

--- a/src/features/uibuilder/editor/componentRegistry.ts
+++ b/src/features/uibuilder/editor/componentRegistry.ts
@@ -7,7 +7,10 @@ export interface RegisteredComponent {
   name: string;
   type: ComponentCategory;
   icon: React.ReactNode;
-  props?: Record<string, any>;
+  tags: string[];
+  description: string;
+  preview?: React.FC;
+  defaultProps?: Record<string, any>;
   component: React.ComponentType<any>;
 }
 

--- a/src/features/uibuilder/editor/registerComponents.ts
+++ b/src/features/uibuilder/editor/registerComponents.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import PublishButton from '../../../../components/PublishButton';
 import TextBlock from '../../../../components/TextBlock';
 import FormBox from '../../../../components/FormBox';
@@ -9,7 +10,10 @@ registerComponent(PublishButton, {
   name: 'Publish Button',
   type: 'action',
   icon: '🚀',
-  props: {},
+  tags: ['action'],
+  description: 'Triggers page publication.',
+  preview: () => <PublishButton />,
+  defaultProps: {},
 });
 
 registerComponent(TextBlock, {
@@ -17,7 +21,10 @@ registerComponent(TextBlock, {
   name: 'Text Block',
   type: 'visual',
   icon: '📝',
-  props: { text: 'Sample text' },
+  tags: ['visual', 'text'],
+  description: 'Displays simple text content.',
+  preview: () => <TextBlock text="Sample text" />,
+  defaultProps: { text: 'Sample text' },
 });
 
 registerComponent(FormBox, {
@@ -25,7 +32,10 @@ registerComponent(FormBox, {
   name: 'Form',
   type: 'functional',
   icon: '📋',
-  props: {},
+  tags: ['functional', 'form'],
+  description: 'Simple form container.',
+  preview: () => <FormBox />,
+  defaultProps: {},
 });
 
 registerComponent(ContainerBox, {
@@ -33,6 +43,9 @@ registerComponent(ContainerBox, {
   name: 'Container',
   type: 'layout',
   icon: '📦',
-  props: {},
+  tags: ['layout', 'container'],
+  description: 'Generic container for layout.',
+  preview: () => <ContainerBox />,
+  defaultProps: {},
 });
 

--- a/src/features/uibuilder/editor/useEditorStore.ts
+++ b/src/features/uibuilder/editor/useEditorStore.ts
@@ -75,7 +75,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       const parent = findNode(root, parentId);
       if (parent) {
         const meta = getRegisteredComponent(type);
-        const props = meta?.props || {};
+        const props = meta?.defaultProps || {};
         parent.children.push(
           createNode(type, { props: { text: meta?.name || type, ...props } })
         );

--- a/web/app/builder/pages/[id]/edit/page.tsx
+++ b/web/app/builder/pages/[id]/edit/page.tsx
@@ -1,21 +1,65 @@
-"use client"
-import { useRouter } from 'next/navigation'
+"use client";
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { usePageStore } from '@/store/pageStore';
+import { toast } from '@/lib/toast';
 
 export default function PageEditor({ params }: { params: { id: string } }) {
-  const router = useRouter()
+  const router = useRouter();
+  const selectPage = usePageStore((s) => s.selectPage);
+  const page = usePageStore((s) => s.pages.find((p) => p.id === s.currentPageId));
+  const theme = usePageStore((s) => s.getTheme());
+  const setTheme = usePageStore((s) => s.setTheme);
+  const [themeJson, setThemeJson] = useState(() => JSON.stringify(theme, null, 2));
+
+  useEffect(() => {
+    selectPage(params.id);
+  }, [params.id, selectPage]);
+
+  useEffect(() => {
+    setThemeJson(JSON.stringify(theme, null, 2));
+  }, [theme]);
+
+  const handleThemeChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setThemeJson(e.target.value);
+    try {
+      const obj = JSON.parse(e.target.value);
+      setTheme(obj);
+    } catch {
+      // ignore invalid JSON
+    }
+  };
+
+  const handlePublish = () => {
+    console.log('Publishing page', { page });
+    toast.success('保存しました');
+  };
 
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Page Editor</h1>
-        <button
-          onClick={() => router.push(`/builder/pages/${params.id}/preview`)}
-          className="px-3 py-2 rounded-lg border"
-        >
-          Preview
-        </button>
+        <div className="flex gap-2">
+          <button onClick={handlePublish} className="px-3 py-2 rounded-lg border">
+            Publish
+          </button>
+          <button
+            onClick={() => router.push(`/builder/pages/${params.id}/preview`)}
+            className="px-3 py-2 rounded-lg border"
+          >
+            Preview
+          </button>
+        </div>
       </div>
       <p className="text-sm text-zinc-500">Editing page: {params.id}</p>
+      <div>
+        <h2 className="font-medium mb-1">Theme Override</h2>
+        <textarea
+          value={themeJson}
+          onChange={handleThemeChange}
+          className="w-full border rounded p-2 h-40 font-mono text-xs"
+        />
+      </div>
     </div>
-  )
+  );
 }

--- a/web/lib/builder/themes/useTheme.ts
+++ b/web/lib/builder/themes/useTheme.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react';
 import type { ThemeTokens } from './themeTokens';
 import { defaultTheme } from './themeTokens';
 import { useThemeContext } from './ThemeProvider';
+import { usePageStore } from '@/store/pageStore';
 
 const mergeTheme = (base: ThemeTokens, override?: Partial<ThemeTokens>): ThemeTokens => {
   if (!override) return base;
@@ -22,6 +23,10 @@ export const useTheme = (options?: {
   scope?: 'global' | 'local';
 }): ThemeTokens => {
   const { theme, setTheme } = useThemeContext();
+  const pageTheme = usePageStore((s) => {
+    const p = s.pages.find((p) => p.id === s.currentPageId);
+    return p?.theme;
+  });
 
   useEffect(() => {
     if (options?.override && options.scope === 'global') {
@@ -30,9 +35,10 @@ export const useTheme = (options?: {
   }, [options?.override, options?.scope, setTheme, theme]);
 
   return useMemo(() => {
-    const merged = resolveTheme(theme, options?.override);
+    const withPage = resolveTheme(theme, pageTheme);
+    const merged = resolveTheme(withPage, options?.override);
     return mergeTheme(defaultTheme, merged);
-  }, [theme, options?.override]);
+  }, [theme, pageTheme, options?.override]);
 };
 
 export default useTheme;

--- a/web/lib/toast.ts
+++ b/web/lib/toast.ts
@@ -1,0 +1,6 @@
+export const toast = {
+  success(message: string) {
+    console.log(`[toast:success] ${message}`);
+  },
+};
+export default toast;

--- a/web/store/pageStore.ts
+++ b/web/store/pageStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { nanoid } from 'nanoid'
 import { type Elm } from '@/store/builderStore'
+import type { ThemeTokens } from '@/lib/builder/themes/themeTokens'
 
 export type PageId = string
 export type RoutePath = `/${string}`
@@ -11,6 +12,7 @@ export type Page = {
   path: RoutePath
   tree: Elm[]
   bindings: Record<`${string}:${string}`, unknown>
+  theme?: Partial<ThemeTokens>
 }
 
 interface PageState {
@@ -31,6 +33,8 @@ interface PageActions {
   setTree: (tree: Elm[]) => void
   getBindings: () => Page['bindings']
   setBindings: (b: Page['bindings']) => void
+  getTheme: () => Page['theme']
+  setTheme: (theme: Page['theme']) => void
   exportJSON: () => string
   importJSON: (json: string) => void
 }
@@ -42,6 +46,7 @@ function defaultPage(idx: number): Page {
     path: idx === 0 ? '/' : (`/page-${idx + 1}` as RoutePath),
     tree: [],
     bindings: {},
+    theme: {},
   }
 }
 
@@ -67,6 +72,7 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
       title: init?.title ?? `Page ${idx + 1}`,
       tree: init?.tree ?? [],
       bindings: init?.bindings ?? {},
+      theme: init?.theme ?? {},
     }
     set({ pages: [...pages, page], currentPageId: page.id })
     return page.id
@@ -94,6 +100,7 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
       path: (`/page-${idx + 1}` as RoutePath),
       tree: JSON.parse(JSON.stringify(src.tree)),
       bindings: JSON.parse(JSON.stringify(src.bindings)),
+      theme: JSON.parse(JSON.stringify(src.theme)),
     }
     set((s) => ({ pages: [...s.pages, newPage], currentPageId: newPage.id }))
     return newPage.id
@@ -127,6 +134,19 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
     set((s) => ({
       pages: s.pages.map((p) =>
         p.id === s.currentPageId ? { ...p, bindings: b } : p,
+      ),
+    }))
+  },
+
+  getTheme() {
+    const p = get().pages.find((p) => p.id === get().currentPageId)
+    return p?.theme ?? {}
+  },
+
+  setTheme(theme) {
+    set((s) => ({
+      pages: s.pages.map((p) =>
+        p.id === s.currentPageId ? { ...p, theme } : p,
       ),
     }))
   },


### PR DESCRIPTION
## Summary
- add Publish button action that logs page data and shows toast
- expand component registry with tags, descriptions, previews, and default props
- enable page-level theme overrides with new store hooks and theme merging

## Testing
- `pnpm -C web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a42e7a48832c82a10e3cdc6e84fb