### PR TITLE
feat: add rule engine and editor

### DIFF
--- a/src/components/rules/RuleEditor.tsx
+++ b/src/components/rules/RuleEditor.tsx
@@ -1,0 +1,163 @@
+import React from 'react'
+import { BuilderRule, useRuleStore } from '../../stores/ruleStore'
+
+const newRuleDefaults = (): Omit<BuilderRule, 'id'> => ({
+  trigger: 'click',
+  sourceNodeId: '',
+  enabled: true,
+  action: { type: 'classToggle', targetNodeId: '', classNames: [] }
+})
+
+export const RuleEditor: React.FC = () => {
+  const { rules, addRule, updateRule, removeRule, toggleRule } = useRuleStore()
+  const handleAdd = () => addRule(newRuleDefaults())
+
+  return (
+    <div>
+      <button className="mb-2 px-2 py-1 border" onClick={handleAdd}>
+        Add Rule
+      </button>
+      {rules.map((rule) => (
+        <div key={rule.id} className="border p-2 mb-2">
+          <div className="flex items-center gap-2 mb-2">
+            <input
+              type="checkbox"
+              checked={rule.enabled}
+              onChange={(e) => toggleRule(rule.id, e.target.checked)}
+            />
+            <select
+              value={rule.trigger}
+              onChange={(e) =>
+                updateRule(rule.id, { trigger: e.target.value as BuilderRule['trigger'] })
+              }
+            >
+              <option value="click">click</option>
+              <option value="hover">hover</option>
+              <option value="inview">inview</option>
+            </select>
+            <input
+              className="border px-1 py-0.5 flex-1"
+              placeholder="source node id"
+              value={rule.sourceNodeId}
+              onChange={(e) => updateRule(rule.id, { sourceNodeId: e.target.value })}
+            />
+            <button className="text-red-500" onClick={() => removeRule(rule.id)}>
+              x
+            </button>
+          </div>
+          <ActionFields rule={rule} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const ActionFields: React.FC<{ rule: BuilderRule }> = ({ rule }) => {
+  const updateRule = useRuleStore((s) => s.updateRule)
+  const action = rule.action
+  return (
+    <div className="space-y-1">
+      <select
+        value={action.type}
+        onChange={(e) => {
+          const t = e.target.value as BuilderRule['action']['type']
+          if (t === 'classToggle')
+            updateRule(rule.id, {
+              action: { type: 'classToggle', targetNodeId: '', classNames: [] }
+            })
+          else if (t === 'scrollTo')
+            updateRule(rule.id, {
+              action: { type: 'scrollTo', selector: '', behavior: 'smooth' }
+            })
+          else
+            updateRule(rule.id, { action: { type: 'navigate', href: '' } })
+        }}
+      >
+        <option value="classToggle">classToggle</option>
+        <option value="scrollTo">scrollTo</option>
+        <option value="navigate">navigate</option>
+      </select>
+
+      {action.type === 'classToggle' && (
+        <div className="space-y-1">
+          <input
+            className="border px-1 py-0.5 w-full"
+            placeholder="target node id"
+            value={action.targetNodeId}
+            onChange={(e) =>
+              updateRule(rule.id, {
+                action: {
+                  type: 'classToggle',
+                  targetNodeId: e.target.value,
+                  classNames: action.classNames
+                }
+              })
+            }
+          />
+          <input
+            className="border px-1 py-0.5 w-full"
+            placeholder="class names (space separated)"
+            value={action.classNames.join(' ')}
+            onChange={(e) =>
+              updateRule(rule.id, {
+                action: {
+                  type: 'classToggle',
+                  targetNodeId: action.targetNodeId,
+                  classNames: e.target.value.split(/\s+/).filter(Boolean)
+                }
+              })
+            }
+          />
+        </div>
+      )}
+
+      {action.type === 'scrollTo' && (
+        <div className="space-y-1">
+          <input
+            className="border px-1 py-0.5 w-full"
+            placeholder="selector"
+            value={action.selector}
+            onChange={(e) =>
+              updateRule(rule.id, {
+                action: {
+                  type: 'scrollTo',
+                  selector: e.target.value,
+                  behavior: action.behavior
+                }
+              })
+            }
+          />
+          <select
+            value={action.behavior || 'auto'}
+            onChange={(e) =>
+              updateRule(rule.id, {
+                action: {
+                  type: 'scrollTo',
+                  selector: action.selector,
+                  behavior: e.target.value as 'smooth' | 'auto'
+                }
+              })
+            }
+          >
+            <option value="auto">auto</option>
+            <option value="smooth">smooth</option>
+          </select>
+        </div>
+      )}
+
+      {action.type === 'navigate' && (
+        <input
+          className="border px-1 py-0.5 w-full"
+          placeholder="href"
+          value={action.href}
+          onChange={(e) =>
+            updateRule(rule.id, { action: { type: 'navigate', href: e.target.value } })
+          }
+        />
+      )}
+    </div>
+  )
+}
+
+export default RuleEditor
+

--- a/src/stores/ruleStore.ts
+++ b/src/stores/ruleStore.ts
@@ -1,0 +1,139 @@
+import { create } from 'zustand'
+
+export type BuilderRule = {
+  id: string
+  trigger: 'click' | 'hover' | 'inview'
+  sourceNodeId: string
+  enabled: boolean
+  action:
+    | { type: 'classToggle'; targetNodeId: string; classNames: string[] }
+    | { type: 'scrollTo'; selector: string; behavior?: 'smooth' }
+    | { type: 'navigate'; href: string }
+}
+
+interface RuleStore {
+  rules: BuilderRule[]
+  addRule: (rule: Omit<BuilderRule, 'id'>) => void
+  updateRule: (id: string, rule: Partial<BuilderRule>) => void
+  removeRule: (id: string) => void
+  toggleRule: (id: string, enabled: boolean) => void
+}
+
+const listeners = new Map<string, () => void>()
+
+function runAction(action: BuilderRule['action']) {
+  switch (action.type) {
+    case 'classToggle': {
+      const target = document.querySelector(
+        `[data-node-id="${action.targetNodeId}"]`
+      ) as HTMLElement | null
+      if (!target) return
+      action.classNames.forEach((c) => target.classList.toggle(c))
+      break
+    }
+    case 'scrollTo': {
+      const el = document.querySelector(action.selector)
+      if (el) el.scrollIntoView({ behavior: action.behavior })
+      break
+    }
+    case 'navigate': {
+      window.location.href = action.href
+      break
+    }
+  }
+}
+
+function attach(rule: BuilderRule) {
+  const source = document.querySelector(
+    `[data-node-id="${rule.sourceNodeId}"]`
+  ) as HTMLElement | null
+  if (!source) return
+
+  let cleanup: () => void = () => {}
+
+  if (rule.trigger === 'click') {
+    const handler = () => runAction(rule.action)
+    source.addEventListener('click', handler)
+    cleanup = () => source.removeEventListener('click', handler)
+  } else if (rule.trigger === 'hover') {
+    if (rule.action.type === 'classToggle') {
+      const enter = () => {
+        const target = document.querySelector(
+          `[data-node-id="${rule.action.targetNodeId}"]`
+        ) as HTMLElement | null
+        if (!target) return
+        rule.action.classNames.forEach((c) => target.classList.add(c))
+      }
+      const leave = () => {
+        const target = document.querySelector(
+          `[data-node-id="${rule.action.targetNodeId}"]`
+        ) as HTMLElement | null
+        if (!target) return
+        rule.action.classNames.forEach((c) => target.classList.remove(c))
+      }
+      source.addEventListener('mouseenter', enter)
+      source.addEventListener('mouseleave', leave)
+      cleanup = () => {
+        source.removeEventListener('mouseenter', enter)
+        source.removeEventListener('mouseleave', leave)
+      }
+    } else {
+      const handler = () => runAction(rule.action)
+      source.addEventListener('mouseenter', handler)
+      cleanup = () => source.removeEventListener('mouseenter', handler)
+    }
+  } else if (rule.trigger === 'inview') {
+    const handler = (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) runAction(rule.action)
+      })
+    }
+    const observer = new IntersectionObserver(handler)
+    observer.observe(source)
+    cleanup = () => observer.disconnect()
+  }
+
+  listeners.set(rule.id, cleanup)
+}
+
+function detach(id: string) {
+  const c = listeners.get(id)
+  if (c) c()
+  listeners.delete(id)
+}
+
+export const useRuleStore = create<RuleStore>((set, get) => ({
+  rules: [],
+  addRule: (rule) =>
+    set((state) => {
+      const newRule: BuilderRule = { id: `rule-${Date.now()}`, ...rule }
+      if (newRule.enabled) attach(newRule)
+      return { rules: [...state.rules, newRule] }
+    }),
+  updateRule: (id, rule) =>
+    set((state) => {
+      const rules = state.rules.map((r) =>
+        r.id === id ? { ...r, ...rule } : r
+      )
+      const updated = rules.find((r) => r.id === id)
+      detach(id)
+      if (updated?.enabled) attach(updated)
+      return { rules }
+    }),
+  removeRule: (id) =>
+    set((state) => {
+      detach(id)
+      return { rules: state.rules.filter((r) => r.id !== id) }
+    }),
+  toggleRule: (id, enabled) =>
+    set((state) => {
+      const rules = state.rules.map((r) =>
+        r.id === id ? { ...r, enabled } : r
+      )
+      detach(id)
+      const rule = rules.find((r) => r.id === id)
+      if (rule?.enabled) attach(rule)
+      return { rules }
+    })
+}))
+


### PR DESCRIPTION
## Summary
- add Zustand rule store with runtime event listeners for click, hover, and in-view triggers
- add visual RuleEditor component for managing rule actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9da6caacc832ca42001f9ed6ad80d