### PR TITLE
feat: add basic i18n support

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "hero.title": "Hello",
+  "hero.subtitle": "Sample subtitle"
+}

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,4 @@
+{
+  "hero.title": "こんにちは",
+  "hero.subtitle": "サンプルサブタイトル"
+}

--- a/src/AutoPropsEditor.tsx
+++ b/src/AutoPropsEditor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useDataSources } from './dataSources';
 import { PropBinding, useEditorState, useEditorActions } from './store';
 import { library as componentMeta } from '../lib/registry';
+import { t, generateKey, registerKey, getLanguage } from './lib/i18n';
 
 interface PropMeta {
   name: string;
@@ -210,7 +211,44 @@ const AutoPropsEditor: React.FC<AutoPropsEditorProps> = ({
       );
     }
 
-    // default: text input with Bind
+    const textual = ['text', 'label', 'title', 'placeholder'].some((s) =>
+      prop.name.toLowerCase().includes(s)
+    );
+    if (textual) {
+      const isI18n = value && typeof value === 'object' && typeof value.key === 'string';
+      const textVal = isI18n ? t(value.key) : value ?? '';
+      return (
+        <div className="flex space-x-1">
+          <input
+            type="text"
+            className={`${common} flex-1`}
+            value={textVal}
+            onChange={(e) => {
+              const txt = e.target.value;
+              if (!txt) {
+                updateProp(prop.name, undefined);
+                return;
+              }
+              if (isI18n) {
+                registerKey(getLanguage(), value.key, txt);
+                updateProp(prop.name, { key: value.key });
+              } else {
+                const key = generateKey(txt);
+                registerKey(getLanguage(), key, txt);
+                updateProp(prop.name, { key });
+              }
+            }}
+          />
+          <button
+            className="text-xs text-blue-600"
+            onClick={() => updateBinding(prop.name, { source: '', endpoint: '', path: '' })}
+          >
+            Bind
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="flex space-x-1">
         <input

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   DndContext,
   DragEndEvent,
@@ -19,6 +19,7 @@ import {
   useEditorActions,
   ComponentNode,
 } from './store';
+import { t, setLanguage } from './lib/i18n';
 
 function NodeView({ node, path }: { node: ComponentNode; path: number[] }) {
   const actions = useEditorActions();
@@ -52,10 +53,17 @@ function NodeView({ node, path }: { node: ComponentNode; path: number[] }) {
     <NodeView key={c.id} node={c} path={[...path, i]} />
   ));
 
+  const translatedProps: Record<string, any> = { ...(node.props || {}) };
+  for (const [k, v] of Object.entries(translatedProps)) {
+    if (v && typeof v === 'object' && typeof (v as any).key === 'string') {
+      translatedProps[k] = t((v as any).key);
+    }
+  }
+
   const content = React.createElement(
     node.type as any,
     {
-      ...(node.props || {}),
+      ...translatedProps,
       onClick: (e: React.MouseEvent) => {
         e.stopPropagation();
         actions.selectComponent(node.id);
@@ -85,6 +93,11 @@ const Canvas: React.FC = () => {
   const { tree, hoverPreview } = useEditorState();
   const actions = useEditorActions();
   const sensors = useSensors(useSensor(PointerSensor));
+  const [lang, setLang] = useState<'ja' | 'en'>('ja');
+
+  useEffect(() => {
+    setLanguage(lang);
+  }, [lang]);
 
   const rootDrop = useDroppable({
     id: 'c-root',
@@ -122,6 +135,14 @@ const Canvas: React.FC = () => {
             onChange={(e) => actions.setHoverPreview(e.target.checked)}
           />
           <span className="text-sm">Hover preview</span>
+          <select
+            className="border px-2 py-1 text-sm"
+            value={lang}
+            onChange={(e) => setLang(e.target.value as 'ja' | 'en')}
+          >
+            <option value="ja">ja</option>
+            <option value="en">en</option>
+          </select>
         </div>
 
         {/* キャンバス */}

--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -5,6 +5,7 @@ import { ComponentNode, PropBinding } from './store';
 import { useDataSources, DataSource } from './dataSources';
 import { NodeWrapper } from '@/components/shared/NodeWrapper';
 import { getByKey } from '../lib/registry';
+import { t } from './lib/i18n';
 
 function getByPath(obj: any, path: string) {
   if (!path || !path.startsWith('$.')) return undefined;
@@ -76,6 +77,12 @@ const NodeRenderer: React.FC<NodeRendererProps> = ({ node, previewHover }) => {
         const val = dataMap[prop];
         props[prop] = val !== undefined ? val : binding.fallback ?? '';
       }
+    }
+  }
+
+  for (const [k, v] of Object.entries(props)) {
+    if (v && typeof v === 'object' && typeof (v as any).key === 'string') {
+      props[k] = t((v as any).key);
     }
   }
 

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,0 +1,39 @@
+let currentLang = 'ja';
+const dictionaries: Record<string, Record<string, string>> = {};
+const listeners = new Set<() => void>();
+
+export async function setLanguage(lang: string) {
+  currentLang = lang;
+  if (!dictionaries[lang]) {
+    const res = await fetch(`/locales/${lang}.json`);
+    dictionaries[lang] = await res.json();
+  }
+  listeners.forEach((l) => l());
+}
+
+export function t(key: string): string {
+  const dict = dictionaries[currentLang] || {};
+  return dict[key] ?? key;
+}
+
+export function getLanguage() {
+  return currentLang;
+}
+
+export function registerKey(lang: string, key: string, value: string) {
+  if (!dictionaries[lang]) dictionaries[lang] = {};
+  dictionaries[lang][key] = value;
+}
+
+export function generateKey(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '.')
+    .replace(/^\.|\.$/g, '');
+}
+
+export function subscribe(fn: () => void) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}


### PR DESCRIPTION
## Summary
- add simple i18n module and locale files
- translate node props and allow switching preview language
- auto-generate i18n keys when editing text props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ddc7879c832ca09ad8a4b61b2235