### PR TITLE
feat: auto sidebar menu from routes with rbac

### DIFF
--- a/src/components/sidebar/MenuEditor.tsx
+++ b/src/components/sidebar/MenuEditor.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import type { NestedMenuItem } from '../../lib/router/scanRoutes'
+
+export interface MenuEditorProps {
+  value: NestedMenuItem[]
+  onChange?: (items: NestedMenuItem[]) => void
+}
+
+function EditorNode({ item, depth, update }: { item: NestedMenuItem; depth: number; update: (n: NestedMenuItem) => void }) {
+  const [label, setLabel] = useState(item.label)
+  const [hidden, setHidden] = useState(!!item.hidden)
+  const [children, setChildren] = useState(item.children ?? [])
+
+  const handleChildChange = (idx: number, child: NestedMenuItem) => {
+    const next = children.slice()
+    next[idx] = child
+    setChildren(next)
+    update({ ...item, label, hidden, children: next })
+  }
+
+  return (
+    <div style={{ marginLeft: depth * 12 }} className="space-y-1">
+      <div className="flex items-center gap-2">
+        <input
+          className="border px-1 text-sm"
+          value={label}
+          onChange={(e) => {
+            setLabel(e.target.value)
+            update({ ...item, label: e.target.value, hidden, children })
+          }}
+        />
+        <label className="text-xs flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={hidden}
+            onChange={(e) => {
+              setHidden(e.target.checked)
+              update({ ...item, label, hidden: e.target.checked, children })
+            }}
+          />
+          hidden
+        </label>
+      </div>
+
+      {children.map((c, i) => (
+        <EditorNode key={c.id} item={c} depth={depth + 1} update={(n) => handleChildChange(i, n)} />
+      ))}
+    </div>
+  )
+}
+
+export default function MenuEditor({ value, onChange }: MenuEditorProps) {
+  const [items, setItems] = useState(value)
+  const handleUpdate = (idx: number, item: NestedMenuItem) => {
+    const next = items.slice()
+    next[idx] = item
+    setItems(next)
+    onChange?.(next)
+  }
+
+  return (
+    <div className="space-y-2">
+      {items.map((it, i) => (
+        <EditorNode key={it.id} item={it} depth={0} update={(n) => handleUpdate(i, n)} />
+      ))}
+    </div>
+  )
+}

--- a/src/lib/router/scanRoutes.ts
+++ b/src/lib/router/scanRoutes.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface NestedMenuItem {
+  id: string;            // unique id (path)
+  label: string;         // display label
+  href: string;          // route href
+  children?: NestedMenuItem[];
+  hidden?: boolean;
+  disabled?: boolean;
+}
+
+// helper to humanize segment name
+function labelFromSegment(seg: string): string {
+  if (!seg) return 'Home';
+  const s = seg.replace(/^[\[\]\(\)]+|[\[\]\(\)]+$/g, '');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function readTitle(file: string, fallback: string): string {
+  try {
+    const content = fs.readFileSync(file, 'utf8');
+    const first = content.split(/\r?\n/)[0];
+    const m = first.match(/\/\/\s*title:\s*(.+)/i);
+    if (m) return m[1].trim();
+  } catch {
+    // ignore
+  }
+  return fallback;
+}
+
+function walk(dir: string, segs: string[]): NestedMenuItem | null {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const children: NestedMenuItem[] = [];
+
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      const child = walk(path.join(dir, e.name), [...segs, e.name]);
+      if (child) children.push(child);
+    }
+  }
+
+  const page = entries.find(e => e.isFile() && /^page\.(tsx|ts|jsx|js)$/.test(e.name));
+  if (!page && children.length === 0) return null;
+
+  const href = '/' + segs.join('/');
+  const label = page ? readTitle(path.join(dir, page.name), labelFromSegment(segs[segs.length - 1] ?? '')) : labelFromSegment(segs[segs.length - 1] ?? '');
+
+  return { id: href || '/', href: href || '/', label, children: children.length ? children : undefined };
+}
+
+export function scanRoutes(root = path.join(process.cwd(), 'src/app')): NestedMenuItem[] {
+  if (!fs.existsSync(root)) return [];
+  const rootNode = walk(root, []);
+  return rootNode?.children ?? [];
+}
+
+export default scanRoutes;

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -1,36 +1,15 @@
-'use client';
-import Link from 'next/link';
-import { mergeMenu } from '@/lib/menu';
-import { useSidebarStore } from '@/store/sidebarStore';
+import type { NestedMenuItem } from '../../../src/lib/router/scanRoutes'
+import scanRoutes from '../../../src/lib/router/scanRoutes'
+import type { FeatureKey } from '../../../src/stores/rbacStore'
+import SidebarClient from './SidebarClient'
 
