### PR TITLE
feat: add slot resizing with layout persistence

### DIFF
--- a/src/components/layout/LayoutCanvas.tsx
+++ b/src/components/layout/LayoutCanvas.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { useTheme } from '../../hooks/useTheme'
+import SlotResizer from './SlotResizer'
+import {
+  loadLayoutTemplate,
+  saveLayoutTemplate,
+  LayoutTemplate,
+} from '../../lib/layoutTemplates'
+
+interface LayoutCanvasProps {
+  layoutId: string
+}
+
+export const LayoutCanvas: React.FC<LayoutCanvasProps> = ({ layoutId }) => {
+  const [template, setTemplate] = React.useState<LayoutTemplate>(() =>
+    loadLayoutTemplate(layoutId)
+  )
+  const { attrs } = useTheme({ layoutId, scope: 'local' })
+
+  const update = (slot: 'header' | 'sidebar' | 'footer', value: number) => {
+    setTemplate(prev => {
+      const next: LayoutTemplate = {
+        slots: {
+          ...prev.slots,
+          [slot]: {
+            ...(prev.slots as any)[slot],
+            [slot === 'sidebar' ? 'width' : 'height']: value,
+          },
+        },
+      }
+      saveLayoutTemplate(layoutId, next)
+      return next
+    })
+  }
+
+  return (
+    <div {...attrs} className="w-full h-full flex flex-col">
+      <div style={{ height: template.slots.header.height, position: 'relative' }}>
+        <SlotResizer
+          axis="y"
+          value={template.slots.header.height}
+          onChange={v => update('header', v)}
+          className="absolute bottom-0 left-0 right-0 h-2"
+        />
+      </div>
+      <div className="flex flex-1">
+        <div
+          style={{ width: template.slots.sidebar.width, position: 'relative' }}
+          className="h-full"
+        >
+          <SlotResizer
+            axis="x"
+            value={template.slots.sidebar.width}
+            onChange={v => update('sidebar', v)}
+            className="absolute top-0 right-0 bottom-0 w-2"
+          />
+        </div>
+        <div className="flex-1" />
+      </div>
+      <div style={{ height: template.slots.footer.height, position: 'relative' }}>
+        <SlotResizer
+          axis="y"
+          value={template.slots.footer.height}
+          onChange={v => update('footer', v)}
+          className="absolute top-0 left-0 right-0 h-2"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default LayoutCanvas

--- a/src/components/layout/SlotResizer.tsx
+++ b/src/components/layout/SlotResizer.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+const GRID_SIZE = 8
+
+function snap(value: number): number {
+  return Math.round(value / GRID_SIZE) * GRID_SIZE
+}
+
+export interface SlotResizerProps {
+  axis: 'x' | 'y'
+  value: number
+  onChange: (value: number) => void
+  className?: string
+}
+
+export const SlotResizer: React.FC<SlotResizerProps> = ({
+  axis,
+  value,
+  onChange,
+  className,
+}) => {
+  const startRef = React.useRef<{ start: number; initial: number } | null>(null)
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    startRef.current = {
+      start: axis === 'x' ? e.clientX : e.clientY,
+      initial: value,
+    }
+
+    const handleMove = (ev: MouseEvent) => {
+      if (!startRef.current) return
+      const delta =
+        axis === 'x'
+          ? ev.clientX - startRef.current.start
+          : ev.clientY - startRef.current.start
+      const next = snap(startRef.current.initial + delta)
+      onChange(next)
+    }
+
+    const handleUp = () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mouseup', handleUp)
+      startRef.current = null
+    }
+
+    window.addEventListener('mousemove', handleMove)
+    window.addEventListener('mouseup', handleUp)
+  }
+
+  const style: React.CSSProperties = {
+    cursor: axis === 'x' ? 'col-resize' : 'row-resize',
+  }
+
+  return <div className={className} style={style} onMouseDown={onMouseDown} />
+}
+
+export default SlotResizer

--- a/src/lib/layoutTemplates.ts
+++ b/src/lib/layoutTemplates.ts
@@ -1,0 +1,47 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface LayoutSlots {
+  header: { height: number }
+  sidebar: { width: number }
+  footer: { height: number }
+}
+
+export interface LayoutTemplate {
+  slots: LayoutSlots
+}
+
+const ROOT = process.cwd()
+const DIR = path.join(ROOT, 'layoutTemplates')
+
+function ensureDir() {
+  if (!fs.existsSync(DIR)) {
+    fs.mkdirSync(DIR, { recursive: true })
+  }
+}
+
+export function loadLayoutTemplate(id: string): LayoutTemplate {
+  ensureDir()
+  const file = path.join(DIR, `${id}.json`)
+  if (fs.existsSync(file)) {
+    try {
+      const raw = fs.readFileSync(file, 'utf-8')
+      return JSON.parse(raw) as LayoutTemplate
+    } catch {
+      /* ignore */
+    }
+  }
+  return {
+    slots: {
+      header: { height: 64 },
+      sidebar: { width: 240 },
+      footer: { height: 48 },
+    },
+  }
+}
+
+export function saveLayoutTemplate(id: string, template: LayoutTemplate): void {
+  ensureDir()
+  const file = path.join(DIR, `${id}.json`)
+  fs.writeFileSync(file, JSON.stringify(template, null, 2))
+}


### PR DESCRIPTION
## Summary
- add draggable SlotResizer handle with 8px snapping
- implement LayoutCanvas applying header/sidebar/footer size updates
- persist layout slot dimensions to layoutTemplates JSON files

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9dd1f12b0832c9a1a90d8da3de28c