### PR TITLE
feat: add undo/redo history timeline

### DIFF
--- a/src/stores/history.ts
+++ b/src/stores/history.ts
@@ -1,0 +1,1 @@
+export { useHistoryStore, type Snapshot } from '@/store/historyStore'

--- a/web/app/builder/layout.tsx
+++ b/web/app/builder/layout.tsx
@@ -10,6 +10,7 @@ import ProjectMetaMenu from '@/components/builder/ProjectMetaMenu'
 import UndoRedoButtons from '@/components/builder/UndoRedoButtons'
 import LoadFromGitHubMenu from '@/components/builder/LoadFromGitHubMenu'
 import HistoryHotkeys from '@/components/hud/HistoryHotkeys'
+import HistoryTimeline from '@/components/hud/HistoryTimeline'
 import { mountHistorySync } from '@/store/historySync'
 import StatusCenter from '@/components/hud/StatusCenter'
 import ErrorBoundary from '@/components/hud/ErrorBoundary'
@@ -40,6 +41,7 @@ export default function BuilderLayout({ children }: { children: React.ReactNode 
       </ErrorBoundary>
       <StatusCenter />
       <HistoryHotkeys />
+      <HistoryTimeline />
       {process.env.NODE_ENV !== 'production' && <DevConsoleHUD />}
       <ModalHost />
     </div>

--- a/web/components/hud/HistoryTimeline.tsx
+++ b/web/components/hud/HistoryTimeline.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { useHistoryStore } from '@/store/historyStore'
+
+export default function HistoryTimeline() {
+  const { past, future, apply } = useHistoryStore(s => ({ past: s.past, future: s.future, apply: s.apply }))
+  const prev = past.slice(-2)
+  const next = future.slice(0, 2)
+  const handle = (offset: number) => () => apply(offset)
+  return (
+    <div className="pointer-events-auto fixed bottom-2 right-2 flex items-center gap-1 text-xs text-zinc-200">
+      <span className="opacity-60">←</span>
+      {prev.map((_, i) => (
+        <button
+          key={`p${i}`}
+          className="w-2 h-2 rounded-full bg-zinc-500 hover:bg-zinc-400"
+          onClick={handle(i - prev.length)}
+        />
+      ))}
+      <div className="w-2 h-2 rounded-full bg-white" />
+      {next.map((_, i) => (
+        <button
+          key={`f${i}`}
+          className="w-2 h-2 rounded-full bg-zinc-500 hover:bg-zinc-400"
+          onClick={handle(i + 1)}
+        />
+      ))}
+      <span className="opacity-60">→</span>
+    </div>
+  )
+}

--- a/web/store/historyStore.ts
+++ b/web/store/historyStore.ts
@@ -23,7 +23,7 @@ type Actions = {
   redo: () => void
   clear: () => void
   setCapacity: (n: number) => void
-  apply: (snap: Snapshot) => void
+  apply: (offset: number) => void
   getCounts: () => { past: number; future: number }
   getPresent: () => Snapshot | null
 }
@@ -32,7 +32,7 @@ export const useHistoryStore = create<State & Actions>((set, get) => ({
   past: [],
   present: null,
   future: [],
-  capacity: 50,
+  capacity: 100,
   busy: false,
   initFromCurrent: () => {
     const s = snapshotFromStores()
@@ -65,10 +65,28 @@ export const useHistoryStore = create<State & Actions>((set, get) => ({
   },
   clear: () => set({ past: [], present: get().present, future: [] }),
   setCapacity: (n) => set({ capacity: Math.max(1, Math.min(500, n)) }),
-  apply: (snap) => {
-    set({ busy: true })
-    applyToStores(snap)
-    set({ busy: false })
+  apply: (offset) => {
+    const { past, present, future } = get()
+    if (!present || offset === 0) return
+    if (offset < 0) {
+      const idx = past.length + offset
+      if (idx < 0) return
+      const target = past[idx]
+      const newPast = past.slice(0, idx)
+      const newFuture = [...past.slice(idx + 1), present, ...future]
+      set({ past: newPast, present: target, future: newFuture, busy: true })
+      applyToStores(target)
+      set({ busy: false })
+    } else {
+      const idx = offset - 1
+      if (idx >= future.length) return
+      const target = future[idx]
+      const newPast = [...past, present, ...future.slice(0, idx)]
+      const newFuture = future.slice(idx + 1)
+      set({ past: newPast, present: target, future: newFuture, busy: true })
+      applyToStores(target)
+      set({ busy: false })
+    }
   },
   getCounts: () => ({ past: get().past.length, future: get().future.length }),
   getPresent: () => get().present,

--- a/web/store/historySync.ts
+++ b/web/store/historySync.ts
@@ -18,7 +18,7 @@ export function mountHistorySync() {
       useHistoryStore.getState().push(snap)
       saveProject({ schemaVersion: 1, meta: snap.meta, elements: snap.elements, designTokens: snap.designTokens, assets: [] })
     }
-  }, 150)
+  }, 1000)
 
   useHistoryStore.getState().initFromCurrent()
 


### PR DESCRIPTION
## Summary
- track builder snapshots with past/present/future and 100 entry capacity
- debounce snapshot pushes and enable jumping via mini timeline
- wire up global history timeline UI

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d5a81fa4832c84fe76eca5cee72d