### PR TITLE
feat(builder): enhance component registry metadata

### DIFF
--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -23,15 +23,31 @@ function Item({ comp }: { comp: RegistryItem }) {
     id: 'palette:' + comp.meta.id,
     data: { from: 'palette', type: 'instance', meta: { componentId: comp.meta.id } },
   })
+  const Preview = comp.meta.preview
   return (
     <button
       ref={setNodeRef}
       {...attributes}
       {...listeners}
-      className="w-full text-left px-2 py-1 border border-zinc-700 rounded hover:bg-zinc-800"
+      className="w-full text-left px-2 py-1 border border-zinc-700 rounded hover:bg-zinc-800 flex items-center gap-2"
       title={comp.meta.id}
     >
-      {comp.meta.displayName}
+      {Preview && (
+        <div className="w-8 h-8 flex items-center justify-center">
+          <Preview />
+        </div>
+      )}
+      <div className="flex flex-col">
+        <span>{comp.meta.displayName}</span>
+        {comp.meta.description && (
+          <span className="text-xs text-zinc-400">{comp.meta.description}</span>
+        )}
+        {comp.meta.tags?.length ? (
+          <span className="text-[10px] text-zinc-500">
+            {comp.meta.tags.join(', ')}
+          </span>
+        ) : null}
+      </div>
     </button>
   )
 }

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { ComponentMeta } from '@/types/builder';
 import Card from '@/components/Card';
 import TripHeader from '@/components/travel/TripHeader';
@@ -92,6 +93,10 @@ register({
     allowChildren: true,
     defaultW: 240,
     defaultH: 160,
+    tags: ['layout', 'container'],
+    description: 'Generic container card.',
+    preview: () => <Card />,
+    defaultProps: {},
   },
   Render: Card,
 });
@@ -104,6 +109,10 @@ register({
     allowChildren: false,
     defaultW: 320,
     defaultH: 80,
+    tags: ['visual'],
+    description: 'Header section for trips.',
+    preview: () => <TripHeader />,
+    defaultProps: {},
   },
   Render: TripHeader,
 });

--- a/web/types/builder.ts
+++ b/web/types/builder.ts
@@ -1,3 +1,5 @@
+import type React from 'react';
+
 export type PropMeta = {
   id: string;
   label: string;
@@ -19,6 +21,14 @@ export type ComponentMeta = {
   preferredSize?: { width: number; height: number };
   defaultW?: number;
   defaultH?: number;
+  /** classification tags for search or filtering */
+  tags?: string[];
+  /** short description shown in libraries */
+  description?: string;
+  /** optional preview component rendered in libraries */
+  preview?: React.FC;
+  /** default props applied on insert */
+  defaultProps?: Record<string, any>;
 };
 
 export type RendererProps = {


### PR DESCRIPTION
## Summary
- extend `ComponentMeta` with tags, description, preview and default props
- surface new metadata in registry and palette

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c614b518832c806a128c786023a5