### PR TITLE
feat: add theme tokens store and provider

### DIFF
--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -1,0 +1,106 @@
+import React, { createContext, useCallback, useLayoutEffect } from 'react'
+import { useThemeStore, defaultTheme, type ThemeTokens } from '../../stores/themeStore'
+
+interface ThemeContextValue {
+  getEffectiveTheme: (opts?: {
+    pageId?: string
+    layoutId?: string
+    override?: Partial<ThemeTokens>
+  }) => ThemeTokens
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  getEffectiveTheme: () => defaultTheme
+})
+
+function mergeTheme(base: ThemeTokens, override?: Partial<ThemeTokens>): ThemeTokens {
+  if (!override) return base
+  return {
+    ...base,
+    ...override,
+    colors: { ...base.colors, ...override.colors },
+    radius: { ...base.radius, ...override.radius },
+    spacing: { ...base.spacing, ...override.spacing },
+    typography: { ...base.typography, ...override.typography }
+  }
+}
+
+function toCSSVars(theme: ThemeTokens): Record<string, string> {
+  const vars: Record<string, string> = {}
+  Object.entries(theme.colors).forEach(([k, v]) => {
+    vars[`--color-${k}`] = v
+  })
+  Object.entries(theme.radius).forEach(([k, v]) => {
+    vars[`--radius-${k}`] = v
+  })
+  Object.entries(theme.spacing).forEach(([k, v]) => {
+    vars[`--space-${k}`] = v
+  })
+  vars['--font-family'] = theme.typography.fontFamily
+  vars['--font-size-base'] = theme.typography.baseSize
+  vars['--heading-scale'] = String(theme.typography.headingScale)
+  vars['--font-weight-regular'] = theme.typography.weightRegular
+  vars['--font-weight-bold'] = theme.typography.weightBold
+  return vars
+}
+
+export function applyTheme(theme: ThemeTokens, el: HTMLElement) {
+  const vars = toCSSVars(theme)
+  for (const [key, value] of Object.entries(vars)) {
+    el.style.setProperty(key, value)
+  }
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const {
+    currentDomainId,
+    currentLayoutId,
+    currentPageId,
+    domainDefaultTheme,
+    themes,
+    layoutThemeMap,
+    pageThemeOverride
+  } = useThemeStore()
+
+  const getEffectiveTheme = useCallback(
+    ({
+      pageId,
+      layoutId,
+      override
+    }: {
+      pageId?: string
+      layoutId?: string
+      override?: Partial<ThemeTokens>
+    } = {}): ThemeTokens => {
+      const domainThemeId = currentDomainId && domainDefaultTheme[currentDomainId]
+      let theme = domainThemeId && themes[domainThemeId] ? themes[domainThemeId] : defaultTheme
+
+      const layoutThemeId = (layoutId && layoutThemeMap[layoutId]) || (currentLayoutId && layoutThemeMap[currentLayoutId])
+      if (layoutThemeId && themes[layoutThemeId]) {
+        theme = themes[layoutThemeId]
+      }
+
+      const pageOverrideObj =
+        (pageId && pageThemeOverride[pageId]) || (currentPageId && pageThemeOverride[currentPageId])
+      theme = mergeTheme(theme, pageOverrideObj)
+      theme = mergeTheme(theme, override)
+      return theme
+    },
+    [
+      currentDomainId,
+      currentLayoutId,
+      currentPageId,
+      domainDefaultTheme,
+      themes,
+      layoutThemeMap,
+      pageThemeOverride
+    ]
+  )
+
+  useLayoutEffect(() => {
+    const theme = getEffectiveTheme()
+    applyTheme(theme, document.documentElement)
+  }, [getEffectiveTheme])
+
+  return <ThemeContext.Provider value={{ getEffectiveTheme }}>{children}</ThemeContext.Provider>
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,47 @@
+import { useContext, useLayoutEffect, useRef } from 'react'
+import { ThemeContext, applyTheme } from '../components/theme/ThemeProvider'
+import type { ThemeTokens } from '../stores/themeStore'
+
+interface UseThemeOptions {
+  pageId?: string
+  layoutId?: string
+  override?: Partial<ThemeTokens>
+  scope?: 'global' | 'local'
+}
+
+interface UseThemeResult {
+  theme: ThemeTokens
+  attrs?: Record<string, string>
+}
+
+export function useTheme(options?: UseThemeOptions): UseThemeResult {
+  const { getEffectiveTheme } = useContext(ThemeContext)
+  const theme = getEffectiveTheme({
+    pageId: options?.pageId,
+    layoutId: options?.layoutId,
+    override: options?.override
+  })
+
+  const scopeIdRef = useRef<string>()
+
+  useLayoutEffect(() => {
+    const el =
+      options?.scope === 'local'
+        ? scopeIdRef.current
+          ? (document.querySelector(`[data-theme-scope='${scopeIdRef.current}']`) as HTMLElement | null)
+          : null
+        : document.documentElement
+    if (el) {
+      applyTheme(theme, el)
+    }
+  }, [theme, options?.scope])
+
+  if (options?.scope === 'local') {
+    if (!scopeIdRef.current) {
+      scopeIdRef.current = Math.random().toString(36).slice(2, 8)
+    }
+    return { theme, attrs: { 'data-theme-scope': scopeIdRef.current } }
+  }
+
+  return { theme }
+}

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import minimal from '../themes/presets/minimal.json'
+
+export type ThemeTokens = {
+  name: string
+  brandId?: string
+  colors: {
+    background: string
+    surface: string
+    primary: string
+    secondary: string
+    text: string
+    border: string
+  }
+  radius: {
+    sm: string
+    md: string
+    lg: string
+    full: string
+  }
+  spacing: {
+    xs: string
+    sm: string
+    md: string
+    lg: string
+    xl: string
+  }
+  typography: {
+    fontFamily: string
+    baseSize: string
+    headingScale: number
+    weightRegular: string
+    weightBold: string
+  }
+}
+
+export const defaultTheme: ThemeTokens = minimal as ThemeTokens
+
+interface ThemeStore {
+  currentDomainId?: string
+  currentLayoutId?: string
+  currentPageId?: string
+  domainDefaultTheme: Record<string, string>
+  themes: Record<string, ThemeTokens>
+  layoutThemeMap: Record<string, string>
+  pageThemeOverride: Record<string, Partial<ThemeTokens>>
+  setThemeByDomain: (domainId: string, themeId: string) => void
+  setThemeForLayout: (layoutId: string, themeId: string) => void
+  setPageThemeOverride: (pageId: string, override: Partial<ThemeTokens>) => void
+}
+
+export const useThemeStore = create<ThemeStore>((set) => ({
+  currentDomainId: undefined,
+  currentLayoutId: undefined,
+  currentPageId: undefined,
+  domainDefaultTheme: {},
+  themes: { default: defaultTheme },
+  layoutThemeMap: {},
+  pageThemeOverride: {},
+  setThemeByDomain: (domainId, themeId) =>
+    set((state) => ({
+      domainDefaultTheme: { ...state.domainDefaultTheme, [domainId]: themeId }
+    })),
+  setThemeForLayout: (layoutId, themeId) =>
+    set((state) => ({
+      layoutThemeMap: { ...state.layoutThemeMap, [layoutId]: themeId }
+    })),
+  setPageThemeOverride: (pageId, override) =>
+    set((state) => ({
+      pageThemeOverride: {
+        ...state.pageThemeOverride,
+        [pageId]: { ...state.pageThemeOverride[pageId], ...override }
+      }
+    }))
+}))

--- a/src/themes/presets/corporate.json
+++ b/src/themes/presets/corporate.json
@@ -1,0 +1,31 @@
+{
+  "name": "Corporate",
+  "colors": {
+    "background": "#111827",
+    "surface": "#1f2937",
+    "primary": "#2563eb",
+    "secondary": "#10b981",
+    "text": "#f9fafb",
+    "border": "#374151"
+  },
+  "radius": {
+    "sm": "2px",
+    "md": "4px",
+    "lg": "8px",
+    "full": "9999px"
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px"
+  },
+  "typography": {
+    "fontFamily": "Inter, sans-serif",
+    "baseSize": "16px",
+    "headingScale": 1.2,
+    "weightRegular": "400",
+    "weightBold": "700"
+  }
+}

--- a/src/themes/presets/minimal.json
+++ b/src/themes/presets/minimal.json
@@ -1,0 +1,31 @@
+{
+  "name": "Minimal",
+  "colors": {
+    "background": "#0f172a",
+    "surface": "#1e293b",
+    "primary": "#3b82f6",
+    "secondary": "#f59e0b",
+    "text": "#f8fafc",
+    "border": "#334155"
+  },
+  "radius": {
+    "sm": "4px",
+    "md": "8px",
+    "lg": "12px",
+    "full": "9999px"
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px"
+  },
+  "typography": {
+    "fontFamily": "Inter, sans-serif",
+    "baseSize": "16px",
+    "headingScale": 1.25,
+    "weightRegular": "400",
+    "weightBold": "700"
+  }
+}

--- a/src/themes/presets/pop.json
+++ b/src/themes/presets/pop.json
@@ -1,0 +1,31 @@
+{
+  "name": "Pop",
+  "colors": {
+    "background": "#1a1a1a",
+    "surface": "#2a2a2a",
+    "primary": "#e11d48",
+    "secondary": "#14b8a6",
+    "text": "#fafafa",
+    "border": "#52525b"
+  },
+  "radius": {
+    "sm": "4px",
+    "md": "10px",
+    "lg": "20px",
+    "full": "9999px"
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px"
+  },
+  "typography": {
+    "fontFamily": "Inter, sans-serif",
+    "baseSize": "16px",
+    "headingScale": 1.3,
+    "weightRegular": "400",
+    "weightBold": "700"
+  }
+}


### PR DESCRIPTION
## Summary
- add ThemeTokens presets and Zustand theme store
- implement ThemeProvider and useTheme hook for CSS variable injection

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d1ff6430832caf554753b6272162