### PR TITLE
fix: render panels in any builder layout slot

### DIFF
--- a/web/app/builder/page.tsx
+++ b/web/app/builder/page.tsx
@@ -2,20 +2,29 @@
 
 import { useBuilderLayout } from '@/stores/builderLayout'
 
+const renderPanel = (panel: string | undefined) => {
+  switch (panel) {
+    case 'toolbar':
+      return <Toolbar />
+    case 'palette':
+      return <Palette />
+    case 'inspector':
+      return <Inspector />
+    default:
+      return null
+  }
+}
+
 export default function BuilderPage() {
   const { layout } = useBuilderLayout()
 
   return (
     <div className="grid grid-rows-[48px_minmax(0,1fr)_48px] grid-cols-[260px_1fr_280px] h-[calc(100vh-64px)]">
       {/* Top */}
-      <div className="col-span-3 border-b border-zinc-800">
-        {layout.top === 'toolbar' ? <Toolbar /> : null}
-      </div>
+      <div className="col-span-3 border-b border-zinc-800">{renderPanel(layout.top)}</div>
 
       {/* Left */}
-      <div className="border-r border-zinc-800">
-        {layout.left === 'palette' ? <Palette /> : layout.left === 'inspector' ? <Inspector /> : null}
-      </div>
+      <div className="border-r border-zinc-800">{renderPanel(layout.left)}</div>
 
       {/* Center = Canvas 固定 */}
       <div className="overflow-hidden">
@@ -23,14 +32,10 @@ export default function BuilderPage() {
       </div>
 
       {/* Right */}
-      <div className="border-l border-zinc-800">
-        {layout.right === 'inspector' ? <Inspector /> : layout.right === 'palette' ? <Palette /> : null}
-      </div>
+      <div className="border-l border-zinc-800">{renderPanel(layout.right)}</div>
 
       {/* Bottom */}
-      <div className="col-span-3 border-t border-zinc-800">
-        {layout.bottom === 'toolbar' ? <Toolbar /> : null}
-      </div>
+      <div className="col-span-3 border-t border-zinc-800">{renderPanel(layout.bottom)}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- render palette, inspector, or toolbar in any builder layout slot

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbcdc60c78832c9d2e74e18994d14a