### PR TITLE
feat: add preview share token

### DIFF
--- a/web/app/api/previewToken/route.ts
+++ b/web/app/api/previewToken/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import {
+  createPreviewToken,
+  getPreviewToken,
+  deletePreviewToken,
+  listPreviewTokens,
+} from '@/lib/previewTokenStore';
+
+export async function POST(req: NextRequest) {
+  const { pageId, expiresIn } = await req.json().catch(() => ({}));
+  if (!pageId) {
+    return NextResponse.json({ error: 'pageId required' }, { status: 400 });
+  }
+  const { token, expiresAt } = createPreviewToken(pageId, expiresIn ?? 3600);
+  return NextResponse.json({ token, expiresAt, pageId });
+}
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token');
+  if (!token) {
+    return NextResponse.json({ tokens: listPreviewTokens() });
+  }
+  const info = getPreviewToken(token);
+  if (!info) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+  }
+  try {
+    const filePath = path.join(process.cwd(), 'data/pages', `${info.pageId}.json`);
+    const json = await readFile(filePath, 'utf8');
+    const page = JSON.parse(json);
+    return NextResponse.json({ pageId: info.pageId, expiresAt: info.expiresAt, page });
+  } catch {
+    return NextResponse.json({ error: 'page not found' }, { status: 404 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token');
+  if (!token) {
+    return NextResponse.json({ error: 'token required' }, { status: 400 });
+  }
+  deletePreviewToken(token);
+  return NextResponse.json({ ok: true });
+}

--- a/web/app/preview/shared/[token]/page.tsx
+++ b/web/app/preview/shared/[token]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from 'next/navigation';
+import { getPreviewToken } from '@/lib/previewTokenStore';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import TokenStyle from '@/components/theme/TokenStyle';
+import { NodeRendererCompat } from '@/components/NodeRendererCompat';
+
+export const dynamic = 'force-dynamic';
+
+export default async function PreviewSharedPage({ params }: { params: { token: string } }) {
+  const info = getPreviewToken(params.token);
+  if (!info) notFound();
+
+  try {
+    const filePath = path.join(process.cwd(), 'data/pages', `${info.pageId}.json`);
+    const json = await readFile(filePath, 'utf8');
+    const page = JSON.parse(json);
+    const elements = Array.isArray(page?.tree) ? page.tree : [];
+    const roots = elements.filter((e: any) => !e.parentId);
+    return (
+      <>
+        <TokenStyle />
+        <div className="w-full h-screen relative bg-black">
+          {roots.map((n: any) => (
+            <NodeRendererCompat key={String(n.id)} node={n} />
+          ))}
+        </div>
+      </>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/web/lib/previewTokenStore.ts
+++ b/web/lib/previewTokenStore.ts
@@ -1,0 +1,26 @@
+const tokens = new Map<string, { pageId: string; expiresAt: number }>();
+
+export function createPreviewToken(pageId: string, ttlSeconds = 3600) {
+  const token = Math.random().toString(36).slice(2, 10);
+  const expiresAt = Date.now() + ttlSeconds * 1000;
+  tokens.set(token, { pageId, expiresAt });
+  return { token, expiresAt, pageId };
+}
+
+export function getPreviewToken(token: string) {
+  const info = tokens.get(token);
+  if (!info) return null;
+  if (info.expiresAt < Date.now()) {
+    tokens.delete(token);
+    return null;
+  }
+  return info;
+}
+
+export function deletePreviewToken(token: string) {
+  tokens.delete(token);
+}
+
+export function listPreviewTokens() {
+  return Array.from(tokens.entries()).map(([token, v]) => ({ token, ...v }));
+}


### PR DESCRIPTION
## Summary
- add API endpoint for temporary preview tokens
- add shared preview page by token

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9da8cc8cc832c9cb3153c67901895