### PR TITLE
Add Zod schemas for theme, layout, and page data

### DIFF
--- a/src/lib/migrations/layout.ts
+++ b/src/lib/migrations/layout.ts
@@ -1,3 +1,6 @@
+import { layoutTemplateSchema, type LayoutTemplate } from '../../schemas/layout';
+import { ZodError } from 'zod';
+
 export const LAYOUT_VERSION = 1;
 
 export interface LayoutState {
@@ -8,9 +11,7 @@ export interface LayoutState {
   lastResetAt?: number;
 }
 
-export interface LayoutDoc extends LayoutState {
-  version: number;
-}
+export type LayoutDoc = LayoutTemplate;
 
 const DEFAULT_LAYOUT: LayoutState = {
   left: { width: 240, collapsed: false },
@@ -23,15 +24,27 @@ const DEFAULT_LAYOUT: LayoutState = {
 // v1 -> returned as-is; legacy unversioned objects are merged with defaults.
 export function migrateLayout(json: any): LayoutDoc {
   if (!json || typeof json !== 'object') {
-    return { ...DEFAULT_LAYOUT, version: LAYOUT_VERSION };
+    return parse({ ...DEFAULT_LAYOUT, version: LAYOUT_VERSION });
   }
   const v = json.version ?? 0;
   if (v === LAYOUT_VERSION) {
-    return { ...DEFAULT_LAYOUT, ...(json as LayoutState), version: LAYOUT_VERSION };
+    return parse({ ...DEFAULT_LAYOUT, ...(json as LayoutState), version: LAYOUT_VERSION });
   }
   if (v === 0) {
     const state = json as Partial<LayoutState>;
-    return { ...DEFAULT_LAYOUT, ...state, version: LAYOUT_VERSION };
+    return parse({ ...DEFAULT_LAYOUT, ...state, version: LAYOUT_VERSION });
   }
   throw new Error(`Unsupported layout version: ${v}`);
+}
+
+function parse(doc: unknown): LayoutDoc {
+  try {
+    return layoutTemplateSchema.parse(doc);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const msg = err.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      throw new Error(msg);
+    }
+    throw err;
+  }
 }

--- a/src/lib/migrations/page.ts
+++ b/src/lib/migrations/page.ts
@@ -1,14 +1,7 @@
-export const PAGE_VERSION = 1;
+import { pageDocSchema, type PageDoc } from '../../schemas/page';
+import { ZodError } from 'zod';
 
-export interface PageDoc {
-  id: string;
-  title: string;
-  path: string;
-  tree: any[];
-  bindings: Record<string, unknown>;
-  pageOverrides: { theme?: Record<string, any> };
-  version: number;
-}
+export const PAGE_VERSION = 1;
 
 // migratePage converts legacy page JSON to the latest PageDoc format.
 export function migratePage(json: any): PageDoc {
@@ -17,10 +10,10 @@ export function migratePage(json: any): PageDoc {
   }
   const v = json.version ?? 0;
   if (v === PAGE_VERSION) {
-    return json as PageDoc;
+    return parse(json);
   }
   if (v === 0) {
-    return {
+    return parse({
       id: json.id ?? '',
       title: json.title ?? '',
       path: json.path ?? '/',
@@ -28,7 +21,19 @@ export function migratePage(json: any): PageDoc {
       bindings: typeof json.bindings === 'object' && json.bindings ? json.bindings : {},
       pageOverrides: typeof json.pageOverrides === 'object' && json.pageOverrides ? json.pageOverrides : {},
       version: PAGE_VERSION,
-    };
+    });
   }
   throw new Error(`Unsupported page version: ${v}`);
+}
+
+function parse(doc: unknown): PageDoc {
+  try {
+    return pageDocSchema.parse(doc);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const msg = err.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      throw new Error(msg);
+    }
+    throw err;
+  }
 }

--- a/src/lib/migrations/theme.ts
+++ b/src/lib/migrations/theme.ts
@@ -1,10 +1,8 @@
 import { defaultTheme, type ThemeTokens } from '../../stores/themeStore';
+import { themeDocSchema, type ThemeDoc } from '../../schemas/theme';
+import { ZodError } from 'zod';
 
 export const THEME_VERSION = 1;
-
-export interface ThemeDoc extends ThemeTokens {
-  version: number;
-}
 
 // migrateTheme converts given json (possibly legacy) to latest ThemeDoc.
 // It accepts both v1 (current) and legacy unversioned themes.
@@ -14,7 +12,7 @@ export function migrateTheme(json: any): ThemeDoc {
   }
   const v = json.version ?? 0;
   if (v === THEME_VERSION) {
-    return json as ThemeDoc;
+    return parse(json);
   }
   if (v === 0) {
     const merged: ThemeTokens = {
@@ -25,7 +23,19 @@ export function migrateTheme(json: any): ThemeDoc {
       spacing: { ...defaultTheme.spacing, ...(json.spacing || {}) },
       typography: { ...defaultTheme.typography, ...(json.typography || {}) },
     };
-    return { ...merged, version: THEME_VERSION };
+    return parse({ ...merged, version: THEME_VERSION });
   }
   throw new Error(`Unsupported theme version: ${v}`);
+}
+
+function parse(doc: unknown): ThemeDoc {
+  try {
+    return themeDocSchema.parse(doc);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const msg = err.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
+      throw new Error(msg);
+    }
+    throw err;
+  }
 }

--- a/src/schemas/layout.ts
+++ b/src/schemas/layout.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+const paneSchema = z.object({
+  width: z.number(),
+  collapsed: z.boolean(),
+});
+
+const statusSchema = z.object({
+  height: z.number(),
+  visible: z.boolean(),
+});
+
+export const layoutTemplateSchema = z.object({
+  version: z.literal(1),
+  left: paneSchema,
+  right: paneSchema,
+  status: statusSchema,
+  rightSections: z.record(z.boolean()).optional(),
+  lastResetAt: z.number().optional(),
+});
+
+export type LayoutTemplate = z.infer<typeof layoutTemplateSchema>;

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { themeTokensSchema } from './theme';
+
+export interface BuilderNode {
+  id: string;
+  type: string;
+  props?: Record<string, any>;
+  children?: BuilderNode[];
+}
+
+export const builderNodeSchema: z.ZodType<BuilderNode> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    type: z.string(),
+    props: z.record(z.any()).optional(),
+    children: z.array(builderNodeSchema).optional(),
+  })
+);
+
+export const pageSnapshotSchema = z.object({
+  version: z.literal(1),
+  pageId: z.string(),
+  layoutId: z.string(),
+  effectiveTheme: themeTokensSchema,
+  nodes: z.array(builderNodeSchema),
+  timestamp: z.number(),
+});
+export type PageSnapshot = z.infer<typeof pageSnapshotSchema>;
+
+export const pageDocSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  path: z.string(),
+  tree: z.array(z.any()),
+  bindings: z.record(z.any()),
+  pageOverrides: z.object({ theme: themeTokensSchema.partial().optional() }).default({}),
+  version: z.literal(1),
+});
+export type PageDoc = z.infer<typeof pageDocSchema>;

