### PR TITLE
feat: add basic RBAC store and dev tooling

### DIFF
--- a/src/stores/rbacStore.ts
+++ b/src/stores/rbacStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand'
+
+export type Role = 'owner' | 'manager' | 'accountant' | 'viewer'
+
+export type FeatureKey = 'dashboard' | 'reports'
+
+export type PermissionTable = Record<Role, Record<FeatureKey, boolean>>
+
+export interface RbacState {
+  role: Role
+  permissions: PermissionTable
+  locks: Record<FeatureKey, boolean>
+  setRole: (role: Role) => void
+  setPermission: (role: Role, key: FeatureKey, allowed: boolean) => void
+  setLock: (key: FeatureKey, unlocked: boolean) => void
+}
+
+const defaultPermissions: PermissionTable = {
+  owner: { dashboard: true, reports: true },
+  manager: { dashboard: true, reports: false },
+  accountant: { dashboard: false, reports: true },
+  viewer: { dashboard: false, reports: false },
+}
+
+const defaultLocks: Record<FeatureKey, boolean> = {
+  dashboard: true,
+  reports: false,
+}
+
+export const useRbacStore = create<RbacState>((set) => ({
+  role: 'viewer',
+  permissions: defaultPermissions,
+  locks: defaultLocks,
+  setRole: (role) => set({ role }),
+  setPermission: (role, key, allowed) =>
+    set((state) => ({
+      permissions: {
+        ...state.permissions,
+        [role]: { ...state.permissions[role], [key]: allowed },
+      },
+    })),
+  setLock: (key, unlocked) =>
+    set((state) => ({
+      locks: { ...state.locks, [key]: unlocked },
+    })),
+}))
+
+export const FEATURE_KEYS = Object.keys(defaultLocks) as FeatureKey[]

--- a/web/app/dev/rbac/page.tsx
+++ b/web/app/dev/rbac/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { ChangeEvent } from 'react'
+import { useRbacStore, FEATURE_KEYS, Role } from '../../../../src/stores/rbacStore'
+
+const ROLE_OPTIONS: Role[] = ['owner', 'manager', 'accountant', 'viewer']
+
+export default function DevRbacPage() {
+  const { role, setRole, permissions, setPermission, locks, setLock } = useRbacStore()
+
+  const handleRoleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setRole(e.target.value as Role)
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">/dev/rbac</h1>
+
+      <div>
+        <label className="font-semibold mr-2">Role:</label>
+        <select value={role} onChange={handleRoleChange} className="border p-1">
+          {ROLE_OPTIONS.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        {FEATURE_KEYS.map((key) => {
+          const allowed = permissions[role][key]
+          const unlocked = locks[key]
+          return (
+            <div key={key} className="border p-4 rounded space-y-2">
+              <h2 className="font-semibold">{key}</h2>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={allowed}
+                  onChange={(e) => setPermission(role, key, e.target.checked)}
+                />
+                <span>allowed</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={unlocked}
+                  onChange={(e) => setLock(key, e.target.checked)}
+                />
+                <span>unlocked</span>
+              </label>
+              <div className="mt-2 p-2 bg-gray-100 rounded">
+                {allowed ? (
+                  unlocked ? (
+                    <span>Feature UI for {key}</span>
+                  ) : (
+                    <span>🔒 Locked</span>
+                  )
+                ) : (
+                  <span>❌ No permission</span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add zustand-based RBAC store with roles, permissions and feature locks
- add /dev/rbac page for switching roles and toggling permissions/locks

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d5f8f934832cb273dc2a7cc9fbcc