### PR TITLE
feat: add JSON migrations with versioning

### DIFF
--- a/src/lib/migrations/layout.ts
+++ b/src/lib/migrations/layout.ts
@@ -1,0 +1,37 @@
+export const LAYOUT_VERSION = 1;
+
+export interface LayoutState {
+  left: { width: number; collapsed: boolean };
+  right: { width: number; collapsed: boolean };
+  status: { height: number; visible: boolean };
+  rightSections?: Record<string, boolean>;
+  lastResetAt?: number;
+}
+
+export interface LayoutDoc extends LayoutState {
+  version: number;
+}
+
+const DEFAULT_LAYOUT: LayoutState = {
+  left: { width: 240, collapsed: false },
+  right: { width: 320, collapsed: false },
+  status: { height: 28, visible: true },
+  rightSections: {},
+};
+
+// migrateLayout upgrades persisted layout JSON into latest format.
+// v1 -> returned as-is; legacy unversioned objects are merged with defaults.
+export function migrateLayout(json: any): LayoutDoc {
+  if (!json || typeof json !== 'object') {
+    return { ...DEFAULT_LAYOUT, version: LAYOUT_VERSION };
+  }
+  const v = json.version ?? 0;
+  if (v === LAYOUT_VERSION) {
+    return { ...DEFAULT_LAYOUT, ...(json as LayoutState), version: LAYOUT_VERSION };
+  }
+  if (v === 0) {
+    const state = json as Partial<LayoutState>;
+    return { ...DEFAULT_LAYOUT, ...state, version: LAYOUT_VERSION };
+  }
+  throw new Error(`Unsupported layout version: ${v}`);
+}

--- a/src/lib/migrations/page.ts
+++ b/src/lib/migrations/page.ts
@@ -1,0 +1,34 @@
+export const PAGE_VERSION = 1;
+
+export interface PageDoc {
+  id: string;
+  title: string;
+  path: string;
+  tree: any[];
+  bindings: Record<string, unknown>;
+  pageOverrides: { theme?: Record<string, any> };
+  version: number;
+}
+
+// migratePage converts legacy page JSON to the latest PageDoc format.
+export function migratePage(json: any): PageDoc {
+  if (!json || typeof json !== 'object') {
+    throw new Error('Invalid page data');
+  }
+  const v = json.version ?? 0;
+  if (v === PAGE_VERSION) {
+    return json as PageDoc;
+  }
+  if (v === 0) {
+    return {
+      id: json.id ?? '',
+      title: json.title ?? '',
+      path: json.path ?? '/',
+      tree: Array.isArray(json.tree) ? json.tree : [],
+      bindings: typeof json.bindings === 'object' && json.bindings ? json.bindings : {},
+      pageOverrides: typeof json.pageOverrides === 'object' && json.pageOverrides ? json.pageOverrides : {},
+      version: PAGE_VERSION,
+    };
+  }
+  throw new Error(`Unsupported page version: ${v}`);
+}

--- a/src/lib/migrations/theme.ts
+++ b/src/lib/migrations/theme.ts
@@ -1,0 +1,31 @@
+import { defaultTheme, type ThemeTokens } from '../../stores/themeStore';
+
+export const THEME_VERSION = 1;
+
+export interface ThemeDoc extends ThemeTokens {
+  version: number;
+}
+
+// migrateTheme converts given json (possibly legacy) to latest ThemeDoc.
+// It accepts both v1 (current) and legacy unversioned themes.
+export function migrateTheme(json: any): ThemeDoc {
+  if (!json || typeof json !== 'object') {
+    throw new Error('Invalid theme data');
+  }
+  const v = json.version ?? 0;
+  if (v === THEME_VERSION) {
+    return json as ThemeDoc;
+  }
+  if (v === 0) {
+    const merged: ThemeTokens = {
+      ...defaultTheme,
+      ...json,
+      colors: { ...defaultTheme.colors, ...(json.colors || {}) },
+      radius: { ...defaultTheme.radius, ...(json.radius || {}) },
+      spacing: { ...defaultTheme.spacing, ...(json.spacing || {}) },
+      typography: { ...defaultTheme.typography, ...(json.typography || {}) },
+    };
+    return { ...merged, version: THEME_VERSION };
+  }
+  throw new Error(`Unsupported theme version: ${v}`);
+}

