### PR TITLE
feat: add user skin selection preview

### DIFF
--- a/src/app/dev/skins/page.tsx
+++ b/src/app/dev/skins/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import React, { useEffect } from 'react';
+import minimal from '../../../themes/presets/minimal.json';
+import corporate from '../../../themes/presets/corporate.json';
+import pop from '../../../themes/presets/pop.json';
+import { useUserStore } from '../../../stores/userStore';
+import { useThemeStore, type ThemeTokens } from '../../../stores/themeStore';
+
+const presets = [
+  { id: 'minimal', name: 'Minimal', tokens: minimal },
+  { id: 'corporate', name: 'Corporate', tokens: corporate },
+  { id: 'pop', name: 'Pop', tokens: pop },
+];
+
+export default function SkinsPage() {
+  const { brandThemeId, setBrandThemeId } = useUserStore();
+
+  useEffect(() => {
+    useThemeStore.setState((state) => ({
+      themes: {
+        ...state.themes,
+        minimal: minimal as ThemeTokens,
+        corporate: corporate as ThemeTokens,
+        pop: pop as ThemeTokens,
+      },
+    }));
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Skins</h1>
+      <div className="flex flex-wrap gap-2">
+        {presets.map((p) => (
+          <button
+            key={p.id}
+            className={`btn btn-sm ${brandThemeId === p.id ? 'btn-primary' : ''}`}
+            onClick={() => setBrandThemeId(p.id)}
+          >
+            {p.name}
+          </button>
+        ))}
+        <button
+          className={`btn btn-sm ${!brandThemeId ? 'btn-primary' : ''}`}
+          onClick={() => setBrandThemeId(undefined)}
+        >
+          Default
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useLayoutEffect } from 'react'
 import { useThemeStore, defaultTheme, type ThemeTokens } from '../../stores/themeStore'
+import { useUserStore } from '../../stores/userStore'
 
 interface ThemeContextValue {
   getEffectiveTheme: (opts?: {
@@ -61,6 +62,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     layoutThemeMap,
     pageThemeOverride
   } = useThemeStore()
+  const { brandThemeId } = useUserStore()
 
   const getEffectiveTheme = useCallback(
     ({
@@ -72,12 +74,20 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       layoutId?: string
       override?: Partial<ThemeTokens>
     } = {}): ThemeTokens => {
-      const domainThemeId = currentDomainId && domainDefaultTheme[currentDomainId]
-      let theme = domainThemeId && themes[domainThemeId] ? themes[domainThemeId] : defaultTheme
+      const isPreview =
+        typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('preview')
+      let theme: ThemeTokens
+      if (isPreview && brandThemeId && themes[brandThemeId]) {
+        theme = themes[brandThemeId]
+      } else {
+        const domainThemeId = currentDomainId && domainDefaultTheme[currentDomainId]
+        theme = domainThemeId && themes[domainThemeId] ? themes[domainThemeId] : defaultTheme
 
-      const layoutThemeId = (layoutId && layoutThemeMap[layoutId]) || (currentLayoutId && layoutThemeMap[currentLayoutId])
-      if (layoutThemeId && themes[layoutThemeId]) {
-        theme = themes[layoutThemeId]
+        const layoutThemeId = (layoutId && layoutThemeMap[layoutId]) ||
+          (currentLayoutId && layoutThemeMap[currentLayoutId])
+        if (layoutThemeId && themes[layoutThemeId]) {
+          theme = themes[layoutThemeId]
+        }
       }
 
       const pageOverrideObj =
@@ -87,6 +97,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       return theme
     },
     [
+      brandThemeId,
       currentDomainId,
       currentLayoutId,
       currentPageId,

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,0 +1,22 @@
+'use client';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface UserState {
+  userId: string;
+  brandThemeId?: string;
+  setUserId: (id: string) => void;
+  setBrandThemeId: (id?: string) => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      userId: '',
+      brandThemeId: undefined,
+      setUserId: (userId) => set({ userId }),
+      setBrandThemeId: (brandThemeId) => set({ brandThemeId }),
+    }),
+    { name: 'user-settings' }
+  )
+);

--- a/web/app/dev/skins/page.tsx
+++ b/web/app/dev/skins/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import React, { useEffect } from 'react';
+import minimal from '../../../../src/themes/presets/minimal.json';
+import corporate from '../../../../src/themes/presets/corporate.json';
+import pop from '../../../../src/themes/presets/pop.json';
+import { useUserStore } from '../../../../src/stores/userStore';
+import { useThemeStore, type ThemeTokens } from '../../../../src/stores/themeStore';
+
+const presets = [
+  { id: 'minimal', name: 'Minimal', tokens: minimal },
+  { id: 'corporate', name: 'Corporate', tokens: corporate },
+  { id: 'pop', name: 'Pop', tokens: pop },
+];
+
+export default function SkinsPage() {
+  const { brandThemeId, setBrandThemeId } = useUserStore();
+
+  useEffect(() => {
+    useThemeStore.setState((state) => ({
+      themes: {
+        ...state.themes,
+        minimal: minimal as ThemeTokens,
+        corporate: corporate as ThemeTokens,
+        pop: pop as ThemeTokens,
+      },
+    }));
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Skins</h1>
+      <div className="flex flex-wrap gap-2">
+        {presets.map((p) => (
+          <button
+            key={p.id}
+            className={`btn btn-sm ${brandThemeId === p.id ? 'btn-primary' : ''}`}
+            onClick={() => setBrandThemeId(p.id)}
+          >
+            {p.name}
+          </button>
+        ))}
+        <button
+          className={`btn btn-sm ${!brandThemeId ? 'btn-primary' : ''}`}
+          onClick={() => setBrandThemeId(undefined)}
+        >
+          Default
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add persisted user store for skin theme selection
- expose skin presets via new dev page
- prioritize user brand theme in ThemeProvider when previewing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9da97cdf4832c9d2dddcf9ee39a96