### PR TITLE
feat: enable multi-select grouping and locking

### DIFF
--- a/src/features/uibuilder/editor/Canvas.tsx
+++ b/src/features/uibuilder/editor/Canvas.tsx
@@ -15,20 +15,32 @@ function buildClass(node: EditorNode): string {
 
 const RenderNode: React.FC<{ node: EditorNode }> = ({ node }) => {
   const select = useEditorStore((s) => s.select);
-  const selectedId = useEditorStore((s) => s.selectedId);
-  const Tag = getComponentById(node.type) || (node.type as any) || 'div';
+  const addSelect = useEditorStore((s) => s.addSelect);
+  const toggleSelect = useEditorStore((s) => s.toggleSelect);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
+  const Tag =
+    node.type === 'group'
+      ? 'div'
+      : getComponentById(node.type) || (node.type as any) || 'div';
+  const isSelected = selectedIds.includes(node.id);
   return (
     <Tag
-      className={`${buildClass(node)} ${selectedId === node.id ? 'outline outline-blue-500' : ''}`}
+      className={`${buildClass(node)} ${
+        isSelected ? 'outline outline-blue-500' : ''
+      } ${node.locked ? 'opacity-60' : ''}`}
       data-node-id={node.id}
       data-node-type={node.type}
       data-node-name={node.props?.name}
+      data-node-locked={node.locked ? 'true' : 'false'}
       onClick={(e: React.MouseEvent) => {
         e.stopPropagation();
-        select(node.id);
+        if (node.locked) return;
+        if (e.shiftKey) addSelect(node.id);
+        else if (e.metaKey || e.ctrlKey) toggleSelect(node.id);
+        else select([node.id]);
       }}
     >
-      {node.props.text}
+      {node.type !== 'group' && node.props.text}
       {node.children.map((c) => (
         <RenderNode key={c.id} node={c} />
       ))}
@@ -38,13 +50,81 @@ const RenderNode: React.FC<{ node: EditorNode }> = ({ node }) => {
 
 export const Canvas: React.FC = () => {
   const root = useEditorStore((s) => s.root);
+  const select = useEditorStore((s) => s.select);
+  const addSelect = useEditorStore((s) => s.addSelect);
   const { setNodeRef } = useDroppable({ id: 'canvas' });
+  const [marquee, setMarquee] = React.useState<{
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  } | null>(null);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    const origin = { x: e.clientX, y: e.clientY };
+    if (!e.shiftKey) select([]);
+    const move = (ev: PointerEvent) => {
+      setMarquee({
+        x: Math.min(origin.x, ev.clientX),
+        y: Math.min(origin.y, ev.clientY),
+        w: Math.abs(ev.clientX - origin.x),
+        h: Math.abs(ev.clientY - origin.y),
+      });
+    };
+    const up = (ev: PointerEvent) => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      setMarquee(null);
+      const rect = {
+        x: Math.min(origin.x, ev.clientX),
+        y: Math.min(origin.y, ev.clientY),
+        w: Math.abs(ev.clientX - origin.x),
+        h: Math.abs(ev.clientY - origin.y),
+      };
+      const els = Array.from(
+        e.currentTarget.querySelectorAll<HTMLElement>('[data-node-id]')
+      );
+      const ids = els
+        .filter((el) => {
+          const r = el.getBoundingClientRect();
+          const locked = el.dataset.nodeLocked === 'true';
+          return (
+            !locked &&
+            r.left >= rect.x &&
+            r.right <= rect.x + rect.w &&
+            r.top >= rect.y &&
+            r.bottom <= rect.y + rect.h
+          );
+        })
+        .map((el) => el.dataset.nodeId!);
+      ids.forEach((id) => addSelect(id));
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
   return (
-    <div ref={setNodeRef} className="h-full overflow-auto p-4">
+    <div
+      ref={setNodeRef}
+      className="h-full overflow-auto p-4 relative"
+      onPointerDown={onPointerDown}
+    >
       {root.children.length ? (
         root.children.map((c) => <RenderNode key={c.id} node={c} />)
       ) : (
         <div className="text-gray-400">Drop components here</div>
+      )}
+      {marquee && (
+        <div
+          className="absolute border border-blue-400 bg-blue-200/20 pointer-events-none"
+          style={{
+            left: marquee.x,
+            top: marquee.y,
+            width: marquee.w,
+            height: marquee.h,
+          }}
+        />
       )}
     </div>
   );

--- a/src/features/uibuilder/editor/ContextMenu.tsx
+++ b/src/features/uibuilder/editor/ContextMenu.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { useEditorStore, EditorNode } from './useEditorStore';
+
+function findNode(node: EditorNode, id: string): EditorNode | null {
+  if (node.id === id) return node;
+  for (const child of node.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+export const ContextMenu: React.FC = () => {
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
+  const root = useEditorStore((s) => s.root);
+  const groupSelected = useEditorStore((s) => s.groupSelected);
+  const ungroup = useEditorStore((s) => s.ungroup);
+  const setLocked = useEditorStore((s) => s.setLocked);
+
+  const selectedNodes = selectedIds.map((id) => findNode(root, id)).filter(Boolean) as EditorNode[];
+  const allLocked = selectedNodes.every((n) => n.locked);
+  const singleGroup =
+    selectedNodes.length === 1 && selectedNodes[0].type === 'group';
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      e.preventDefault();
+      setPos({ x: e.clientX, y: e.clientY });
+    };
+    const close = () => setPos(null);
+    window.addEventListener('contextmenu', handler);
+    window.addEventListener('click', close);
+    return () => {
+      window.removeEventListener('contextmenu', handler);
+      window.removeEventListener('click', close);
+    };
+  }, []);
+
+  if (!pos) return null;
+
+  return (
+    <ul
+      className="fixed bg-gray-800 text-white text-sm rounded shadow z-50"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      {selectedIds.length >= 2 && (
+        <li
+          className="px-4 py-2 hover:bg-gray-700 cursor-pointer"
+          onClick={() => {
+            groupSelected();
+            setPos(null);
+          }}
+        >
+          Group
+        </li>
+      )}
+      {singleGroup && (
+        <li
+          className="px-4 py-2 hover:bg-gray-700 cursor-pointer"
+          onClick={() => {
+            ungroup(selectedIds[0]);
+            setPos(null);
+          }}
+        >
+          Ungroup
+        </li>
+      )}
+      {selectedIds.length > 0 && (
+        <li
+          className="px-4 py-2 hover:bg-gray-700 cursor-pointer"
+          onClick={() => {
+            setLocked(selectedIds, !allLocked);
+            setPos(null);
+          }}
+        >
+          {allLocked ? 'Unlock' : 'Lock'}
+        </li>
+      )}
+    </ul>
+  );
+};

--- a/src/features/uibuilder/editor/EditorShell.tsx
+++ b/src/features/uibuilder/editor/EditorShell.tsx
@@ -9,6 +9,7 @@ import { ComponentLibrary } from './ComponentLibrary';
 import { Canvas } from './Canvas';
 import { PropertyPanel } from './PropertyPanel';
 import { useEditorStore } from './useEditorStore';
+import { ContextMenu } from './ContextMenu';
 import { templates } from './templates';
 import './registerComponents';
 
@@ -17,6 +18,27 @@ export const EditorShell: React.FC = () => {
   const undo = useEditorStore((s) => s.undo);
   const redo = useEditorStore((s) => s.redo);
   const applyTemplate = useEditorStore((s) => s.applyTemplate);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
+  const root = useEditorStore((s) => s.root);
+  const groupSelected = useEditorStore((s) => s.groupSelected);
+  const ungroup = useEditorStore((s) => s.ungroup);
+  const setLocked = useEditorStore((s) => s.setLocked);
+
+  const findNode = React.useCallback((node: any, id: string): any => {
+    if (node.id === id) return node;
+    for (const c of node.children || []) {
+      const f = findNode(c, id);
+      if (f) return f;
+    }
+    return null;
+  }, []);
+  const selectedNodes = selectedIds
+    .map((id) => findNode(root, id))
+    .filter(Boolean);
+  const canUngroup =
+    selectedNodes.length === 1 && selectedNodes[0].type === 'group';
+  const allLocked =
+    selectedNodes.length > 0 && selectedNodes.every((n: any) => n.locked);
 
   const sensors = useSensors(useSensor(PointerSensor));
 
@@ -42,6 +64,34 @@ export const EditorShell: React.FC = () => {
         <button className="px-2 py-1 border rounded" onClick={redo}>
           Redo
         </button>
+        <button
+          className="px-2 py-1 border rounded"
+          disabled={selectedIds.length < 2}
+          onClick={groupSelected}
+        >
+          Group
+        </button>
+        <button
+          className="px-2 py-1 border rounded"
+          disabled={!canUngroup}
+          onClick={() => ungroup(selectedIds[0])}
+        >
+          Ungroup
+        </button>
+        <button
+          className="px-2 py-1 border rounded"
+          disabled={selectedIds.length === 0 || allLocked}
+          onClick={() => setLocked(selectedIds, true)}
+        >
+          Lock
+        </button>
+        <button
+          className="px-2 py-1 border rounded"
+          disabled={selectedIds.length === 0 || !allLocked}
+          onClick={() => setLocked(selectedIds, false)}
+        >
+          Unlock
+        </button>
         {Object.entries(templates).map(([name, tmpl]) => (
           <button
             key={name}
@@ -52,6 +102,7 @@ export const EditorShell: React.FC = () => {
           </button>
         ))}
       </div>
+      <ContextMenu />
     </DndContext>
   );
 };

--- a/src/features/uibuilder/editor/PropertyPanel.tsx
+++ b/src/features/uibuilder/editor/PropertyPanel.tsx
@@ -11,9 +11,11 @@ function findNode(root: EditorNode, id: string): EditorNode | null {
 }
 
 export const PropertyPanel: React.FC = () => {
-  const selectedId = useEditorStore((s) => s.selectedId);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
   const root = useEditorStore((s) => s.root);
-  const node = useMemo(() => (selectedId ? findNode(root, selectedId) : null), [root, selectedId]);
+  const node = useMemo(() =>
+    selectedIds.length === 1 ? findNode(root, selectedIds[0]) : null,
+  [root, selectedIds]);
   const updateProps = useEditorStore((s) => s.updateProps);
   const updateVariant = useEditorStore((s) => s.updateVariant);
   const [tab, setTab] = useState<'default' | 'hover'>('default');

--- a/src/features/uibuilder/editor/useEditorStore.ts
+++ b/src/features/uibuilder/editor/useEditorStore.ts
@@ -11,6 +11,7 @@ export interface EditorNode {
     [key: string]: any;
   };
   children: EditorNode[];
+  locked?: boolean;
 }
 
 const createNode = (type: string, overrides: Partial<EditorNode> = {}): EditorNode => ({
@@ -45,14 +46,19 @@ function updateNode(node: EditorNode, id: string, updater: (n: EditorNode) => vo
 
 export interface EditorState {
   root: EditorNode;
-  selectedId: string | null;
+  selectedIds: string[];
   history: EditorNode[];
   future: EditorNode[];
-  select: (id: string | null) => void;
+  select: (ids: string[] | null) => void;
+  addSelect: (id: string) => void;
+  toggleSelect: (id: string) => void;
+  groupSelected: () => void;
+  ungroup: (id: string) => void;
+  setLocked: (ids: string[], locked: boolean) => void;
+  removeSelected: () => void;
   addNode: (type: string, parentId?: string) => void;
   updateProps: (id: string, props: Partial<EditorNode['props']>) => void;
   updateVariant: (id: string, variant: string, className: string) => void;
-  removeNode: (id: string) => void;
   applyTemplate: (root: EditorNode) => void;
   undo: () => void;
   redo: () => void;
@@ -65,10 +71,106 @@ const pushHistory = (history: EditorNode[], node: EditorNode): EditorNode[] => {
 
 export const useEditorStore = create<EditorState>((set, get) => ({
   root: createNode('div', { id: 'root' }),
-  selectedId: null,
+  selectedIds: [],
   history: [],
   future: [],
-  select: (id) => set({ selectedId: id }),
+  select: (ids) => set({ selectedIds: ids ? [...ids] : [] }),
+  addSelect: (id) =>
+    set((s) => ({
+      selectedIds: s.selectedIds.includes(id)
+        ? s.selectedIds
+        : [...s.selectedIds, id],
+    })),
+  toggleSelect: (id) =>
+    set((s) => ({
+      selectedIds: s.selectedIds.includes(id)
+        ? s.selectedIds.filter((x) => x !== id)
+        : [...s.selectedIds, id],
+    })),
+  groupSelected: () =>
+    set((state) => {
+      if (state.selectedIds.length < 2) return state;
+      const root = cloneTree(state.root);
+      const ids = state.selectedIds;
+      const findParent = (node: EditorNode, childId: string): EditorNode | null => {
+        for (const child of node.children) {
+          if (child.id === childId) return node;
+          const res = findParent(child, childId);
+          if (res) return res;
+        }
+        return null;
+      };
+      const parent = findParent(root, ids[0]);
+      if (!parent) return state;
+      if (!ids.every((id) => findParent(root, id) === parent)) return state;
+      const group: EditorNode = {
+        id: `group-${Math.random().toString(36).slice(2, 9)}`,
+        type: 'group',
+        props: {},
+        children: [],
+      };
+      parent.children = parent.children.reduce<EditorNode[]>((arr, c) => {
+        if (ids.includes(c.id)) {
+          group.children.push(c);
+        } else {
+          arr.push(c);
+        }
+        return arr;
+      }, []);
+      parent.children.push(group);
+      return {
+        root,
+        selectedIds: [group.id],
+        history: pushHistory(state.history, state.root),
+        future: [],
+      };
+    }),
+  ungroup: (id) =>
+    set((state) => {
+      const root = cloneTree(state.root);
+      const ungroupRec = (node: EditorNode): boolean => {
+        const idx = node.children.findIndex((c) => c.id === id && c.type === 'group');
+        if (idx >= 0) {
+          const grp = node.children[idx];
+          node.children.splice(idx, 1, ...grp.children);
+          return true;
+        }
+        return node.children.some((c) => ungroupRec(c));
+      };
+      if (!ungroupRec(root)) return state;
+      return {
+        root,
+        selectedIds: [],
+        history: pushHistory(state.history, state.root),
+        future: [],
+      };
+    }),
+  setLocked: (ids, locked) =>
+    set((state) => {
+      const root = cloneTree(state.root);
+      ids.forEach((id) => updateNode(root, id, (n) => (n.locked = locked)));
+      return {
+        root,
+        history: pushHistory(state.history, state.root),
+        future: [],
+      };
+    }),
+  removeSelected: () =>
+    set((state) => {
+      if (!state.selectedIds.length) return state;
+      const root = cloneTree(state.root);
+      const remove = (node: EditorNode) => {
+        node.children = node.children.filter((c) => !state.selectedIds.includes(c.id));
+        node.children.forEach(remove);
+      };
+      remove(root);
+      return {
+        root,
+        selectedIds: [],
+        history: pushHistory(state.history, state.root),
+        future: [],
+      };
+    }),
   addNode: (type, parentId = 'root') =>
     set((state) => {
       const root = cloneTree(state.root);
@@ -98,22 +200,12 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       });
       return { root, history: pushHistory(state.history, state.root), future: [] };
     }),
-  removeNode: (id) =>
-    set((state) => {
-      const root = cloneTree(state.root);
-      const remove = (parent: EditorNode) => {
-        parent.children = parent.children.filter((c) => c.id !== id);
-        parent.children.forEach(remove);
-      };
-      remove(root);
-      return { root, history: pushHistory(state.history, state.root), future: [] };
-    }),
   applyTemplate: (root) =>
     set((state) => ({
       root: cloneTree(root),
       history: pushHistory(state.history, state.root),
       future: [],
-      selectedId: null,
+      selectedIds: [],
     })),
   undo: () =>
     set((state) => {


### PR DESCRIPTION
## Summary
- add selection store with support for multiple selections, grouping, locking, and ungrouping
- render group nodes and handle shift-click & marquee selection in the canvas
- provide toolbar buttons and context menu to group, ungroup, lock and unlock nodes

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ddb09cc4832c8fc6b60d7febe1b9