### PR TITLE
feat: add contrast checker and focus ring tokens

### DIFF
--- a/src/lib/a11y/contrast.ts
+++ b/src/lib/a11y/contrast.ts
@@ -1,0 +1,30 @@
+export function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized.length === 3 ? normalized.split('').map(c => c + c).join('') : normalized, 16);
+  return [
+    (bigint >> 16) & 255,
+    (bigint >> 8) & 255,
+    bigint & 255,
+  ];
+}
+
+export function luminance([r, g, b]: [number, number, number]): number {
+  const toLinear = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const [lr, lg, lb] = [toLinear(r), toLinear(g), toLinear(b)];
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+}
+
+export function contrastRatio(hex1: string, hex2: string): number {
+  const l1 = luminance(hexToRgb(hex1));
+  const l2 = luminance(hexToRgb(hex2));
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function passesWcagAA(hex1: string, hex2: string, largeText = false): boolean {
+  const ratio = contrastRatio(hex1, hex2);
+  return largeText ? ratio >= 3 : ratio >= 4.5;
+}

--- a/web/components/theme/ThemeEditor.tsx
+++ b/web/components/theme/ThemeEditor.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useDesignTokens } from "@/store/designTokensStore";
 import { nanoid } from "nanoid";
 import { themePresets, type ThemeToken } from "./themePresets";
+import { contrastRatio, passesWcagAA } from "../../../src/lib/a11y/contrast";
 
 const fontOptions = [
   { label: "inter", value: "Inter, system-ui, sans-serif" },
@@ -16,6 +17,9 @@ export default function ThemeEditor() {
   const [tokens, setTokens] = useState<ThemeToken>(themePresets[preset]);
   const [name, setName] = useState("");
   const [error, setError] = useState("");
+
+  const contrast = contrastRatio(tokens.colors.text, tokens.colors.background);
+  const contrastPass = passesWcagAA(tokens.colors.text, tokens.colors.background);
 
   useEffect(() => {
     const t = themePresets[preset];
@@ -91,6 +95,16 @@ export default function ThemeEditor() {
             />
           </div>
         ))}
+      </section>
+
+      <section>
+        <h3 className="font-bold mb-2">Accessibility</h3>
+        <p>
+          Contrast: {contrast.toFixed(2)}
+          {!contrastPass && (
+            <span className="text-red-500 ml-2">WCAG AA requires ≥4.5</span>
+          )}
+        </p>
       </section>
 
       <section>

--- a/web/components/theme/ThemeProvider.tsx
+++ b/web/components/theme/ThemeProvider.tsx
@@ -23,6 +23,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     Object.entries(tokens.radius).forEach(([k, v]) => root.style.setProperty(`--radius-${k}`, `${v}px`));
     Object.entries(tokens.spacing).forEach(([k, v]) => root.style.setProperty(`--spacing-${k}`, `${v}px`));
     Object.entries(tokens.font).forEach(([k, v]) => root.style.setProperty(`--font-${k}`, v));
+    if (tokens.color.accent) {
+      root.style.setProperty('--focus-ring-color', tokens.color.accent);
+    }
+    root.style.setProperty('--focus-ring-offset', '2px');
   }, [tokens]);
 
   return (

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -32,12 +32,16 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 export function Button({ variant = 'solid', tone = 'neutral', size = 'md', className, children, ...props }: ButtonProps) {
   const classes = cn(
-    'inline-flex items-center justify-center font-medium transition-colors focus-visible:outline-none disabled:opacity-50 disabled:pointer-events-none',
+    'inline-flex items-center justify-center font-medium transition-colors disabled:opacity-50 disabled:pointer-events-none',
     buttonVar({ variant, tone, size }),
     className
   )
   return (
-    <button className={classes} {...props}>
+    <button
+      className={classes}
+      style={{ outlineColor: 'var(--focus-ring-color)', outlineOffset: 'var(--focus-ring-offset)' }}
+      {...props}
+    >
       {children}
     </button>
   )

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -25,6 +25,8 @@
   --color-state-info: 210 90% 60%;
   --color-overlay-scrim: 0 0% 0% / 0.5;
   --color-overlay-focus-ring: 210 90% 60% / 0.6;
+  --focus-ring-color: hsl(var(--color-overlay-focus-ring));
+  --focus-ring-offset: 2px;
 
   --space-xxs: 4px;
   --space-xs: 8px;
@@ -83,6 +85,8 @@
   --color-state-info: 210 90% 60%;
   --color-overlay-scrim: 0 0% 0% / 0.5;
   --color-overlay-focus-ring: 210 90% 60% / 0.6;
+  --focus-ring-color: hsl(var(--color-overlay-focus-ring));
+  --focus-ring-offset: 2px;
 }
 
 @layer base {
@@ -92,7 +96,7 @@
     font-family: var(--font-ui);
   }
   :focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px hsl(var(--color-overlay-focus-ring));
+    outline: 2px solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 }


### PR DESCRIPTION
## Summary
- add color contrast utilities
- show contrast warnings in ThemeEditor
- inject and use focus ring tokens for consistent outlines

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9da582384832cb17b069aae59ba0d