### PR TITLE
feat: add page save/load API for builder

### DIFF
--- a/web/app/api/loadPage/route.ts
+++ b/web/app/api/loadPage/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+export async function GET(req: NextRequest) {
+  const pageId = req.nextUrl.searchParams.get('pageId');
+  if (!pageId) {
+    return NextResponse.json({ error: 'pageId required' }, { status: 400 });
+  }
+  const filePath = path.join(process.cwd(), 'data/pages', `${pageId}.json`);
+  try {
+    const json = await readFile(filePath, 'utf8');
+    return new NextResponse(json, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      return NextResponse.json({ error: 'not found' }, { status: 404 });
+    }
+    const message = err?.message ?? 'Failed to load page';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/web/app/api/savePage/route.ts
+++ b/web/app/api/savePage/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+export type ThemeTokens = {
+  [key: string]: any;
+};
+
+export type BuilderNode = {
+  id: string;
+  type: string;
+  props?: Record<string, any>;
+  children?: BuilderNode[];
+};
+
+export type PageSnapshot = {
+  pageId: string;
+  layoutId: string;
+  effectiveTheme: ThemeTokens;
+  nodes: BuilderNode[];
+  timestamp: number;
+};
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as PageSnapshot;
+    if (!body?.pageId) {
+      return NextResponse.json({ error: 'pageId required' }, { status: 400 });
+    }
+    const pagesDir = path.join(process.cwd(), 'data/pages');
+    await mkdir(pagesDir, { recursive: true });
+    const filePath = path.join(pagesDir, `${body.pageId}.json`);
+    await writeFile(filePath, JSON.stringify(body, null, 2), 'utf8');
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    const message = err?.message ?? 'Failed to save page';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add POST /api/savePage to persist page snapshot JSON
- add GET /api/loadPage to return saved snapshot or 404
- prepare data/pages directory for saved page files

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d46df80c832c8019fbd683adf3d6