### PR TITLE
feat: components playground with live knobs

### DIFF
--- a/web/app/dev/playgrounds/components/KnobsForm.tsx
+++ b/web/app/dev/playgrounds/components/KnobsForm.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { z, ZodFirstPartyTypeKind, ZodTypeAny } from 'zod'
+
+interface KnobsFormProps {
+  schema: z.ZodObject<any>
+  values: Record<string, any>
+  onChange: (v: Record<string, any>) => void
+}
+
+function renderField(name: string, field: ZodTypeAny, value: any, onFieldChange: (v: any) => void) {
+  const kind: ZodFirstPartyTypeKind = (field as any)._def.typeName
+
+  switch (kind) {
+    case z.ZodFirstPartyTypeKind.ZodString:
+      return (
+        <div key={name} className="space-y-1">
+          <label className="block text-xs" htmlFor={name}>{name}</label>
+          <input
+            id={name}
+            className="w-full border rounded px-2 py-1"
+            value={value ?? ''}
+            onChange={(e) => onFieldChange(e.target.value)}
+          />
+        </div>
+      )
+    case z.ZodFirstPartyTypeKind.ZodNumber:
+      return (
+        <div key={name} className="space-y-1">
+          <label className="block text-xs" htmlFor={name}>{name}</label>
+          <input
+            type="number"
+            id={name}
+            className="w-full border rounded px-2 py-1"
+            value={value ?? ''}
+            onChange={(e) => {
+              const val = e.target.value
+              onFieldChange(val === '' ? undefined : Number(val))
+            }}
+          />
+        </div>
+      )
+    case z.ZodFirstPartyTypeKind.ZodBoolean:
+      return (
+        <div key={name} className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            id={name}
+            checked={!!value}
+            onChange={(e) => onFieldChange(e.target.checked)}
+          />
+          <label htmlFor={name} className="text-xs">{name}</label>
+        </div>
+      )
+    case z.ZodFirstPartyTypeKind.ZodEnum:
+      return (
+        <div key={name} className="space-y-1">
+          <label className="block text-xs" htmlFor={name}>{name}</label>
+          <select
+            id={name}
+            className="w-full border rounded px-2 py-1"
+            value={value ?? ''}
+            onChange={(e) => onFieldChange(e.target.value)}
+          >
+            {(field as any)._def.values.map((v: string) => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+        </div>
+      )
+    default:
+      return null
+  }
+}
+
+export function KnobsForm({ schema, values, onChange }: KnobsFormProps) {
+  const shape = schema.shape
+  return (
+    <div className="space-y-4">
+      {Object.entries(shape).map(([name, field]) =>
+        renderField(name, field, values[name], (v) => onChange({ ...values, [name]: v }))
+      )}
+    </div>
+  )
+}
+
+export default KnobsForm
+

--- a/web/app/dev/playgrounds/components/page.tsx
+++ b/web/app/dev/playgrounds/components/page.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { KnobsForm } from './KnobsForm'
+import {
+  getRegisteredComponents,
+  getRegisteredComponent,
+  ComponentCategory,
+} from './registry'
+import { useTheme } from '@/lib/theme/useTheme'
+
+function encodeProps(props: Record<string, any>) {
+  if (typeof window === 'undefined') return ''
+  return btoa(encodeURIComponent(JSON.stringify(props)))
+}
+
+function decodeProps(str: string) {
+  return JSON.parse(decodeURIComponent(atob(str)))
+}
+
+const tabs: { label: string; type: ComponentCategory }[] = [
+  { label: 'Visual', type: 'visual' },
+  { label: 'Functional', type: 'functional' },
+  { label: 'Invocation', type: 'invocation' },
+  { label: 'Layout', type: 'layout' },
+]
+
+export default function ComponentsPlayground() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const { theme } = useTheme()
+
+  const [tab, setTab] = useState<ComponentCategory>('visual')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [props, setProps] = useState<Record<string, any>>({})
+
+  // load from URL on first render
+  useEffect(() => {
+    const c = searchParams.get('c')
+    const p = searchParams.get('p')
+    if (c) {
+      setSelectedId(c)
+      const comp = getRegisteredComponent(c)
+      if (comp) {
+        const init = comp.propSchema.parse({})
+        if (p) {
+          try {
+            setProps({ ...init, ...decodeProps(p) })
+          } catch {
+            setProps(init)
+          }
+        } else {
+          setProps(init)
+        }
+        setTab(comp.type)
+      }
+    }
+  }, [searchParams])
+
+  const selected = selectedId ? getRegisteredComponent(selectedId) : null
+  const Component = selected?.component
+
+  // update URL when props change
+  useEffect(() => {
+    if (!selectedId) return
+    const params = new URLSearchParams()
+    params.set('c', selectedId)
+    params.set('p', encodeProps(props))
+    router.replace(`?${params.toString()}`)
+  }, [props, selectedId, router])
+
+  const groups = useMemo(() => {
+    const comps = getRegisteredComponents(tab)
+    const g: Record<string, typeof comps> = {}
+    comps.forEach((c) => {
+      c.tags.forEach((t) => {
+        if (!g[t]) g[t] = []
+        g[t].push(c)
+      })
+    })
+    return g
+  }, [tab])
+
+  const handleSelect = (id: string) => {
+    setSelectedId(id)
+    const comp = getRegisteredComponent(id)
+    if (comp) {
+      const init = comp.propSchema.parse({})
+      setProps(init)
+      const params = new URLSearchParams()
+      params.set('c', id)
+      params.set('p', encodeProps(init))
+      router.replace(`?${params.toString()}`)
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-[200px_1fr_250px] h-[calc(100vh-4rem)]">
+      <div className="border-r p-2 space-y-2 overflow-y-auto">
+        <div className="flex space-x-2 mb-2">
+          {tabs.map((t) => (
+            <button
+              key={t.type}
+              className={tab === t.type ? 'font-bold' : ''}
+              onClick={() => setTab(t.type)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        {Object.entries(groups).map(([tag, comps]) => (
+          <div key={tag} className="space-y-1">
+            <div className="text-xs font-bold mt-2">{tag}</div>
+            {comps.map((c) => (
+              <div
+                key={c.id}
+                className={`cursor-pointer text-sm px-1 rounded ${selectedId === c.id ? 'bg-gray-200' : ''}`}
+                onClick={() => handleSelect(c.id)}
+              >
+                {c.icon} {c.name}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <div className="p-4 overflow-auto">
+        {Component && (
+          <div data-theme={theme} className="p-4 border rounded">
+            <Component {...props} />
+          </div>
+        )}
+      </div>
+      <div className="border-l p-4 overflow-y-auto">
+        {selected && (
+          <KnobsForm schema={selected.propSchema} values={props} onChange={setProps} />
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/web/app/dev/playgrounds/components/registry.ts
+++ b/web/app/dev/playgrounds/components/registry.ts
@@ -1,0 +1,85 @@
+import React from 'react'
+import { z } from 'zod'
+import PublishButton from '../../../../../components/PublishButton'
+import TextBlock from '../../../../../components/TextBlock'
+import FormBox from '../../../../../components/FormBox'
+import ContainerBox from '../../../../../components/ContainerBox'
+
+export type ComponentCategory = 'visual' | 'functional' | 'invocation' | 'layout'
+
+export interface RegisteredComponent {
+  id: string
+  name: string
+  type: ComponentCategory
+  icon: React.ReactNode
+  tags: string[]
+  description: string
+  component: React.ComponentType<any>
+  propSchema: z.ZodObject<any>
+}
+
+const registry: Record<string, RegisteredComponent> = {}
+
+export function registerComponent(component: React.ComponentType<any>, meta: Omit<RegisteredComponent, 'component'>) {
+  registry[meta.id] = { ...meta, component }
+}
+
+export function getRegisteredComponents(type?: ComponentCategory): RegisteredComponent[] {
+  const comps = Object.values(registry)
+  return type ? comps.filter((c) => c.type === type) : comps
+}
+
+export function getRegisteredComponent(id: string): RegisteredComponent | undefined {
+  return registry[id]
+}
+
+const publishSchema = z.object({})
+registerComponent(PublishButton, {
+  id: 'publish-button',
+  name: 'Publish Button',
+  type: 'invocation',
+  icon: '🚀',
+  tags: ['action'],
+  description: 'Triggers page publication.',
+  propSchema: publishSchema,
+})
+
+const textBlockSchema = z.object({
+  text: z.string().default('Sample text'),
+})
+registerComponent(TextBlock, {
+  id: 'text-block',
+  name: 'Text Block',
+  type: 'visual',
+  icon: '📝',
+  tags: ['visual', 'text'],
+  description: 'Displays simple text content.',
+  propSchema: textBlockSchema,
+})
+
+const formBoxSchema = z.object({})
+registerComponent(FormBox, {
+  id: 'form-box',
+  name: 'Form',
+  type: 'functional',
+  icon: '📋',
+  tags: ['functional', 'form'],
+  description: 'Simple form container.',
+  propSchema: formBoxSchema,
+})
+
+const containerBoxSchema = z.object({
+  className: z.string().optional(),
+})
+registerComponent(ContainerBox, {
+  id: 'container-box',
+  name: 'Container',
+  type: 'layout',
+  icon: '📦',
+  tags: ['layout', 'container'],
+  description: 'Generic container for layout.',
+  propSchema: containerBoxSchema,
+})
+
+export { registry }
+


### PR DESCRIPTION
## Summary
- add components playground page with category tabs and shareable URL
- generate prop-editing knobs from component schemas
- register sample components with Zod prop schemas

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d5c68204832cad93f375be5dc44e