### PR TITLE
feat: add route scanning and sidebar editor

### DIFF
--- a/src/components/sidebar/MenuEditor.tsx
+++ b/src/components/sidebar/MenuEditor.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import type { NestedMenuItem } from '../../lib/router/scanRoutes';
+
+interface MenuEditorProps {
+  items: NestedMenuItem[];
+  onChange?: (items: NestedMenuItem[]) => void;
+}
+
+export default function MenuEditor({ items, onChange }: MenuEditorProps) {
+  const [local, setLocal] = useState<NestedMenuItem[]>(items);
+
+  const update = (next: NestedMenuItem[]) => {
+    setLocal(next);
+    onChange?.(next);
+  };
+
+  const toggleHidden = (id: string) => {
+    const walk = (arr: NestedMenuItem[]): NestedMenuItem[] =>
+      arr.map(n =>
+        n.id === id
+          ? { ...n, hidden: !n.hidden }
+          : { ...n, children: n.children ? walk(n.children) : undefined }
+      );
+    update(walk(local));
+  };
+
+  const rename = (id: string, label: string) => {
+    const walk = (arr: NestedMenuItem[]): NestedMenuItem[] =>
+      arr.map(n =>
+        n.id === id
+          ? { ...n, label }
+          : { ...n, children: n.children ? walk(n.children) : undefined }
+      );
+    update(walk(local));
+  };
+
+  const render = (arr: NestedMenuItem[]) => (
+    <ul className="pl-4 space-y-1">
+      {arr.map(n => (
+        <li key={n.id} className="space-y-1">
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!n.hidden}
+              onChange={() => toggleHidden(n.id)}
+            />
+            <input
+              type="text"
+              value={n.label}
+              onChange={e => rename(n.id, e.target.value)}
+              className="border p-1 rounded flex-1"
+            />
+          </div>
+          {n.children && n.children.length ? render(n.children) : null}
+        </li>
+      ))}
+    </ul>
+  );
+
+  return <div>{render(local)}</div>;
+}

--- a/src/lib/router/scanRoutes.ts
+++ b/src/lib/router/scanRoutes.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface NestedMenuItem {
+  id: string;            // unique identifier, typically the route path
+  href: string;          // path used for navigation
+  label: string;         // display title
+  children?: NestedMenuItem[];
+  hidden?: boolean;
+  disabled?: boolean;
+}
+
+function readTitle(file: string, fallback: string) {
+  try {
+    const src = fs.readFileSync(file, 'utf8');
+    const m = src.match(/^\s*\/\/\s*title:\s*(.+)$/m);
+    return m ? m[1].trim() : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function scanRoutes(appDir: string): NestedMenuItem[] {
+  const walk = (dir: string, parentPath: string): NestedMenuItem[] => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const nodes: NestedMenuItem[] = [];
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const seg = ent.name;
+      const abs = path.join(dir, seg);
+      const rel = path.posix.join(parentPath, seg);
+      const page = ['page.tsx', 'page.ts', 'page.jsx', 'page.js']
+        .map(f => path.join(abs, f))
+        .find(fs.existsSync);
+      const children = walk(abs, rel);
+      if (page) {
+        const label = readTitle(page, seg);
+        nodes.push({ id: rel, href: rel, label, children: children.length ? children : undefined });
+      } else if (children.length) {
+        // folders without page.tsx are flattened
+        nodes.push(...children);
+      }
+    }
+    return nodes;
+  };
+  return walk(appDir, '');
+}

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -2,31 +2,59 @@
 import Link from 'next/link';
 import { mergeMenu } from '@/lib/menu';
 import { useSidebarStore } from '@/store/sidebarStore';
+import type { NestedMenuItem } from '../../../src/lib/router/scanRoutes';
+import { useRbacStore, type FeatureKey } from '../../../src/stores/rbacStore';
 
-function NodeView({ n }: { n: any }) {
+function NodeView({ n }: { n: NestedMenuItem }) {
   if (n.hidden) return null;
   return (
     <li>
-      <Link href={n.href} className="block px-3 py-1.5 rounded hover:bg-[color:var(--panel2)]">
+      <Link
+        href={n.href}
+        className={`block px-3 py-1.5 rounded hover:bg-[color:var(--panel2)] ${n.disabled ? 'opacity-50 pointer-events-none' : ''}`}
+      >
         {n.label}
       </Link>
       {n.children?.length ? (
         <ul className="ml-3 border-l border-[color:var(--border)] pl-2 space-y-1">
-          {n.children.map((c: any) => <NodeView key={c.id} n={c} />)}
+          {n.children.map((c) => <NodeView key={c.id} n={c} />)}
         </ul>
       ) : null}
     </li>
   );
 }
 
-export default function Sidebar() {
+interface SidebarProps {
+  menuItems?: NestedMenuItem[];
+  useAuto?: boolean;
+  rbacKeys?: Record<string, FeatureKey>;
+}
+
+export default function Sidebar({ menuItems = [], useAuto = true, rbacKeys }: SidebarProps) {
   const preset = useSidebarStore(s => s.active());
-  if (preset.rootHidden) return null;
-  const tree = mergeMenu(preset);
+  const { role, permissions, locks } = useRbacStore();
+
+  const applyRbac = (nodes: NestedMenuItem[]): NestedMenuItem[] =>
+    nodes.map(n => {
+      const key = rbacKeys?.[n.href];
+      const allowed = key ? permissions[role][key] : true;
+      const unlocked = key ? locks[key] : true;
+      const children = n.children ? applyRbac(n.children) : undefined;
+      return {
+        ...n,
+        hidden: n.hidden || !allowed,
+        disabled: n.disabled || !unlocked,
+        children,
+      };
+    });
+
+  let tree: NestedMenuItem[] = useAuto ? (mergeMenu(preset) as NestedMenuItem[]) : menuItems;
+  tree = applyRbac(tree);
+
+  if (useAuto && preset.rootHidden) return null;
 
   return (
-    <aside className="w-64 shrink-0 border-r"
-           style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
+    <aside className="w-64 shrink-0 border-r" style={{ background: 'var(--panel)', borderColor: 'var(--border)' }}>
       <div className="p-3 text-xs uppercase tracking-wide text-[color:var(--muted)]">Menu</div>
       <ul className="px-2 pb-4 space-y-1">
         {tree.map((n) => <NodeView key={n.id} n={n} />)}


### PR DESCRIPTION
## Summary
- add scanRoutes utility to crawl app routes into NestedMenuItem tree
- add MenuEditor component for editing sidebar menus
- extend Sidebar to support auto/manual menus with RBAC filtering

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9dd7f8508832cbd6dc24c603f5110