--- a/src/themes/presets/corporate.json
+++ b/src/themes/presets/corporate.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "name": "Corporate",
   "colors": {
     "background": "#111827",

--- a/src/themes/presets/minimal.json
+++ b/src/themes/presets/minimal.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "name": "Minimal",
   "colors": {
     "background": "#0f172a",

--- a/src/themes/presets/pop.json
+++ b/src/themes/presets/pop.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "name": "Pop",
   "colors": {
     "background": "#1a1a1a",

--- a/web/lib/layout/persist.ts
+++ b/web/lib/layout/persist.ts
@@ -1,16 +1,16 @@
-export interface LayoutState {
-  left: { width: number; collapsed: boolean };
-  right: { width: number; collapsed: boolean };
-  status: { height: number; visible: boolean };
-  rightSections?: Record<string, boolean>;
-  lastResetAt?: number;
-}
-
 import {
   LEFT_PANE_DEFAULT_WIDTH,
   RIGHT_PANE_DEFAULT_WIDTH,
   STATUS_BAR_HEIGHT,
 } from './constants';
+import {
+  migrateLayout,
+  LAYOUT_VERSION,
+  type LayoutState,
+  type LayoutDoc,
+} from '../../../src/lib/migrations/layout';
+
+export type { LayoutState } from '../../../src/lib/migrations/layout';
 
 const KEY = 'uibuilder:layout';
 
@@ -26,8 +26,9 @@ export function loadLayout(): LayoutState {
   try {
     const raw = window.localStorage.getItem(KEY);
     if (!raw) return DEFAULT_STATE;
-    const parsed = JSON.parse(raw);
-    return { ...DEFAULT_STATE, ...parsed } as LayoutState;
+    const doc = migrateLayout(JSON.parse(raw));
+    const { version, ...state } = doc as LayoutDoc;
+    return { ...DEFAULT_STATE, ...state };
   } catch {
     return DEFAULT_STATE;
   }
@@ -37,10 +38,16 @@ export function saveLayout(patch: Partial<LayoutState>): void {
   if (typeof window === 'undefined') return;
   const current = loadLayout();
   const next = { ...current, ...patch };
-  window.localStorage.setItem(KEY, JSON.stringify(next));
+  const doc: LayoutDoc = { version: LAYOUT_VERSION, ...next };
+  window.localStorage.setItem(KEY, JSON.stringify(doc));
 }
 
 export function resetLayout(): void {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem(KEY, JSON.stringify({ ...DEFAULT_STATE, lastResetAt: Date.now() }));
+  const doc: LayoutDoc = {
+    version: LAYOUT_VERSION,
+    ...DEFAULT_STATE,
+    lastResetAt: Date.now(),
+  };
+  window.localStorage.setItem(KEY, JSON.stringify(doc));
 }

--- a/web/lib/toast.ts
+++ b/web/lib/toast.ts
@@ -2,5 +2,8 @@ export const toast = {
   success(message: string) {
     console.log(`[toast:success] ${message}`);
   },
+  error(message: string) {
+    console.error(`[toast:error] ${message}`);
+  },
 };
 export default toast;

--- a/web/store/pageStore.ts
+++ b/web/store/pageStore.ts
@@ -2,20 +2,23 @@ import { create } from 'zustand'
 import { nanoid } from 'nanoid'
 import { type Elm } from '@/store/builderStore'
 import type { ThemeTokens } from '@/lib/builder/themes/themeTokens'
+import { migratePage, PAGE_VERSION } from '../../src/lib/migrations/page'
+import { toast } from '@/lib/toast'
 
 export type PageId = string
 export type RoutePath = `/${string}`
 
 export type Page = {
-  id: PageId
-  title: string
-  path: RoutePath
-  tree: Elm[]
-  bindings: Record<`${string}:${string}`, unknown>
-  pageOverrides: {
-    theme?: Partial<ThemeTokens>
+    id: PageId
+    title: string
+    path: RoutePath
+    tree: Elm[]
+    bindings: Record<`${string}:${string}`, unknown>
+    pageOverrides: {
+      theme?: Partial<ThemeTokens>
+    }
+    version: number
   }
-}
 
 interface PageState {
   pages: Page[]
@@ -41,16 +44,17 @@ interface PageActions {
   importJSON: (json: string) => void
 }
 
-function defaultPage(idx: number): Page {
-  return {
-    id: `page_${nanoid(6)}`,
-    title: idx === 0 ? 'Home' : `Page ${idx + 1}`,
-    path: idx === 0 ? '/' : (`/page-${idx + 1}` as RoutePath),
-    tree: [],
-    bindings: {},
-    pageOverrides: { theme: {} },
+  function defaultPage(idx: number): Page {
+    return {
+      id: `page_${nanoid(6)}`,
+      title: idx === 0 ? 'Home' : `Page ${idx + 1}`,
+      path: idx === 0 ? '/' : (`/page-${idx + 1}` as RoutePath),
+      tree: [],
+      bindings: {},
+      pageOverrides: { theme: {} },
+      version: PAGE_VERSION,
+    }
   }
-}
 
 const initial = defaultPage(0)
 
@@ -66,16 +70,17 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
   addPage(init) {
     const pages = get().pages
     const idx = pages.length
-    const page: Page = {
-      ...defaultPage(idx),
-      ...init,
-      id: `page_${nanoid(6)}`,
-      path: init?.path ?? (`/page-${idx + 1}` as RoutePath),
-      title: init?.title ?? `Page ${idx + 1}`,
-      tree: init?.tree ?? [],
-      bindings: init?.bindings ?? {},
-      pageOverrides: { theme: init?.pageOverrides?.theme ?? {} },
-    }
+      const page: Page = {
+        ...defaultPage(idx),
+        ...init,
+        id: `page_${nanoid(6)}`,
+        path: init?.path ?? (`/page-${idx + 1}` as RoutePath),
+        title: init?.title ?? `Page ${idx + 1}`,
+        tree: init?.tree ?? [],
+        bindings: init?.bindings ?? {},
+        pageOverrides: { theme: init?.pageOverrides?.theme ?? {} },
+        version: PAGE_VERSION,
+      }
     set({ pages: [...pages, page], currentPageId: page.id })
     return page.id
   },
@@ -95,15 +100,16 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
     const src = get().pages.find((p) => p.id === id)
     if (!src) return get().currentPageId
     const idx = get().pages.length
-    const newPage: Page = {
-      ...src,
-      id: `page_${nanoid(6)}`,
-      title: `${src.title} Copy`,
-      path: (`/page-${idx + 1}` as RoutePath),
-      tree: JSON.parse(JSON.stringify(src.tree)),
-      bindings: JSON.parse(JSON.stringify(src.bindings)),
-      pageOverrides: JSON.parse(JSON.stringify(src.pageOverrides ?? {})),
-    }
+      const newPage: Page = {
+        ...src,
+        id: `page_${nanoid(6)}`,
+        title: `${src.title} Copy`,
+        path: (`/page-${idx + 1}` as RoutePath),
+        tree: JSON.parse(JSON.stringify(src.tree)),
+        bindings: JSON.parse(JSON.stringify(src.bindings)),
+        pageOverrides: JSON.parse(JSON.stringify(src.pageOverrides ?? {})),
+        version: PAGE_VERSION,
+      }
     set((s) => ({ pages: [...s.pages, newPage], currentPageId: newPage.id }))
     return newPage.id
   },
@@ -155,19 +161,27 @@ export const usePageStore = create<PageState & PageActions>((set, get) => ({
     }))
   },
 
-  exportJSON() {
-    return JSON.stringify(get().pages)
-  },
+    exportJSON() {
+      return JSON.stringify(get().pages)
+    },
 
-  importJSON(json) {
-    try {
-      const pages = JSON.parse(json) as Page[]
-      if (Array.isArray(pages) && pages.length) {
-        set({ pages, currentPageId: pages[0].id })
+    importJSON(json) {
+      try {
+        const parsed = JSON.parse(json)
+        const arr = Array.isArray(parsed)
+          ? parsed
+          : Array.isArray((parsed as any).pages)
+            ? (parsed as any).pages
+            : null
+        if (arr && arr.length) {
+          const pages = arr.map((p: any) => migratePage(p))
+          set({ pages, currentPageId: pages[0].id })
+        } else {
+          throw new Error('Invalid page data')
+        }
+      } catch (e: any) {
+        toast.error(e?.message ?? 'Failed to import pages')
       }
-    } catch {
-      // ignore
-    }
-  },
-}))
+    },
+  }))
 


### PR DESCRIPTION
## Summary
- add migration helpers for theme, layout, and page JSON
- version presets and persist layout/page data with auto-migration
- show toast error on failed page import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d5f0e560832cb40ba428d2b3b12c