### PR TITLE
Add publish action and page-level theme overrides

### DIFF
--- a/packages/types/src/builder.ts
+++ b/packages/types/src/builder.ts
@@ -10,6 +10,10 @@ export type PropMeta<T=unknown> = {
 export type ComponentMeta = {
   id: string; displayName: string; group?: string; icon?: string;
   props: PropMeta[]; allowChildren?: boolean;
+  tags?: string[];
+  description?: string;
+  preview?: () => JSX.Element;
+  defaultProps?: Record<string, any>;
 };
 
 export type RendererProps = { nodeId: string; values: Record<string, any>; children?: ReactNode; };

--- a/src/features/uibuilder/editor/componentRegistry.ts
+++ b/src/features/uibuilder/editor/componentRegistry.ts
@@ -9,7 +9,7 @@ export interface RegisteredComponent {
   icon: React.ReactNode;
   tags: string[];
   description: string;
-  preview?: React.FC;
+  preview?: () => JSX.Element;
   defaultProps?: Record<string, any>;
   component: React.ComponentType<any>;
 }

--- a/web/app/builder/pages/[id]/edit/page.tsx
+++ b/web/app/builder/pages/[id]/edit/page.tsx
@@ -3,35 +3,52 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { usePageStore } from '@/store/pageStore';
 import { toast } from '@/lib/toast';
+import ThemeEditor from '@/components/theme/ThemeEditor';
+import { useDesignTokens } from '@/store/designTokensStore';
+import type { ThemeTokens } from '@/lib/builder/themes/themeTokens';
 
 export default function PageEditor({ params }: { params: { id: string } }) {
   const router = useRouter();
   const selectPage = usePageStore((s) => s.selectPage);
-  const page = usePageStore((s) => s.pages.find((p) => p.id === s.currentPageId));
-  const theme = usePageStore((s) => s.getTheme());
   const setTheme = usePageStore((s) => s.setTheme);
-  const [themeJson, setThemeJson] = useState(() => JSON.stringify(theme, null, 2));
+  const [showThemeEditor, setShowThemeEditor] = useState(false);
 
   useEffect(() => {
     selectPage(params.id);
   }, [params.id, selectPage]);
 
-  useEffect(() => {
-    setThemeJson(JSON.stringify(theme, null, 2));
-  }, [theme]);
+  const tokensToTheme = (tokens: Record<string, any>): ThemeTokens => ({
+    colors: {
+      primary: tokens.color?.primary ?? '#1d4ed8',
+      secondary: tokens.color?.accent ?? '#9333ea',
+      background: tokens.color?.background ?? '#ffffff',
+      surface: tokens.color?.surface ?? tokens.color?.border ?? '#f3f4f6',
+      text: tokens.color?.text ?? '#111827',
+    },
+    radius: {
+      sm: `${tokens.radius?.sm ?? 4}px`,
+      md: `${tokens.radius?.md ?? 8}px`,
+      lg: `${tokens.radius?.lg ?? 16}px`,
+    },
+    fontSize: {
+      sm: `${tokens.fontSize?.sm ?? 0.875}rem`,
+      base: `${tokens.fontSize?.base ?? 1}rem`,
+      lg: `${tokens.fontSize?.lg ?? 1.125}rem`,
+      xl: `${tokens.fontSize?.xl ?? 1.25}rem`,
+    },
+  });
 
-  const handleThemeChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setThemeJson(e.target.value);
-    try {
-      const obj = JSON.parse(e.target.value);
-      setTheme(obj);
-    } catch {
-      // ignore invalid JSON
-    }
+  const handleThemeSave = () => {
+    const tokens = useDesignTokens.getState().getAll();
+    const theme = tokensToTheme(tokens);
+    setTheme(theme);
+    setShowThemeEditor(false);
   };
 
   const handlePublish = () => {
-    console.log('Publishing page', { page });
+    const state = usePageStore.getState();
+    const current = state.pages.find((p) => p.id === state.currentPageId);
+    console.log('Publishing page', current);
     toast.success('保存しました');
   };
 
@@ -54,12 +71,34 @@ export default function PageEditor({ params }: { params: { id: string } }) {
       <p className="text-sm text-zinc-500">Editing page: {params.id}</p>
       <div>
         <h2 className="font-medium mb-1">Theme Override</h2>
-        <textarea
-          value={themeJson}
-          onChange={handleThemeChange}
-          className="w-full border rounded p-2 h-40 font-mono text-xs"
-        />
+        <button
+          onClick={() => setShowThemeEditor(true)}
+          className="px-3 py-2 rounded-lg border"
+        >
+          Edit Theme
+        </button>
       </div>
+      {showThemeEditor && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white rounded shadow-lg max-h-[90vh] w-full max-w-2xl overflow-auto">
+            <ThemeEditor />
+            <div className="flex justify-end gap-2 p-4 border-t">
+              <button
+                onClick={() => setShowThemeEditor(false)}
+                className="px-3 py-1 rounded border"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleThemeSave}
+                className="px-3 py-1 rounded bg-blue-600 text-white"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/lib/builder/themes/useTheme.ts
+++ b/web/lib/builder/themes/useTheme.ts
@@ -25,7 +25,7 @@ export const useTheme = (options?: {
   const { theme, setTheme } = useThemeContext();
   const pageTheme = usePageStore((s) => {
     const p = s.pages.find((p) => p.id === s.currentPageId);
-    return p?.theme;
+    return p?.pageOverrides?.theme;
   });
 
   useEffect(() => {
@@ -35,9 +35,9 @@ export const useTheme = (options?: {
   }, [options?.override, options?.scope, setTheme, theme]);
 
   return useMemo(() => {
-    const withPage = resolveTheme(theme, pageTheme);
-    const merged = resolveTheme(withPage, options?.override);
-    return mergeTheme(defaultTheme, merged);
+    const withLayout = mergeTheme(defaultTheme, theme);
+    const withPage = mergeTheme(withLayout, pageTheme);
+    return mergeTheme(withPage, options?.override);
   }, [theme, pageTheme, options?.override]);
 };
 

--- a/web/store/pageStore.ts
+++ b/web/store/pageStore.ts
@@ -12,7 +12,9 @@ export type Page = {
   path: RoutePath
   tree: Elm[]
   bindings: Record<`${string}:${string}`, unknown>
-  theme?: Partial<ThemeTokens>
+  pageOverrides: {
+    theme?: Partial<ThemeTokens>
+  }
 }
 
 interface PageState {
@@ -33,8 +35,8 @@ interface PageActions {
   setTree: (tree: Elm[]) => void
   getBindings: () => Page['bindings']
   setBindings: (b: Page['bindings']) => void
-  getTheme: () => Page['theme']
-  setTheme: (theme: Page['theme']) => void
+  getTheme: () => Page['pageOverrides']['theme']
+  setTheme: (theme: Page['pageOverrides']['theme']) => void
   exportJSON: () => string
   importJSON: (json: string) => void
 }
@@ -46,7 +48,7 @@ function defaultPage(idx: number): Page {
     path: idx === 0 ? '/' : (`/page-${idx + 1}` as RoutePath),
     tree: [],
     bindings: {},
-    theme: {},
+    pageOverrides: { theme: {} },
   }
 }
 
@@ -72,7 +74,7 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
       title: init?.title ?? `Page ${idx + 1}`,
       tree: init?.tree ?? [],
       bindings: init?.bindings ?? {},
-      theme: init?.theme ?? {},
+      pageOverrides: { theme: init?.pageOverrides?.theme ?? {} },
     }
     set({ pages: [...pages, page], currentPageId: page.id })
     return page.id
@@ -100,7 +102,7 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
       path: (`/page-${idx + 1}` as RoutePath),
       tree: JSON.parse(JSON.stringify(src.tree)),
       bindings: JSON.parse(JSON.stringify(src.bindings)),
-      theme: JSON.parse(JSON.stringify(src.theme)),
+      pageOverrides: JSON.parse(JSON.stringify(src.pageOverrides ?? {})),
     }
     set((s) => ({ pages: [...s.pages, newPage], currentPageId: newPage.id }))
     return newPage.id
@@ -140,13 +142,15 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
 
   getTheme() {
     const p = get().pages.find((p) => p.id === get().currentPageId)
-    return p?.theme ?? {}
+    return p?.pageOverrides?.theme ?? {}
   },
 
   setTheme(theme) {
     set((s) => ({
       pages: s.pages.map((p) =>
-        p.id === s.currentPageId ? { ...p, theme } : p,
+        p.id === s.currentPageId
+          ? { ...p, pageOverrides: { ...(p.pageOverrides ?? {}), theme } }
+          : p,
       ),
     }))
   },

--- a/web/types/builder.ts
+++ b/web/types/builder.ts
@@ -26,7 +26,7 @@ export type ComponentMeta = {
   /** short description shown in libraries */
   description?: string;
   /** optional preview component rendered in libraries */
-  preview?: React.FC;
+  preview?: () => JSX.Element;
   /** default props applied on insert */
   defaultProps?: Record<string, any>;
 };


### PR DESCRIPTION
## Summary
- stub publish handler to log current page state
- extend component registry metadata with tags, descriptions, and previews
- support page-specific theme overrides with editor modal and cascading fallback

## Testing
- `pnpm test`
- `pnpm -C web build` *(fails: Expression expected in web/lib/registry.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cf78e6ec832cbb717bcd987b3fc7