### PR TITLE
feat: add builder layout store

### DIFF
--- a/web/app/builder/layout/page.tsx
+++ b/web/app/builder/layout/page.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { DndContext, useDraggable, useDroppable, DragEndEvent } from '@dnd-kit/core';
 import { NodeWrapper } from '@/components/shared/NodeWrapper';
-import { useBuilderLayoutStore, type BuilderLayout } from '@/stores/builderLayout';
+import { useBuilderLayout, type BuilderLayout } from '@/stores/builderLayout';
 
 const PANELS = ['palette', 'inspector', 'toolbar', 'canvas'] as const;
 const ZONES = ['top', 'left', 'center', 'right', 'bottom'] as const;
@@ -44,8 +44,8 @@ function DropZone({ id, children }: { id: Zone; children?: React.ReactNode }) {
 }
 
 export default function LayoutEditorPage() {
-  const { builderLayout, setBuilderLayout } = useBuilderLayoutStore();
-  const [draft, setDraft] = useState<BuilderLayout>(builderLayout);
+  const { layout, setLayout } = useBuilderLayout();
+  const [draft, setDraft] = useState<BuilderLayout>(layout);
 
   const handleDragEnd = (e: DragEndEvent) => {
     const { active, over } = e;
@@ -92,7 +92,7 @@ export default function LayoutEditorPage() {
       </DndContext>
       <div className="flex gap-2">
         <button
-          onClick={() => setBuilderLayout(draft)}
+          onClick={() => setLayout(draft)}
           className="px-4 py-2 rounded border bg-white"
         >
           保存

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { NodeWrapper } from '@/components/shared/NodeWrapper';
-import { useBuilderLayoutStore } from '@/stores/builderLayout';
+import { useBuilderLayout } from '@/stores/builderLayout';
 
 const Panel = ({ label }: { label: string }) => (
   <NodeWrapper nodeId={label}>
@@ -17,7 +17,7 @@ const panelMap: Record<string, JSX.Element> = {
 };
 
 export default function BuilderPage() {
-  const layout = useBuilderLayoutStore((s) => s.builderLayout);
+  const layout = useBuilderLayout((s) => s.layout);
   const center = (['palette', 'inspector', 'toolbar', 'canvas'] as const).find(
     (p) => !Object.values(layout).includes(p),
   ) || 'canvas';

--- a/web/stores/builderLayout.ts
+++ b/web/stores/builderLayout.ts
@@ -9,24 +9,29 @@ export type BuilderLayout = {
   bottom?: string;
 };
 
-type BuilderLayoutState = {
-  builderLayout: BuilderLayout;
-  setBuilderLayout: (layout: BuilderLayout) => void;
-};
+interface BuilderLayoutState {
+  layout: BuilderLayout;
+  setLayout: (next: BuilderLayout) => void;
+  resetLayout: () => void;
+}
 
 const defaultLayout: BuilderLayout = {
   left: 'palette',
   right: 'inspector',
   top: 'toolbar',
+  bottom: 'canvas',
 };
 
-export const useBuilderLayoutStore = create<BuilderLayoutState>()(
+export const useBuilderLayout = create<BuilderLayoutState>()(
   persist(
     (set) => ({
-      builderLayout: defaultLayout,
-      setBuilderLayout: (layout) => set({ builderLayout: layout }),
+      layout: defaultLayout,
+      setLayout: (next) => set({ layout: next }),
+      resetLayout: () => set({ layout: defaultLayout }),
     }),
-    { name: 'builder-layout' }
+    {
+      name: 'builder-layout',
+    }
   )
 );
 


### PR DESCRIPTION
## Summary
- add persistent builder layout store with reset functionality
- update builder and layout editor pages to use new store API

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba859dfc0c832c90feafd6b0ee3528