### PR TITLE
feat: add snapshot diff history panel

### DIFF
--- a/src/components/history/DiffView.tsx
+++ b/src/components/history/DiffView.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { DiffResult } from '../../lib/history/snapshots';
+
+interface Props {
+  diff: DiffResult;
+}
+
+export function DiffView({ diff }: Props) {
+  return (
+    <div style={{ marginTop: '0.5rem', fontSize: '0.8rem' }}>
+      <h4>Added</h4>
+      <ul>
+        {diff.added.map((p) => (
+          <li key={p} style={{ color: 'green' }}>
+            + {p}
+          </li>
+        ))}
+      </ul>
+      <h4>Removed</h4>
+      <ul>
+        {diff.removed.map((p) => (
+          <li key={p} style={{ color: 'red' }}>
+            - {p}
+          </li>
+        ))}
+      </ul>
+      <h4>Changed</h4>
+      <ul>
+        {diff.changed.map((p) => (
+          <li key={p} style={{ color: 'orange' }}>
+            ~ {p}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default DiffView;

--- a/src/components/history/HistoryPanel.tsx
+++ b/src/components/history/HistoryPanel.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import {
+  listSnapshots,
+  loadSnapshot,
+  diffSnapshots,
+  type SnapshotMeta,
+  type StoredSnapshot,
+  type PageSnapshot,
+} from '../../lib/history/snapshots';
+import DiffView from './DiffView';
+
+interface Props {
+  pageId: string;
+  onRestore: (snap: PageSnapshot) => void;
+}
+
+export function HistoryPanel({ pageId, onRestore }: Props) {
+  const [items, setItems] = useState<SnapshotMeta[]>([]);
+  const [selected, setSelected] = useState<SnapshotMeta[]>([]);
+  const [loaded, setLoaded] = useState<StoredSnapshot[]>([]);
+  const [diff, setDiff] = useState<any>(null);
+
+  useEffect(() => {
+    listSnapshots(pageId).then(setItems);
+  }, [pageId]);
+
+  const toggle = async (meta: SnapshotMeta) => {
+    let next = selected.find((m) => m.timestamp === meta.timestamp)
+      ? selected.filter((m) => m.timestamp !== meta.timestamp)
+      : [...selected, meta].slice(-2);
+    setSelected(next);
+    if (next.length === 2) {
+      const a = await loadSnapshot(pageId, next[0].timestamp);
+      const b = await loadSnapshot(pageId, next[1].timestamp);
+      if (a && b) {
+        setLoaded([a, b]);
+        setDiff(diffSnapshots(a.snapshot, b.snapshot));
+      }
+    } else {
+      setDiff(null);
+      setLoaded([]);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        right: 0,
+        bottom: 0,
+        width: 300,
+        background: '#fff',
+        border: '1px solid #ccc',
+        padding: '0.5rem',
+        fontSize: '0.8rem',
+      }}
+    >
+      <h3>History</h3>
+      <ul style={{ listStyle: 'none', padding: 0, maxHeight: 200, overflow: 'auto' }}>
+        {items.map((m) => (
+          <li
+            key={m.timestamp}
+            onClick={() => toggle(m)}
+            style={{
+              cursor: 'pointer',
+              background: selected.some((s) => s.timestamp === m.timestamp)
+                ? '#eee'
+                : 'transparent',
+              padding: '0.25rem',
+            }}
+          >
+            {new Date(m.timestamp).toLocaleTimeString()} [{m.type}]
+          </li>
+        ))}
+      </ul>
+      {diff && loaded.length === 2 && (
+        <div>
+          <DiffView diff={diff} />
+          <button onClick={() => onRestore(loaded[0].snapshot)}>
+            Restore first
+          </button>
+          <button onClick={() => onRestore(loaded[1].snapshot)}>
+            Restore second
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default HistoryPanel;

--- a/src/lib/history/snapshots.ts
+++ b/src/lib/history/snapshots.ts
@@ -1,0 +1,105 @@
+import { mkdir, writeFile, readdir, readFile } from 'fs/promises';
+import path from 'path';
+
+export type ThemeTokens = { [key: string]: any };
+
+export type BuilderNode = {
+  id: string;
+  type: string;
+  props?: Record<string, any>;
+  children?: BuilderNode[];
+};
+
+export type PageSnapshot = {
+  pageId: string;
+  layoutId: string;
+  effectiveTheme: ThemeTokens;
+  nodes: BuilderNode[];
+  timestamp: number;
+};
+
+export type SaveType = 'auto' | 'apply' | 'publish';
+
+export interface StoredSnapshot {
+  snapshot: PageSnapshot;
+  type: SaveType;
+}
+
+export interface SnapshotMeta {
+  timestamp: number;
+  type: SaveType;
+}
+
+const SNAPSHOT_ROOT = path.join(process.cwd(), 'snapshots');
+
+export async function saveSnapshot(pageId: string, snapshot: PageSnapshot, type: SaveType = 'auto'): Promise<SnapshotMeta> {
+  const dir = path.join(SNAPSHOT_ROOT, pageId);
+  await mkdir(dir, { recursive: true });
+  const ts = snapshot.timestamp ?? Date.now();
+  const data: StoredSnapshot = { snapshot: { ...snapshot, timestamp: ts }, type };
+  const file = path.join(dir, `${ts}.json`);
+  await writeFile(file, JSON.stringify(data, null, 2), 'utf8');
+  return { timestamp: ts, type };
+}
+
+export async function listSnapshots(pageId: string): Promise<SnapshotMeta[]> {
+  const dir = path.join(SNAPSHOT_ROOT, pageId);
+  try {
+    const files = await readdir(dir);
+    const metas: SnapshotMeta[] = [];
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const text = await readFile(path.join(dir, file), 'utf8');
+        const data = JSON.parse(text) as StoredSnapshot;
+        metas.push({ timestamp: data.snapshot.timestamp, type: data.type });
+      } catch {
+        // ignore bad files
+      }
+    }
+    return metas.sort((a, b) => b.timestamp - a.timestamp);
+  } catch {
+    return [];
+  }
+}
+
+export async function loadSnapshot(pageId: string, timestamp: number): Promise<StoredSnapshot | null> {
+  const file = path.join(SNAPSHOT_ROOT, pageId, `${timestamp}.json`);
+  try {
+    const text = await readFile(file, 'utf8');
+    return JSON.parse(text) as StoredSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export interface DiffResult {
+  added: string[];
+  removed: string[];
+  changed: string[];
+}
+
+export function diffSnapshots(a: any, b: any): DiffResult {
+  const res: DiffResult = { added: [], removed: [], changed: [] };
+
+  function walk(a: any, b: any, path: string) {
+    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+      if (JSON.stringify(a) !== JSON.stringify(b)) res.changed.push(path);
+      return;
+    }
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    for (const k of aKeys) {
+      const p = path ? `${path}.${k}` : k;
+      if (!(k in b)) res.removed.push(p);
+      else walk(a[k], b[k], p);
+    }
+    for (const k of bKeys) {
+      const p = path ? `${path}.${k}` : k;
+      if (!(k in a)) res.added.push(p);
+    }
+  }
+
+  walk(a, b, '');
+  return res;
+}


### PR DESCRIPTION
## Summary
- save and load page snapshots for diffing
- highlight added, removed, and changed fields
- show history panel with diff view and restore buttons

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9da5ff634832c848a6a0239c91148