### PR TITLE
feat(figma-v0): /dev/figma skeleton + Zustand store (feature-flagged, append-only)

### DIFF
--- a/apps/builder/app/dev/figma/page.tsx
+++ b/apps/builder/app/dev/figma/page.tsx
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic'
+
+export const metadata = { title: 'Figma Dev (v0 placeholder)' }
+
+const FigmaDev = dynamic(() => import('../../../components/figma/FigmaDev'), { ssr: false })
+
+export default function Page() {
+  const enabled = process.env.NEXT_PUBLIC_FIGMA === '1'
+  if (!enabled) {
+    return (
+      <div className="p-6 text-sm text-gray-600">
+        <h1 className="text-lg font-semibold mb-2">Figma Dev is disabled</h1>
+        <p>Set <code>NEXT_PUBLIC_FIGMA=1</code> to enable this route.</p>
+      </div>
+    )
+  }
+  return <FigmaDev />
+}
+

--- a/apps/builder/components/figma/Canvas.tsx
+++ b/apps/builder/components/figma/Canvas.tsx
@@ -1,0 +1,72 @@
+'use client'
+import { useFigmaStore } from '../../lib/figma/store'
+import InlineTextEditor from './InlineTextEditor'
+import type { Node } from '../../lib/figma/model'
+import { useMemo } from 'react'
+
+function NodeBox({ node }: { node: Node }) {
+  const select = useFigmaStore((s) => s.select)
+  const selectedIds = useFigmaStore((s) => s.selectedIds)
+  const editingTextId = useFigmaStore((s) => s.editingTextId)
+  const startEditingText = useFigmaStore((s) => s.startEditingText)
+
+  const isSelected = selectedIds.includes(node.id)
+  const style: React.CSSProperties = useMemo(() => ({
+    position: 'absolute',
+    left: node.x,
+    top: node.y,
+    width: node.width,
+    height: node.height,
+    opacity: node.style?.opacity ?? 1,
+    borderRadius: node.style?.radius ?? 0,
+  }), [node])
+
+  const onClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation()
+    select([node.id], e.shiftKey)
+  }
+  const onDoubleClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation()
+    if (node.type === 'TEXT') startEditingText(node.id)
+  }
+
+  const fill = node.type === 'TEXT' ? undefined : (node.style?.fill ? '#0000000a' : '#9ca3af22')
+
+  return (
+    <div onClick={onClick} onDoubleClick={onDoubleClick}
+      style={{ ...style, background: fill, outline: isSelected ? '1px solid #3b82f6' : 'none' }}>
+      {node.type === 'TEXT' && (
+        <>
+          <div className="select-none cursor-text p-1 text-sm">
+            {editingTextId !== node.id && (node.content ?? '')}
+          </div>
+          {editingTextId === node.id && (
+            <InlineTextEditor nodeId={node.id} initialText={node.content ?? ''} />
+          )}
+        </>
+      )}
+      {'children' in node && Array.isArray(node.children) && node.children.map((c) => (
+        <NodeBox key={c.id} node={c} />
+      ))}
+    </div>
+  )
+}
+
+export default function Canvas() {
+  const page = useFigmaStore((s) => s.doc.pages[0])
+  const root = page.root
+  const clearSelect = useFigmaStore((s) => s.clearSelect)
+  return (
+    <div className="relative h-full w-full overflow-auto" onClick={() => clearSelect()}>
+      <div style={{
+        position: 'relative',
+        width: root.width, height: root.height, left: root.x, top: root.y,
+        background: '#fff',
+        boxShadow: '0 0 0 1px rgba(0,0,0,0.06), 0 2px 12px rgba(0,0,0,0.08)',
+      }}>
+        <NodeBox node={root} />
+      </div>
+    </div>
+  )
+}
+

--- a/apps/builder/components/figma/FigmaDev.tsx
+++ b/apps/builder/components/figma/FigmaDev.tsx
@@ -1,0 +1,17 @@
+'use client'
+import Canvas from './Canvas'
+import RightPanel from './RightPanel'
+
+export default function FigmaDev() {
+  return (
+    <div className="h-screen w-screen grid grid-cols-[1fr_320px]">
+      <div className="h-full w-full bg-[linear-gradient(90deg,rgba(0,0,0,0.04)_1px,transparent_1px),linear-gradient(0deg,rgba(0,0,0,0.04)_1px,transparent_1px)] bg-[size:8px_8px]">
+        <Canvas />
+      </div>
+      <div className="h-full border-l border-gray-200 bg-white">
+        <RightPanel />
+      </div>
+    </div>
+  )
+}
+