--- a/src/schemas/theme.ts
+++ b/src/schemas/theme.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const themeTokensSchema = z.object({
+  name: z.string(),
+  brandId: z.string().optional(),
+  colors: z.object({
+    background: z.string(),
+    surface: z.string(),
+    primary: z.string(),
+    secondary: z.string(),
+    text: z.string(),
+    border: z.string(),
+  }),
+  radius: z.object({
+    sm: z.string(),
+    md: z.string(),
+    lg: z.string(),
+    full: z.string(),
+  }),
+  spacing: z.object({
+    xs: z.string(),
+    sm: z.string(),
+    md: z.string(),
+    lg: z.string(),
+    xl: z.string(),
+  }),
+  typography: z.object({
+    fontFamily: z.string(),
+    baseSize: z.string(),
+    headingScale: z.number(),
+    weightRegular: z.string(),
+    weightBold: z.string(),
+  }),
+});
+
+export const themeDocSchema = themeTokensSchema.extend({
+  version: z.literal(1),
+});
+
+export type ThemeTokens = z.infer<typeof themeTokensSchema>;
+export type ThemeDoc = z.infer<typeof themeDocSchema>;

--- a/web/app/api/savePage/route.ts
+++ b/web/app/api/savePage/route.ts
@@ -1,32 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
-
-export type ThemeTokens = {
-  [key: string]: any;
-};
-
-export type BuilderNode = {
-  id: string;
-  type: string;
-  props?: Record<string, any>;
-  children?: BuilderNode[];
-};
-
-export type PageSnapshot = {
-  pageId: string;
-  layoutId: string;
-  effectiveTheme: ThemeTokens;
-  nodes: BuilderNode[];
-  timestamp: number;
-};
+import {
+  pageSnapshotSchema,
+  type PageSnapshot,
+} from '../../../../src/schemas/page';
 
 export async function POST(req: NextRequest) {
   try {
-    const body = (await req.json()) as PageSnapshot;
-    if (!body?.pageId) {
-      return NextResponse.json({ error: 'pageId required' }, { status: 400 });
+    const json = await req.json();
+    const parsed = pageSnapshotSchema.safeParse(json);
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map(e => `${e.path.join('.')}: ${e.message}`)
+        .join(', ');
+      return NextResponse.json({ error: msg }, { status: 400 });
     }
+    const body: PageSnapshot = parsed.data;
     const pagesDir = path.join(process.cwd(), 'data/pages');
     await mkdir(pagesDir, { recursive: true });
     const filePath = path.join(pagesDir, `${body.pageId}.json`);

--- a/web/app/dev/registry/page.tsx
+++ b/web/app/dev/registry/page.tsx
@@ -4,15 +4,25 @@ import { registry } from "@/lib/registry";
 import { themePresets } from "@/lib/themePresets";
 import { hoverActionPresets } from "@/lib/hoverActionPresets";
 import { animationPresets } from "@/lib/animationPresets";
+import { ZodError } from "zod";
+import { themeDocSchema } from "../../../../src/schemas/theme";
+import { layoutTemplateSchema } from "../../../../src/schemas/layout";
+import { pageSnapshotSchema } from "../../../../src/schemas/page";
 
- type Tab = "components" | "themes" | "hover" | "animations";
+ type Tab = "components" | "themes" | "hover" | "animations" | "schemas";
 
 export default function DevRegistryPage() {
   const [tab, setTab] = useState<Tab>("components");
   return (
     <div className="p-4 space-y-4">
       <div className="flex gap-2">
-        {[{ key: "components", label: "Components" }, { key: "themes", label: "Themes" }, { key: "hover", label: "Hover Actions" }, { key: "animations", label: "Animations" }].map(t => (
+        {[
+          { key: "components", label: "Components" },
+          { key: "themes", label: "Themes" },
+          { key: "hover", label: "Hover Actions" },
+          { key: "animations", label: "Animations" },
+          { key: "schemas", label: "Schemas" },
+        ].map(t => (
           <button
             key={t.key}
             onClick={() => setTab(t.key as Tab)}
@@ -27,6 +37,7 @@ export default function DevRegistryPage() {
       {tab === "themes" && <ThemesSection />}
       {tab === "hover" && <HoverSection />}
       {tab === "animations" && <AnimationSection />}
+      {tab === "schemas" && <SchemasSection />}
     </div>
   );
 }
@@ -141,6 +152,60 @@ function AnimationSection() {
           </details>
         );
       })}
+    </div>
+  );
+}
+
+function SchemasSection() {
+  const [kind, setKind] = useState<'theme' | 'layout' | 'page'>('theme');
+  const [text, setText] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+
+  const validate = () => {
+    try {
+      const json = JSON.parse(text);
+      const schema =
+        kind === 'theme'
+          ? themeDocSchema
+          : kind === 'layout'
+          ? layoutTemplateSchema
+          : pageSnapshotSchema;
+      schema.parse(json);
+      setResult('Valid!');
+    } catch (e) {
+      if (e instanceof ZodError) {
+        setResult(e.errors.map(err => `${err.path.join('.')}: ${err.message}`).join(', '));
+      } else if (e instanceof Error) {
+        setResult(e.message);
+      } else {
+        setResult('Unknown error');
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-2 max-w-xl">
+      <div className="flex gap-2">
+        <select
+          value={kind}
+          onChange={e => setKind(e.target.value as any)}
+          className="border px-2 py-1 rounded text-sm"
+        >
+          <option value="theme">Theme</option>
+          <option value="layout">Layout</option>
+          <option value="page">Page</option>
+        </select>
+        <button onClick={validate} className="px-2 py-1 rounded border text-sm">
+          Validate
+        </button>
+      </div>
+      <textarea
+        value={text}
+        onChange={e => setText(e.target.value)}
+        className="w-full h-40 border p-2 text-xs font-mono rounded"
+        placeholder="Paste JSON here"
+      />
+      {result && <p className="text-sm">{result}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- introduce Zod schemas for ThemeTokens, LayoutTemplate, and PageSnapshot
- enforce schema validation in migrations and page save API with detailed errors
- add dev registry UI tab to validate JSON against these schemas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9da7b1748832c9cab99210f4c6e64