### PR TITLE
feat: add static export and error recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "codemod:href": "jscodeshift -t codemods/fix-next-dynamic-href.ts web",
     "routes:gen": "ts-node --project tsconfig.json scripts/gen_route_helpers.ts",
     "routes:check": "ts-node --project tsconfig.json scripts/check_dynamic_hrefs.ts",
-    "prebuild": "pnpm routes:gen && pnpm routes:check"
+    "prebuild": "pnpm routes:gen && pnpm routes:check",
+    "export:pages": "ts-node scripts/export-pages.ts"
   },
   "bin": {
     "json2tsx": "./scripts/json2tsx.js"

--- a/scripts/export-pages.ts
+++ b/scripts/export-pages.ts
@@ -1,0 +1,46 @@
+import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+
+async function main() {
+  const snapshotsDir = path.join(process.cwd(), 'snapshots');
+  const outDir = path.join(process.cwd(), 'out', 'pages');
+  await mkdir(outDir, { recursive: true });
+  let pageIds: string[] = [];
+  try {
+    pageIds = await readdir(snapshotsDir);
+  } catch {
+    console.warn('no snapshots directory');
+    return;
+  }
+  for (const pageId of pageIds) {
+    const pageDir = path.join(snapshotsDir, pageId);
+    let files: string[] = [];
+    try {
+      files = await readdir(pageDir);
+    } catch {
+      continue;
+    }
+    const timestamps = files
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => parseInt(f.replace(/\.json$/, ''), 10))
+      .filter((n) => !isNaN(n))
+      .sort((a, b) => b - a);
+    if (timestamps.length === 0) continue;
+    const latestFile = path.join(pageDir, `${timestamps[0]}.json`);
+    try {
+      const text = await readFile(latestFile, 'utf8');
+      const data = JSON.parse(text);
+      const snapshot = data.snapshot ?? data;
+      const outFile = path.join(outDir, `${pageId}.json`);
+      await writeFile(outFile, JSON.stringify(snapshot, null, 2), 'utf8');
+      console.log(`exported ${pageId}`);
+    } catch (err) {
+      console.error(`failed to export ${pageId}`, err);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/system/ErrorBoundary.tsx
+++ b/src/components/system/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { RecoveryModal } from './RecoveryModal';
+
+interface Props {
+  onDisable?: () => void;
+  onRollback?: () => void;
+  children: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    if (typeof window !== 'undefined') {
+      const logs = (window as any).__DEV_LOGS__ || ((window as any).__DEV_LOGS__ = []);
+      logs.push({ message: error.message, stack: error.stack, info, time: Date.now() });
+    }
+  }
+
+  handleReload = () => {
+    if (typeof window !== 'undefined') window.location.reload();
+  };
+
+  handleDisable = () => {
+    this.setState({ error: null });
+    this.props.onDisable?.();
+  };
+
+  handleRollback = () => {
+    this.setState({ error: null });
+    this.props.onRollback?.();
+  };
+
+  render() {
+    if (this.state.error) {
+      return (
+        <RecoveryModal
+          onReload={this.handleReload}
+          onDisable={this.handleDisable}
+          onRollback={this.handleRollback}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/system/RecoveryModal.tsx
+++ b/src/components/system/RecoveryModal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface Props {
+  onReload: () => void;
+  onDisable: () => void;
+  onRollback: () => void;
+}
+
+export const RecoveryModal: React.FC<Props> = ({ onReload, onDisable, onRollback }) => {
+  return (
+    <div role="dialog" style={{ padding: 16, border: '1px solid #f00', background: '#fff' }}>
+      <p>Something went wrong.</p>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={onDisable}>Disable and continue</button>
+        <button onClick={onRollback}>Restore snapshot</button>
+        <button onClick={onReload}>Reload</button>
+      </div>
+    </div>
+  );
+};

--- a/src/runtime/hydratePage.tsx
+++ b/src/runtime/hydratePage.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export interface BuilderNode {
+  id: string;
+  type: string;
+  props?: Record<string, any>;
+  children?: BuilderNode[];
+}
+
+export interface ThemeTokens {
+  [key: string]: any;
+}
+
+export interface PageSnapshot {
+  version: number;
+  pageId: string;
+  layoutId: string;
+  effectiveTheme: ThemeTokens;
+  nodes: BuilderNode[];
+  timestamp: number;
+}
+
+export type ComponentRegistry = Record<string, React.ComponentType<any>>;
+
+function applyTheme(theme: ThemeTokens, el: HTMLElement) {
+  const vars: Record<string, string> = {};
+  const { colors = {}, radius = {}, spacing = {}, typography = {} } = theme as any;
+  Object.entries(colors).forEach(([k, v]) => (vars[`--color-${k}`] = String(v)));
+  Object.entries(radius).forEach(([k, v]) => (vars[`--radius-${k}`] = String(v)));
+  Object.entries(spacing).forEach(([k, v]) => (vars[`--space-${k}`] = String(v)));
+  if (typography.fontFamily) vars['--font-family'] = typography.fontFamily;
+  if (typography.baseSize) vars['--font-size-base'] = typography.baseSize;
+  if (typography.headingScale) vars['--heading-scale'] = String(typography.headingScale);
+  if (typography.weightRegular) vars['--font-weight-regular'] = String(typography.weightRegular);
+  if (typography.weightBold) vars['--font-weight-bold'] = String(typography.weightBold);
+  for (const [key, value] of Object.entries(vars)) {
+    el.style.setProperty(key, value);
+  }
+}
+
+function renderNode(node: BuilderNode, registry: ComponentRegistry): React.ReactNode {
+  const Comp = registry[node.type];
+  if (!Comp) return null;
+  const children = node.children?.map((c) => renderNode(c, registry));
+  return React.createElement(Comp, { key: node.id, ...(node.props || {}) }, children);
+}
+
+export function hydratePage(snapshot: PageSnapshot, registry: ComponentRegistry): React.ReactElement {
+  if (typeof document !== 'undefined') {
+    applyTheme(snapshot.effectiveTheme, document.documentElement);
+  }
+  return <>{snapshot.nodes.map((n) => renderNode(n, registry))}</>;
+}

--- a/static-preview/index.html
+++ b/static-preview/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Static Preview</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module">
+    import React from 'https://esm.sh/react@18';
+    import ReactDOM from 'https://esm.sh/react-dom@18/client';
+    import { hydratePage } from '../src/runtime/hydratePage.tsx';
+    import registry from './registry.js';
+    fetch('./page.json').then(r => r.json()).then(snapshot => {
+      const el = hydratePage(snapshot, registry);
+      ReactDOM.createRoot(document.getElementById('root')!).render(el);
+    });
+  </script>
+</body>
+</html>

--- a/static-preview/page.json
+++ b/static-preview/page.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "pageId": "sample",
+  "layoutId": "sample",
+  "effectiveTheme": {
+    "colors": { "text": "#000", "background": "#fff" },
+    "radius": {},
+    "spacing": {},
+    "typography": {
+      "fontFamily": "sans-serif",
+      "baseSize": "16px",
+      "headingScale": 1.2,
+      "weightRegular": "400",
+      "weightBold": "700"
+    }
+  },
+  "nodes": [
+    {
+      "id": "n1",
+      "type": "Box",
+      "props": { "style": { "padding": "20px" } },
+      "children": [
+        { "id": "n2", "type": "Text", "props": { "children": "Hello static preview!" } }
+      ]
+    }
+  ],
+  "timestamp": 0
+}

--- a/static-preview/registry.js
+++ b/static-preview/registry.js
@@ -1,0 +1,6 @@
+import React from 'https://esm.sh/react@18';
+
+export default {
+  Box: (props) => React.createElement('div', { style: { padding: '8px', border: '1px solid #ccc', ...(props.style || {}) } }, props.children),
+  Text: (props) => React.createElement('span', props, props.children)
+};

--- a/web/app/dev/logs/page.tsx
+++ b/web/app/dev/logs/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+export default function LogsPage() {
+  const [logs, setLogs] = React.useState<any[]>([]);
+  React.useEffect(() => {
+    const l = (window as any).__DEV_LOGS__ || [];
+    setLogs(l);
+  }, []);
+  return (
+    <div style={{ padding: 16 }}>
+      <h1>/dev/logs</h1>
+      {logs.length === 0 ? (
+        <p>No logs</p>
+      ) : (
+        <ul>
+          {logs.map((log, idx) => (
+            <li key={idx} style={{ marginBottom: 8 }}>
+              <pre>{log.message}</pre>
+              {log.stack && <pre>{log.stack}</pre>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- export latest page snapshots to `/out/pages` via `npm run export:pages`
- add lightweight client runtime for hydrating snapshots
- introduce error boundary with recovery modal and dev log viewer

## Testing
- `npm test`
- `npm run export:pages`


------
https://chatgpt.com/codex/tasks/task_e_68b9ddbfc268832c8d92a0aaa5b17fe4