--- a/apps/builder/components/figma/InlineTextEditor.tsx
+++ b/apps/builder/components/figma/InlineTextEditor.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import { useFigmaStore } from '../../lib/figma/store'
+
+export default function InlineTextEditor({ nodeId, initialText }:{nodeId:string; initialText:string}) {
+  const stopEditingText = useFigmaStore((s)=>s.stopEditingText)
+  const setTextContent = useFigmaStore((s)=>s.setTextContent)
+  const [value, setValue] = useState(initialText)
+  const ref = useRef<HTMLInputElement>(null)
+
+  useEffect(()=>{ ref.current?.focus(); ref.current?.select() }, [])
+
+  const commit = () => { setTextContent(nodeId, value); stopEditingText() }
+
+  return (
+    <input ref={ref}
+      className="absolute left-0 top-0 w-full border-none outline-none bg-transparent p-1 text-sm"
+      value={value}
+      onChange={(e)=>setValue(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e)=>{ if(e.key==='Enter') commit(); if(e.key==='Escape') stopEditingText() }}
+    />
+  )
+}
+

--- a/apps/builder/components/figma/RightPanel.tsx
+++ b/apps/builder/components/figma/RightPanel.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { useFigmaStore } from '../../lib/figma/store'
+
+function NumberInput({ label, value, onChange }:{
+  label:string; value:number; onChange:(n:number)=>void
+}) {
+  return (
+    <label className="flex items-center justify-between py-1 text-sm">
+      <span className="text-gray-500">{label}</span>
+      <input type="number" className="w-28 rounded border border-gray-200 px-2 py-1 text-right"
+        value={Number.isFinite(value) ? value : 0}
+        onChange={(e)=>onChange(Number(e.target.value))}/>
+    </label>
+  )
+}
+
+export default function RightPanel() {
+  const selected = useFigmaStore((s)=>s.selectedNode)
+  const setNodeRect = useFigmaStore((s)=>s.setNodeRect)
+
+  if (!selected) {
+    return <div className="p-4 text-sm text-gray-500">
+      <div className="font-semibold text-gray-700 mb-2">Properties</div>
+      <p>No selection</p>
+    </div>
+  }
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Selection</div>
+        <div className="text-sm font-medium text-gray-800">
+          {selected.name || selected.type} <span className="text-gray-400">({selected.type})</span>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <div className="text-xs uppercase tracking-wider text-gray-400">Position</div>
+        <NumberInput label="X" value={selected.x} onChange={(n)=>setNodeRect(selected.id,{x:n})}/>
+        <NumberInput label="Y" value={selected.y} onChange={(n)=>setNodeRect(selected.id,{y:n})}/>
+      </div>
+      <div className="space-y-1">
+        <div className="text-xs uppercase tracking-wider text-gray-400">Size</div>
+        <NumberInput label="W" value={selected.width} onChange={(n)=>setNodeRect(selected.id,{width:n})}/>
+        <NumberInput label="H" value={selected.height} onChange={(n)=>setNodeRect(selected.id,{height:n})}/>
+      </div>
+      <div className="space-y-1 opacity-50 pointer-events-none">
+        <div className="text-xs uppercase tracking-wider text-gray-400">Style (v0 stub)</div>
+        <NumberInput label="Radius" value={selected.style?.radius ?? 0} onChange={()=>{}}/>
+        <NumberInput label="Opacity" value={selected.style?.opacity ?? 1} onChange={()=>{}}/>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/builder/lib/figma/actions.ts
+++ b/apps/builder/lib/figma/actions.ts
@@ -1,0 +1,15 @@
+// Action signatures placeholder (future use)
+export type SelectAction = { type: 'select'; ids: string[]; additive?: boolean }
+export type ClearSelectAction = { type: 'clearSelect' }
+export type StartEditTextAction = { type: 'startEditText'; id: string }
+export type StopEditTextAction = { type: 'stopEditText' }
+export type SetTextContentAction = { type: 'setTextContent'; id: string; value: string }
+export type SetNodeRectAction = { type: 'setNodeRect'; id: string; patch: Partial<{ x:number; y:number; width:number; height:number }> }
+export type UndoAction = { type: 'undo' }
+export type RedoAction = { type: 'redo' }
+export type FigmaAction =
+  | SelectAction | ClearSelectAction
+  | StartEditTextAction | StopEditTextAction
+  | SetTextContentAction | SetNodeRectAction
+  | UndoAction | RedoAction
+

--- a/apps/builder/lib/figma/model.ts
+++ b/apps/builder/lib/figma/model.ts
@@ -1,0 +1,48 @@
+export type TokenRef = { $token: string }
+
+export type Constraints = {
+  horizontal: 'LEFT' | 'RIGHT' | 'CENTER' | 'SCALE'
+  vertical: 'TOP' | 'BOTTOM' | 'CENTER' | 'SCALE'
+}
+
+export type Style = { fill?: TokenRef; text?: TokenRef; radius?: number; opacity?: number }
+
+export type NodeBase = {
+  id: string
+  type: 'FRAME' | 'STACK' | 'RECT' | 'TEXT' | 'IMAGE' | 'COMPONENT' | 'INSTANCE'
+  name?: string
+  visible?: boolean
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation?: number
+  constraints?: Constraints
+  style?: Style
+}
+
+export type Stack = NodeBase & {
+  type: 'STACK'
+  direction: 'H' | 'V'
+  spacing: number
+  padding: { t: number; r: number; b: number; l: number }
+  align: 'START' | 'CENTER' | 'END' | 'SPACE_BETWEEN'
+  children: Node[]
+}
+
+export type Text = NodeBase & {
+  type: 'TEXT'
+  content: string
+  font?: { family: string; size: number; weight?: number; lineHeight?: number }
+}
+
+export type Frame = NodeBase & { type: 'FRAME'; children: Node[] }
+export type Rect = NodeBase & { type: 'RECT' }
+export type Image = NodeBase & { type: 'IMAGE'; src?: string }
+
+export type Node = Frame | Stack | Text | Rect | Image | NodeBase
+
+export type Page = { id: string; name: string; root: Frame }
+
+export type Document = { id: string; name: string; pages: Page[]; tokens?: Record<string, string | number> }
+

--- a/apps/builder/lib/figma/store.ts
+++ b/apps/builder/lib/figma/store.ts
@@ -1,0 +1,88 @@
+'use client'
+import { create } from 'zustand'
+import type { Document, Node, Page } from './model'
+
+function findNode(root: Node, id: string): Node | null {
+  if (root.id === id) return root
+  // @ts-expect-error runtime guard
+  if (root.children && Array.isArray(root.children)) {
+    for (const c of root.children) {
+      const r = findNode(c, id)
+      if (r) return r
+    }
+  }
+  return null
+}
+
+const defaultDoc: Document = {
+  id: 'doc-1',
+  name: 'Untitled',
+  pages: [
+    {
+      id: 'page-1',
+      name: 'Page 1',
+      root: {
+        id: 'root',
+        type: 'FRAME',
+        name: 'Frame',
+        x: 80, y: 80, width: 960, height: 640,
+        children: [
+          { id: 't1', type: 'TEXT', name: 'Heading', x: 40, y: 40, width: 320, height: 24, content: 'ダブルクリックで編集（v0）' },
+        ],
+      },
+    },
+  ],
+}
+
+type RectPatch = Partial<Pick<Node, 'x' | 'y' | 'width' | 'height'>>
+
+type State = {
+  doc: Document
+  selectedIds: string[]
+  editingTextId?: string | null
+  readonly selectedNode: Node | null
+  select: (ids: string[], additive?: boolean) => void
+  clearSelect: () => void
+  startEditingText: (id: string) => void
+  stopEditingText: () => void
+  setTextContent: (id: string, value: string) => void
+  setNodeRect: (id: string, patch: RectPatch) => void
+  undo: () => void
+  redo: () => void
+}
+
+export const useFigmaStore = create<State>((set, get) => ({
+  doc: defaultDoc,
+  selectedIds: [],
+  editingTextId: null,
+  get selectedNode() {
+    const ids = get().selectedIds
+    if (!ids.length) return null
+    const page: Page = get().doc.pages[0]
+    return findNode(page.root, ids[0])
+  },
+  select: (ids, additive) => set((s) => ({ selectedIds: additive ? Array.from(new Set([...s.selectedIds, ...ids])) : ids })),
+  clearSelect: () => set({ selectedIds: [] }),
+  startEditingText: (id) => set({ editingTextId: id }),
+  stopEditingText: () => set({ editingTextId: null }),
+  setTextContent: (id, value) => set((s) => {
+    const page = s.doc.pages[0]
+    const node = findNode(page.root, id)
+    if (node && node.type === 'TEXT') { /* @ts-expect-error mutate */ node.content = value }
+    return { doc: { ...s.doc } }
+  }),
+  setNodeRect: (id, patch) => set((s) => {
+    const page = s.doc.pages[0]
+    const node = findNode(page.root, id)
+    if (node) {
+      if (typeof patch.x === 'number') node.x = patch.x
+      if (typeof patch.y === 'number') node.y = patch.y
+      if (typeof patch.width === 'number') node.width = patch.width
+      if (typeof patch.height === 'number') node.height = patch.height
+    }
+    return { doc: { ...s.doc } }
+  }),
+  undo: () => { /* stub */ },
+  redo: () => { /* stub */ },
+}))
+


### PR DESCRIPTION
﻿/dev/figma のプレースホルダーと Zustand ストア骨組みを追加（feature flag: NEXT_PUBLIC_FIGMA=1 時のみ有効）。

- ルート: /dev/figma
- Canvas: 選択ハイライト、Textダブルクリックでインライン編集（Enter/Esc/blur）
- RightPanel: X/Y/W/H 編集（即時反映）
- Store: model/store/actions の最小セット（undo/redoはstub）

※ 実装差分のみ。既存機能は非影響（append-only）
