### PR TITLE
feat: add offline draft saving with IndexedDB

### DIFF
--- a/web/app/api/saveDraft/route.ts
+++ b/web/app/api/saveDraft/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PUT(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  console.log('saveDraft', body);
+  return NextResponse.json({ ok: true });
+}

--- a/web/app/builder/pages/[id]/edit/page.tsx
+++ b/web/app/builder/pages/[id]/edit/page.tsx
@@ -1,21 +1,94 @@
 "use client";
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { usePageStore } from '@/store/pageStore';
 import { toast } from '@/lib/toast';
 import ThemeEditor from '@/components/theme/ThemeEditor';
 import { useDesignTokens } from '@/store/designTokensStore';
 import type { ThemeTokens } from '@/lib/builder/themes/themeTokens';
+import { saveDraft, loadDraft, clearDraft } from '@/lib/storage/drafts';
 
 export default function PageEditor({ params }: { params: { id: string } }) {
   const router = useRouter();
   const selectPage = usePageStore((s) => s.selectPage);
   const setTheme = usePageStore((s) => s.setTheme);
   const [showThemeEditor, setShowThemeEditor] = useState(false);
+  const [status, setStatus] = useState<'saved' | 'saving' | 'offline'>('saved');
+  const saveTimer = useRef<number>();
 
   useEffect(() => {
     selectPage(params.id);
   }, [params.id, selectPage]);
+
+  const persistDraft = useCallback(async () => {
+    const state = usePageStore.getState();
+    const snapshot = {
+      tree: state.getTree(),
+      bindings: state.getBindings(),
+      theme: state.getTheme(),
+      tokens: useDesignTokens.getState().getAll(),
+    };
+    const record = { pageId: params.id, snapshot, updatedAt: Date.now() };
+    if (navigator.onLine) {
+      setStatus('saving');
+      try {
+        await fetch('/api/saveDraft', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(record),
+        });
+        await clearDraft(params.id);
+        setStatus('saved');
+      } catch {
+        await saveDraft(record);
+        setStatus('offline');
+      }
+    } else {
+      await saveDraft(record);
+      setStatus('offline');
+    }
+  }, [params.id]);
+
+  useEffect(() => {
+    const schedule = () => {
+      if (saveTimer.current) window.clearTimeout(saveTimer.current);
+      saveTimer.current = window.setTimeout(() => {
+        persistDraft();
+      }, 800);
+    };
+    const unsubPage = usePageStore.subscribe((s) => s.pages, schedule);
+    const unsubTokens = useDesignTokens.subscribe((s) => s.tokens, schedule);
+    return () => {
+      unsubPage();
+      unsubTokens();
+      if (saveTimer.current) window.clearTimeout(saveTimer.current);
+    };
+  }, [persistDraft]);
+
+  useEffect(() => {
+    loadDraft(params.id).then((draft) => {
+      if (draft && window.confirm('ドラフトを復元しますか？')) {
+        const snap = draft.snapshot || {};
+        const ps = usePageStore.getState();
+        ps.setTree(snap.tree ?? []);
+        ps.setBindings(snap.bindings ?? {});
+        ps.setTheme(snap.theme ?? {});
+        useDesignTokens.getState().replaceAll(snap.tokens ?? {});
+        setStatus('offline');
+      }
+    });
+  }, [params.id]);
+
+  useEffect(() => {
+    const sync = async () => {
+      const draft = await loadDraft(params.id);
+      if (draft) {
+        await persistDraft();
+      }
+    };
+    window.addEventListener('online', sync);
+    return () => window.removeEventListener('online', sync);
+  }, [persistDraft, params.id]);
 
   const tokensToTheme = (tokens: Record<string, any>): ThemeTokens => ({
     colors: {
@@ -53,21 +126,30 @@ export default function PageEditor({ params }: { params: { id: string } }) {
   };
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Page Editor</h1>
-        <div className="flex gap-2">
-          <button onClick={handlePublish} className="px-3 py-2 rounded-lg border">
-            Publish
-          </button>
-          <button
-            onClick={() => router.push(`/builder/pages/${params.id}/preview`)}
-            className="px-3 py-2 rounded-lg border"
-          >
-            Preview
-          </button>
+      <div className="p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Page Editor</h1>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-zinc-500">
+              {status === 'saving'
+                ? 'Saving...'
+                : status === 'offline'
+                ? 'Offline • Draft'
+                : 'Saved •'}
+            </span>
+            <div className="flex gap-2">
+              <button onClick={handlePublish} className="px-3 py-2 rounded-lg border">
+                Publish
+              </button>
+              <button
+                onClick={() => router.push(`/builder/pages/${params.id}/preview`)}
+                className="px-3 py-2 rounded-lg border"
+              >
+                Preview
+              </button>
+            </div>
+          </div>
         </div>
-      </div>
       <p className="text-sm text-zinc-500">Editing page: {params.id}</p>
       <div>
         <h2 className="font-medium mb-1">Theme Override</h2>

--- a/web/lib/storage/drafts.ts
+++ b/web/lib/storage/drafts.ts
@@ -1,0 +1,56 @@
+const DB_NAME = 'ui_builder_drafts';
+const STORE_NAME = 'drafts';
+
+export interface DraftRecord {
+  pageId: string;
+  snapshot: any;
+  updatedAt: number;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'pageId' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveDraft(record: DraftRecord) {
+  const db = await openDB();
+  await new Promise<void>((res, rej) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(record);
+    tx.oncomplete = () => res();
+    tx.onerror = () => rej(tx.error);
+  });
+  db.close();
+}
+
+export async function loadDraft(pageId: string): Promise<DraftRecord | undefined> {
+  const db = await openDB();
+  const out = await new Promise<DraftRecord | undefined>((res, rej) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(pageId);
+    req.onsuccess = () => res(req.result as DraftRecord | undefined);
+    req.onerror = () => rej(req.error);
+  });
+  db.close();
+  return out;
+}
+
+export async function clearDraft(pageId: string): Promise<void> {
+  const db = await openDB();
+  await new Promise<void>((res, rej) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(pageId);
+    tx.oncomplete = () => res();
+    tx.onerror = () => rej(tx.error);
+  });
+  db.close();
+}


### PR DESCRIPTION
## Summary
- add IndexedDB draft storage helpers
- log incoming draft saves via `/api/saveDraft`
- auto-save page edits with offline restoration and status indicator

## Testing
- `pnpm -C web lint` *(fails: Parsing error in lib/registry.ts)*
- `pnpm -C web typecheck` *(fails: TS errors in hooks/useTheme.ts, lib/registry.ts)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d599cfb8832cb96b49b114f96a12