### PR TITLE
feat: implement drag-and-drop builder layout editor

### DIFF
--- a/web/app/builder/layout/page.tsx
+++ b/web/app/builder/layout/page.tsx
@@ -1,107 +1,214 @@
-'use client';
-import { useState } from 'react';
-import Link from 'next/link';
-import { DndContext, useDraggable, useDroppable, DragEndEvent } from '@dnd-kit/core';
-import { NodeWrapper } from '@/components/shared/NodeWrapper';
-import { useBuilderLayout, type BuilderLayout } from '@/stores/builderLayout';
+'use client'
 
-const PANELS = ['palette', 'inspector', 'toolbar', 'canvas'] as const;
-const ZONES = ['top', 'left', 'center', 'right', 'bottom'] as const;
+import { useEffect, useMemo, useState } from 'react'
+import { useBuilderLayout, type BuilderLayout } from '@/stores/builderLayout'
+import clsx from 'clsx'
 
-type Panel = typeof PANELS[number];
-type Zone = typeof ZONES[number];
+type PanelKey = 'palette' | 'inspector' | 'toolbar'
+const ALL_PANELS: PanelKey[] = ['palette', 'inspector', 'toolbar']
 
-function DraggablePanel({ id }: { id: Panel }) {
-  const { attributes, listeners, setNodeRef, transform } = useDraggable({ id });
-  const style = transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` } : undefined;
-  return (
-    <NodeWrapper nodeId={id}>
-      <div
-        ref={setNodeRef}
-        style={style}
-        {...listeners}
-        {...attributes}
-        className="px-2 py-1 text-sm rounded border bg-white cursor-move"
-      >
-        {id}
-      </div>
-    </NodeWrapper>
-  );
+const panelLabel: Record<PanelKey, string> = {
+  palette: 'Palette（コンポーネント辞書）',
+  inspector: 'Inspector（プロパティ編集）',
+  toolbar: 'Toolbar（操作バー）',
 }
 
-function DropZone({ id, children }: { id: Zone; children?: React.ReactNode }) {
-  const { setNodeRef, isOver } = useDroppable({ id });
+function DraggablePanelCard({ id, disabled = false }: { id: PanelKey; disabled?: boolean }) {
   return (
     <div
-      ref={setNodeRef}
-      className={`flex items-center justify-center border rounded p-2 min-h-[60px] ${
-        isOver ? 'bg-blue-50' : 'bg-gray-50'
-      }`}
+      draggable={!disabled}
+      onDragStart={(e) => {
+        if (disabled) return
+        e.dataTransfer.setData('text/panel', id)
+        e.dataTransfer.effectAllowed = 'move'
+      }}
+      className={clsx(
+        'rounded-xl border px-3 py-2 text-sm shadow-sm select-none',
+        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-grab active:cursor-grabbing',
+        'bg-zinc-900/40 border-zinc-700'
+      )}
+      title={panelLabel[id]}
     >
-      {children || <span className="text-xs text-zinc-400">{id}</span>}
+      <div className="font-medium">{id}</div>
+      <div className="text-xs text-zinc-400">{panelLabel[id]}</div>
     </div>
-  );
+  )
 }
 
-export default function LayoutEditorPage() {
-  const { layout, setLayout } = useBuilderLayout();
-  const [draft, setDraft] = useState<BuilderLayout>(layout);
-
-  const handleDragEnd = (e: DragEndEvent) => {
-    const { active, over } = e;
-    if (!over) return;
-    const panel = active.id as Panel;
-    const zone = over.id as Zone;
-    setDraft((cur) => {
-      const next: BuilderLayout = { ...cur };
-      const prevPos = (['left', 'right', 'top', 'bottom'] as Array<keyof BuilderLayout>).find(
-        (k) => next[k] === panel,
-      );
-      if (zone === 'center') {
-        if (prevPos) {
-          delete next[prevPos];
-        }
-        return next;
-      }
-      const swapped = next[zone as keyof BuilderLayout];
-      if (prevPos) {
-        next[prevPos] = swapped;
-      }
-      next[zone as keyof BuilderLayout] = panel;
-      return next;
-    });
-  };
-
-  const center = PANELS.find((p) => !Object.values(draft).includes(p)) as Panel | undefined;
-
+function DropSlot({
+  title,
+  slotKey,
+  value,
+  onDropPanel,
+  onClear,
+}: {
+  title: string
+  slotKey: keyof BuilderLayout
+  value?: string | ''
+  onDropPanel: (slot: keyof BuilderLayout, panel: PanelKey) => void
+  onClear: (slot: keyof BuilderLayout) => void
+}) {
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold mb-4">Builder Layout</h1>
-      <DndContext onDragEnd={handleDragEnd}>
-        <div className="grid grid-cols-3 grid-rows-3 gap-4 max-w-xl">
-          <div className="col-span-3">
-            <DropZone id="top">{draft.top && <DraggablePanel id={draft.top as Panel} />}</DropZone>
+    <div className="space-y-2">
+      <div className="text-xs text-zinc-400">{title}</div>
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          e.preventDefault()
+          const panel = e.dataTransfer.getData('text/panel') as PanelKey
+          if (!panel) return
+          onDropPanel(slotKey, panel)
+        }}
+        className={clsx(
+          'min-h-[72px] rounded-xl border border-dashed px-3 py-2',
+          'bg-zinc-900/30 border-zinc-700'
+        )}
+      >
+        {value ? (
+          <div className="flex items-center justify-between gap-2">
+            <DraggablePanelCard id={value as PanelKey} disabled />
+            <button
+              className="text-xs text-zinc-300 hover:text-red-400 transition"
+              onClick={() => onClear(slotKey)}
+            >
+              Clear
+            </button>
           </div>
-          <DropZone id="left">{draft.left && <DraggablePanel id={draft.left as Panel} />}</DropZone>
-          <DropZone id="center">{center && <DraggablePanel id={center} />}</DropZone>
-          <DropZone id="right">{draft.right && <DraggablePanel id={draft.right as Panel} />}</DropZone>
-          <div className="col-span-3">
-            <DropZone id="bottom">{draft.bottom && <DraggablePanel id={draft.bottom as Panel} />}</DropZone>
-          </div>
-        </div>
-      </DndContext>
-      <div className="flex gap-2">
-        <button
-          onClick={() => setLayout(draft)}
-          className="px-4 py-2 rounded border bg-white"
-        >
-          保存
-        </button>
-        <Link href="/builder" className="px-4 py-2 rounded border bg-white">
-          戻る
-        </Link>
+        ) : (
+          <div className="text-xs text-zinc-500">ここにドラッグして配置</div>
+        )}
       </div>
     </div>
-  );
+  )
+}
+
+export default function BuilderLayoutEditorPage() {
+  const { layout, setLayout, resetLayout } = useBuilderLayout()
+  const [draft, setDraft] = useState<BuilderLayout>(layout)
+
+  useEffect(() => setDraft(layout), [layout])
+
+  const assigned = useMemo(() => new Set(Object.values(draft).filter(Boolean) as string[]), [draft])
+
+  const place = (slot: keyof BuilderLayout, panel: PanelKey) => {
+    // 同一パネルは一意にする: 既存配置から取り外してから新しい slot に置く
+    const next: BuilderLayout = { ...draft }
+    ;(['left', 'right', 'top', 'bottom'] as (keyof BuilderLayout)[]).forEach((k) => {
+      if (next[k] === panel) next[k] = ''
+    })
+    next[slot] = panel
+    setDraft(next)
+  }
+
+  const clearSlot = (slot: keyof BuilderLayout) => {
+    setDraft((d) => ({ ...d, [slot]: '' }))
+  }
+
+  const availablePanels = ALL_PANELS.filter((p) => !assigned.has(p))
+
+  return (
+    <div className="h-[calc(100vh-64px)] p-4 space-y-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Builder Layout Editor</h1>
+        <div className="flex items-center gap-2">
+          <button
+            className="rounded-lg border px-3 py-1.5 text-sm bg-zinc-900/50 border-zinc-700 hover:bg-zinc-800"
+            onClick={() => setDraft(layout)}
+          >
+            Revert
+          </button>
+          <button
+            className="rounded-lg border px-3 py-1.5 text-sm bg-zinc-900/50 border-zinc-700 hover:bg-zinc-800"
+            onClick={resetLayout}
+          >
+            Reset to Default
+          </button>
+          <button
+            className="rounded-lg border px-3 py-1.5 text-sm bg-blue-600/80 border-blue-500 hover:bg-blue-600"
+            onClick={() => setLayout(draft)}
+          >
+            Apply
+          </button>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-12 gap-4">
+        {/* 左ペイン: 未配置パネル */}
+        <aside className="col-span-3 space-y-2">
+          <div className="text-xs text-zinc-400">未配置のパネル</div>
+          <div className="space-y-2">
+            {availablePanels.length === 0 ? (
+              <div className="text-xs text-zinc-500">すべて配置済みです</div>
+            ) : (
+              availablePanels.map((p) => <DraggablePanelCard key={p} id={p} />)
+            )}
+          </div>
+          <div className="mt-4 text-xs text-zinc-500">
+            パネルをドラッグして右側のスロットに配置できます。
+          </div>
+        </aside>
+
+        {/* 右ペイン: 配置グリッド（Top / Left / Center(Canvas固定) / Right / Bottom） */}
+        <main className="col-span-9">
+          <div className="grid grid-rows-[64px_minmax(240px,1fr)_64px] grid-cols-[260px_1fr_280px] gap-4">
+            {/* Top */}
+            <div className="col-span-3">
+              <DropSlot
+                title="Top"
+                slotKey="top"
+                value={draft.top}
+                onDropPanel={place}
+                onClear={clearSlot}
+              />
+            </div>
+
+            {/* Left / Center / Right */}
+            <div className="col-span-1">
+              <DropSlot
+                title="Left"
+                slotKey="left"
+                value={draft.left}
+                onDropPanel={place}
+                onClear={clearSlot}
+              />
+            </div>
+
+            <div className="col-span-1">
+              <div className="space-y-2">
+                <div className="text-xs text-zinc-400">Center（Canvas 固定）</div>
+                <div className="rounded-xl border bg-zinc-900/30 border-zinc-700 h-full min-h-[240px] p-3">
+                  <div className="text-xs text-zinc-500">
+                    ここは Canvas 領域です（固定）。プレビュー的にダミーを表示しています。
+                  </div>
+                  <div className="mt-3 h-32 rounded-lg border border-zinc-700 bg-zinc-900/40" />
+                </div>
+              </div>
+            </div>
+
+            <div className="col-span-1">
+              <DropSlot
+                title="Right"
+                slotKey="right"
+                value={draft.right}
+                onDropPanel={place}
+                onClear={clearSlot}
+              />
+            </div>
+
+            {/* Bottom */}
+            <div className="col-span-3">
+              <DropSlot
+                title="Bottom"
+                slotKey="bottom"
+                value={draft.bottom}
+                onDropPanel={place}
+                onClear={clearSlot}
+              />
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  )
 }
 

--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -1,43 +1,51 @@
-'use client';
-import Link from 'next/link';
-import { NodeWrapper } from '@/components/shared/NodeWrapper';
-import { useBuilderLayout } from '@/stores/builderLayout';
+'use client'
 
-const Panel = ({ label }: { label: string }) => (
-  <NodeWrapper nodeId={label}>
-    <div className="p-2 bg-white border rounded text-sm">{label}</div>
-  </NodeWrapper>
-);
-
-const panelMap: Record<string, JSX.Element> = {
-  palette: <Panel label="palette" />,
-  inspector: <Panel label="inspector" />,
-  toolbar: <Panel label="toolbar" />,
-  canvas: <Panel label="canvas" />,
-};
+import { useBuilderLayout } from '@/stores/builderLayout'
 
 export default function BuilderPage() {
-  const layout = useBuilderLayout((s) => s.layout);
-  const center = (['palette', 'inspector', 'toolbar', 'canvas'] as const).find(
-    (p) => !Object.values(layout).includes(p),
-  ) || 'canvas';
+  const { layout } = useBuilderLayout()
+
   return (
-    <div className="h-screen grid grid-cols-[auto_1fr_auto] grid-rows-[auto_1fr_auto] gap-2 p-2">
-      {layout.top && (
-        <div className="col-span-3">{panelMap[layout.top]}</div>
-      )}
-      <div>{layout.left && panelMap[layout.left]}</div>
-      <div>{panelMap[center]}</div>
-      <div>{layout.right && panelMap[layout.right]}</div>
-      {layout.bottom && (
-        <div className="col-span-3">{panelMap[layout.bottom]}</div>
-      )}
-      <div className="absolute top-2 right-2">
-        <Link href="/builder/layout" className="text-blue-600 underline text-xs">
-          レイアウト編集
-        </Link>
+    <div className="grid grid-rows-[48px_minmax(0,1fr)_48px] grid-cols-[260px_1fr_280px] h-[calc(100vh-64px)]">
+      {/* Top */}
+      <div className="col-span-3 border-b border-zinc-800">
+        {layout.top === 'toolbar' ? <Toolbar /> : null}
+      </div>
+
+      {/* Left */}
+      <div className="border-r border-zinc-800">
+        {layout.left === 'palette' ? <Palette /> : layout.left === 'inspector' ? <Inspector /> : null}
+      </div>
+
+      {/* Center = Canvas 固定 */}
+      <div className="overflow-hidden">
+        <Canvas />
+      </div>
+
+      {/* Right */}
+      <div className="border-l border-zinc-800">
+        {layout.right === 'inspector' ? <Inspector /> : layout.right === 'palette' ? <Palette /> : null}
+      </div>
+
+      {/* Bottom */}
+      <div className="col-span-3 border-t border-zinc-800">
+        {layout.bottom === 'toolbar' ? <Toolbar /> : null}
       </div>
     </div>
-  );
+  )
+}
+
+// ここは実アプリのものに置き換えてね
+function Toolbar() {
+  return <div className="h-full px-3 flex items-center text-sm">Toolbar</div>
+}
+function Palette() {
+  return <div className="h-full p-3 text-sm">Palette</div>
+}
+function Inspector() {
+  return <div className="h-full p-3 text-sm">Inspector</div>
+}
+function Canvas() {
+  return <div className="h-full bg-zinc-900/30">Canvas</div>
 }
 

--- a/web/stores/builderLayout.ts
+++ b/web/stores/builderLayout.ts
@@ -1,26 +1,26 @@
-'use client';
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 export type BuilderLayout = {
-  left: string;
-  right: string;
-  top?: string;
-  bottom?: string;
-};
+  left: string | ''
+  right: string | ''
+  top?: string | ''
+  bottom?: string | ''
+}
 
 interface BuilderLayoutState {
-  layout: BuilderLayout;
-  setLayout: (next: BuilderLayout) => void;
-  resetLayout: () => void;
+  layout: BuilderLayout
+  setLayout: (next: BuilderLayout) => void
+  resetLayout: () => void
 }
 
 const defaultLayout: BuilderLayout = {
   left: 'palette',
   right: 'inspector',
   top: 'toolbar',
-  bottom: 'canvas',
-};
+  bottom: '',
+}
 
 export const useBuilderLayout = create<BuilderLayoutState>()(
   persist(
@@ -29,9 +29,7 @@ export const useBuilderLayout = create<BuilderLayoutState>()(
       setLayout: (next) => set({ layout: next }),
       resetLayout: () => set({ layout: defaultLayout }),
     }),
-    {
-      name: 'builder-layout',
-    }
+    { name: 'builder-layout' }
   )
-);
+)
 


### PR DESCRIPTION
## Summary
- add persistent builder layout store with empty bottom slot
- implement HTML5 drag-and-drop layout editor page
- wire builder page to layout store

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8dc0a9a4832c8b714874d0ae1f4b