### PR TITLE
feat: add page template wizard and saving

### DIFF
--- a/src/lib/pageTemplates.ts
+++ b/src/lib/pageTemplates.ts
@@ -1,0 +1,59 @@
+import type { BuilderNode } from '../schemas/page'
+
+export interface PageTemplate {
+  id: string
+  name: string
+  layoutId: string
+  nodes: BuilderNode[]
+  notes?: string
+}
+
+const KEY = 'page-templates-v1'
+
+const uid = () => Math.random().toString(36).slice(2, 9)
+
+function loadTemplates(): PageTemplate[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as PageTemplate[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveTemplates(arr: PageTemplate[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(arr))
+  } catch {}
+}
+
+export function getTemplates(): PageTemplate[] {
+  return loadTemplates()
+}
+
+export function saveTemplate(t: Omit<PageTemplate, 'id'> & { id?: string }): string {
+  const arr = loadTemplates()
+  const id = t.id ?? uid()
+  const tpl: PageTemplate = { id, ...t }
+  const idx = arr.findIndex((x) => x.id === id)
+  const next = idx >= 0 ? arr.map((x) => (x.id === id ? tpl : x)) : [...arr, tpl]
+  saveTemplates(next)
+  return id
+}
+
+export function deleteTemplate(id: string) {
+  const next = loadTemplates().filter((t) => t.id !== id)
+  saveTemplates(next)
+}
+
+export function exportTemplates(): string {
+  return JSON.stringify(loadTemplates(), null, 2)
+}
+
+export function importTemplates(json: string) {
+  try {
+    const arr = JSON.parse(json)
+    if (Array.isArray(arr)) saveTemplates(arr as PageTemplate[])
+  } catch {}
+}

--- a/web/app/builder/pages/new/page.tsx
+++ b/web/app/builder/pages/new/page.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { usePageStore } from '@/store/pageStore'
+import type { PageTemplate } from '../../../../../src/lib/pageTemplates'
+import { getTemplates, importTemplates, exportTemplates } from '../../../../../src/lib/pageTemplates'
+
+export default function NewPageWizard() {
+  const router = useRouter()
+  const addPage = usePageStore((s) => s.addPage)
+  const [templates, setTemplates] = React.useState<PageTemplate[]>([])
+  const [selected, setSelected] = React.useState<PageTemplate | null>(null)
+  const [title, setTitle] = React.useState('')
+  const [path, setPath] = React.useState('/')
+
+  React.useEffect(() => {
+    setTemplates(getTemplates())
+  }, [])
+
+  const onCreate = React.useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      const id = addPage({ title: title || 'New Page', path: (path || '/new-page') as any, tree: selected?.nodes ?? [] })
+      router.push(`/builder/pages/${id}/edit`)
+    },
+    [addPage, title, path, selected, router],
+  )
+
+  const onImport = React.useCallback(() => {
+    const json = window.prompt('Paste templates JSON')
+    if (json) {
+      importTemplates(json)
+      setTemplates(getTemplates())
+    }
+  }, [])
+
+  const onExport = React.useCallback(() => {
+    const json = exportTemplates()
+    void navigator.clipboard.writeText(json)
+    window.alert('Templates copied to clipboard')
+  }, [])
+
+  if (!selected) {
+    return (
+      <div className="p-6 space-y-4">
+        <h1 className="text-xl font-bold">Select Page Template</h1>
+        <div className="flex flex-wrap gap-2">
+          {templates.map((t) => (
+            <button
+              key={t.id}
+              className="px-3 py-1 border rounded hover:bg-zinc-800"
+              onClick={() => setSelected(t)}
+            >
+              {t.name}
+            </button>
+          ))}
+          <button
+            className="px-3 py-1 border rounded hover:bg-zinc-800"
+            onClick={() => setSelected({ id: '', name: 'Blank', layoutId: '', nodes: [] })}
+          >
+            Blank
+          </button>
+        </div>
+        <div className="flex gap-2">
+          <button className="px-2 py-1 border rounded" onClick={onImport}>
+            Import
+          </button>
+          <button className="px-2 py-1 border rounded" onClick={onExport}>
+            Export
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-bold">New Page</h1>
+      <form onSubmit={onCreate} className="space-y-2 max-w-xs">
+        <div>
+          <label className="block text-sm">Title</label>
+          <input
+            className="w-full px-2 py-1 border rounded bg-transparent"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Path</label>
+          <input
+            className="w-full px-2 py-1 border rounded bg-transparent"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+          />
+        </div>
+        <button type="submit" className="px-3 py-1 border rounded">
+          Create
+        </button>
+        <button type="button" className="px-3 py-1 border rounded ml-2" onClick={() => setSelected(null)}>
+          Back
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/web/components/hud/BuilderHUD.tsx
+++ b/web/components/hud/BuilderHUD.tsx
@@ -2,6 +2,9 @@
 import React from 'react'
 import { useHudStore, type DeviceKind } from '@/store/hudStore'
 import { useUIStore } from '@/store/uiStore'
+import { usePageStore } from '@/store/pageStore'
+import { toast } from '@/lib/toast'
+import { saveTemplate } from '../../../src/lib/pageTemplates'
 
 function IconBtn(props: React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean }) {
   const { active, className, ...rest } = props
@@ -34,6 +37,14 @@ export function BuilderHUD() {
     toggleSnap,
   } = useHudStore()
   const { showRulers, toggleRulers } = useUIStore()
+
+  const saveAsTemplate = React.useCallback(() => {
+    const name = window.prompt('Template name?')
+    if (!name) return
+    const nodes = usePageStore.getState().getTree()
+    saveTemplate({ name, layoutId: 'default', nodes })
+    toast.success('Template saved')
+  }, [])
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -78,6 +89,7 @@ export function BuilderHUD() {
         <IconBtn active={showRulers} onClick={toggleRulers} title="Rulers (R)">Rul</IconBtn>
         <IconBtn active={showOutline} onClick={toggleOutline} title="Outline (O)">Out</IconBtn>
         <IconBtn active={snapToPixel} onClick={toggleSnap} title="Snap (P)">Snap</IconBtn>
+        <IconBtn onClick={saveAsTemplate} title="Save as Template">SaveTpl</IconBtn>
         <div className="mx-1 w-px h-6 bg-zinc-800" />
         <DeviceBtn d="free" label="Free" />
         <DeviceBtn d="desktop" label="Desktop" />


### PR DESCRIPTION
## Summary
- add localStorage-backed pageTemplates util
- create new page wizard for template selection and import/export
- allow saving current page as template from HUD

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9dd973238832c925fcb007371a051