-function NodeView({ n }: { n: any }) {
-  if (n.hidden) return null;
-  return (
-    <li>
-      <Link href={n.href} className="block px-3 py-1.5 rounded hover:bg-[color:var(--panel2)]">
-        {n.label}
-      </Link>
-      {n.children?.length ? (
-        <ul className="ml-3 border-l border-[color:var(--border)] pl-2 space-y-1">
-          {n.children.map((c: any) => <NodeView key={c.id} n={c} />)}
-        </ul>
-      ) : null}
-    </li>
-  );
+export interface SidebarProps {
+  menuItems?: NestedMenuItem[]
+  useAuto?: boolean
+  rbacKeys?: Record<string, FeatureKey>
 }
 
-export default function Sidebar() {
-  const preset = useSidebarStore(s => s.active());
-  if (preset.rootHidden) return null;
-  const tree = mergeMenu(preset);
-
-  return (
-    <aside className="w-64 shrink-0 border-r"
-           style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
-      <div className="p-3 text-xs uppercase tracking-wide text-[color:var(--muted)]">Menu</div>
-      <ul className="px-2 pb-4 space-y-1">
-        {tree.map((n) => <NodeView key={n.id} n={n} />)}
-      </ul>
-    </aside>
-  );
+export default function Sidebar({ menuItems, useAuto, rbacKeys }: SidebarProps) {
+  const items = useAuto || !menuItems ? scanRoutes() : menuItems
+  return <SidebarClient items={items ?? []} rbacKeys={rbacKeys} />
 }

--- a/web/components/layout/SidebarClient.tsx
+++ b/web/components/layout/SidebarClient.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Link from 'next/link'
+import { useRbacStore, FeatureKey } from '../../../src/stores/rbacStore'
+import type { NestedMenuItem } from '../../../src/lib/router/scanRoutes'
+
+interface Props {
+  items: NestedMenuItem[]
+  rbacKeys?: Record<string, FeatureKey>
+}
+
+function applyRbac(
+  items: NestedMenuItem[],
+  rbacKeys: Record<string, FeatureKey> | undefined,
+  role: string,
+  permissions: any,
+  locks: Record<FeatureKey, boolean>
+): NestedMenuItem[] {
+  const walk = (arr: NestedMenuItem[]): NestedMenuItem[] =>
+    arr
+      .map((n) => {
+        const key = rbacKeys?.[n.id]
+        let hidden = n.hidden
+        let disabled = n.disabled
+        if (key) {
+          const allowed = permissions[role]?.[key]
+          const unlocked = locks[key]
+          if (!allowed) hidden = true
+          else if (!unlocked) disabled = true
+        }
+        const children = n.children ? walk(n.children) : undefined
+        return { ...n, hidden, disabled, children }
+      })
+      .filter((n) => !n.hidden)
+  return walk(items)
+}
+
+function NodeView({ n }: { n: NestedMenuItem }) {
+  return (
+    <li>
+      <Link
+        href={n.href}
+        className={`block px-3 py-1.5 rounded hover:bg-[color:var(--panel2)] ${n.disabled ? 'opacity-50 pointer-events-none' : ''}`}
+      >
+        {n.label}
+      </Link>
+      {n.children?.length ? (
+        <ul className="ml-3 border-l border-[color:var(--border)] pl-2 space-y-1">
+          {n.children.map((c) => (
+            <NodeView key={c.id} n={c} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  )
+}
+
+export default function SidebarClient({ items, rbacKeys }: Props) {
+  const { role, permissions, locks } = useRbacStore()
+  const tree = applyRbac(items, rbacKeys, role, permissions, locks)
+
+  return (
+    <aside className="w-64 shrink-0 border-r" style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
+      <div className="p-3 text-xs uppercase tracking-wide text-[color:var(--muted)]">Menu</div>
+      <ul className="px-2 pb-4 space-y-1">
+        {tree.map((n) => (
+          <NodeView key={n.id} n={n} />
+        ))}
+      </ul>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary
- scan Next.js app routes to build nested menu data
- add tree-based MenuEditor for manual menu overrides
- update Sidebar to auto-generate menus and apply RBAC controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9dd2c8c38832cab2a23d4064d97e3