### PR TITLE
feat(figma): add motion editing panel

### DIFF
--- a/apps/builder/components/figma/MotionPanel.tsx
+++ b/apps/builder/components/figma/MotionPanel.tsx
@@ -1,0 +1,69 @@
+'use client'
+import { useMemo } from 'react'
+import { useFigmaStore } from '../../lib/figma/store'
+import type { MotionInline } from '../../lib/figma/model'
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex items-center justify-between py-1 text-sm">
+      <span className="text-gray-500">{label}</span>
+      <div className="w-40">{children}</div>
+    </label>
+  )
+}
+
+export default function MotionPanel() {
+  const n = useFigmaStore((s) => s.selectedNode)
+  const setNodeMotion = useFigmaStore((s) => s.setNodeMotion)
+
+  const motion = (n as any)?.motion as MotionInline | undefined
+  const preset = motion?.preset ?? 'fadeIn'
+  const trigger = motion?.trigger ?? 'appear'
+  const duration = typeof motion?.options?.duration === 'number' ? motion?.options?.duration : undefined
+  const distance = typeof motion?.options?.distance === 'number' ? motion?.options?.distance : undefined
+  const engine = motion?.engine ?? 'framer'
+
+  const presets = useMemo(() => ['fadeIn','fadeOut','slideInUp','slideInDown','slideInLeft','slideInRight','scaleIn','pop','flipY','staggerChildren'], [])
+  const triggers = useMemo(() => ['appear','enter','exit','hover','press','focus','loop','scroll'], [])
+  const engines = useMemo(() => ['framer','anime'], [])
+
+  if (!n) return null
+
+  return (
+    <div className="mt-4">
+      <div className="text-xs uppercase tracking-wider text-gray-400">Motion (v0)</div>
+      <Row label="Preset">
+        <select className="w-full border rounded px-2 py-1 text-sm"
+          value={preset}
+          onChange={(e)=>setNodeMotion(n.id, { preset: e.target.value as any })}>
+          {presets.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+      </Row>
+      <Row label="Trigger">
+        <select className="w-full border rounded px-2 py-1 text-sm"
+          value={trigger}
+          onChange={(e)=>setNodeMotion(n.id, { trigger: e.target.value as any })}>
+          {triggers.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </Row>
+      <Row label="Engine">
+        <select className="w-full border rounded px-2 py-1 text-sm"
+          value={engine}
+          onChange={(e)=>setNodeMotion(n.id, { engine: e.target.value as any })}>
+          {engines.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </Row>
+      <Row label="Duration(ms)">
+        <input type="number" className="w-full border rounded px-2 py-1 text-right"
+          value={duration ?? 280}
+          onChange={(e)=>setNodeMotion(n.id, { options: { duration: Number(e.target.value) }})}/>
+      </Row>
+      <Row label="Distance(px)">
+        <input type="number" className="w-full border rounded px-2 py-1 text-right"
+          value={distance ?? 24}
+          onChange={(e)=>setNodeMotion(n.id, { options: { distance: Number(e.target.value) }})}/>
+      </Row>
+      <div className="text-xs text-gray-400 mt-1">※ 再生は後続PR。Reduced Motionは既定で尊重。</div>
+    </div>
+  )
+}

--- a/apps/builder/components/figma/RightPanel.tsx
+++ b/apps/builder/components/figma/RightPanel.tsx
@@ -1,0 +1,34 @@
+'use client'
+import React from 'react'
+import { useFigmaStore } from '../../lib/figma/store'
+import MotionPanel from './MotionPanel'
+
+function NumberInput({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {
+  return (
+    <label className="flex items-center justify-between py-1 text-sm">
+      <span className="text-gray-500">{label}</span>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-40 border rounded px-2 py-1 text-right"
+      />
+    </label>
+  )
+}
+
+export default function RightPanel() {
+  const selected = useFigmaStore((s) => s.selectedNode)
+  if (!selected) return null
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="space-y-1 opacity-50 pointer-events-none">
+        <div className="text-xs uppercase tracking-wider text-gray-400">Style (v0 stub)</div>
+        <NumberInput label="Radius" value={selected.style?.radius ?? 0} onChange={() => {}} />
+        <NumberInput label="Opacity" value={selected.style?.opacity ?? 1} onChange={() => {}} />
+      </div>
+      <MotionPanel />
+    </div>
+  )
+}

--- a/apps/builder/lib/figma/model.ts
+++ b/apps/builder/lib/figma/model.ts
@@ -1,0 +1,60 @@
+export type TokenRef = { $token: string }
+
+export type Style = { fill?: TokenRef; text?: TokenRef; radius?: number; opacity?: number }
+
+// --- Motion types (v0 stub) ---
+export type MotionRef = { $motion: string }
+export type MotionInline = {
+  engine?: 'framer' | 'anime'
+  preset?: 'fadeIn' | 'fadeOut' | 'slideInUp' | 'slideInDown' | 'slideInLeft' | 'slideInRight' | 'scaleIn' | 'pop' | 'flipY' | 'staggerChildren'
+  trigger?: 'appear' | 'enter' | 'exit' | 'hover' | 'press' | 'focus' | 'loop' | 'scroll'
+  options?: {
+    duration?: number | { $token: string }
+    delay?: number | { $token: string }
+    easeToken?: { $token: string }
+    distance?: number | { $token: string }
+    direction?: 'up' | 'down' | 'left' | 'right'
+    repeat?: number | 'infinite'
+    staggerStep?: number | { $token: string }
+    disabledOnReducedMotion?: boolean
+  }
+}
+
+export type Constraints = Record<string, unknown>
+
+export type NodeBase = {
+  id: string
+  type: 'FRAME' | 'STACK' | 'RECT' | 'TEXT' | 'IMAGE' | 'COMPONENT' | 'INSTANCE'
+  name?: string
+  visible?: boolean
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation?: number
+  constraints?: Constraints
+  style?: Style
+  motion?: MotionRef | MotionInline
+}
+
+export type Node = NodeBase & {
+  children?: Node[]
+  text?: string
+}
+
+export type Page = { id: string; name: string; root: Node }
+
+export type Document = { pages: Page[] }
+
+export type RectPatch = Partial<Pick<NodeBase, 'x' | 'y' | 'width' | 'height'>>
+
+export function findNode(root: Node, id: string): Node | null {
+  if (root.id === id) return root
+  if (root.children) {
+    for (const child of root.children) {
+      const found = findNode(child, id)
+      if (found) return found
+    }
+  }
+  return null
+}

--- a/apps/builder/lib/figma/store.ts
+++ b/apps/builder/lib/figma/store.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand'
+import type { Document, Node, MotionInline, RectPatch } from './model'
+import { findNode } from './model'
+
+// simple initial document
+const emptyDoc: Document = {
+  pages: [
+    {
+      id: 'page-1',
+      name: 'Page 1',
+      root: { id: 'root', type: 'FRAME', x: 0, y: 0, width: 0, height: 0 },
+    },
+  ],
+}
+
+type State = {
+  doc: Document
+  selectedIds: string[]
+  editingTextId?: string | null
+  ghostRect?: { id: string; x: number; y: number; width: number; height: number } | null
+  // derived
+  selectedNode: Node | null
+  // actions
+  select: (ids: string[], additive?: boolean) => void
+  clearSelect: () => void
+  startEditingText: (id: string) => void
+  stopEditingText: () => void
+  setTextContent: (id: string, value: string) => void
+  setNodeRect: (id: string, patch: RectPatch) => void
+  beginTransform: (id: string) => void
+  setGhostRect: (rect: { id: string; x: number; y: number; width: number; height: number }) => void
+  commitGhost: () => void
+  cancelGhost: () => void
+  setNodeMotion: (id: string, patch: Partial<MotionInline>) => void
+  undo: () => void
+  redo: () => void
+}
+
+export const useFigmaStore = create<State>((set, get) => ({
+  doc: emptyDoc,
+  selectedIds: [],
+  editingTextId: null,
+  ghostRect: null,
+  selectedNode: null,
+  select: (ids, additive) =>
+    set((state) => {
+      const newIds = additive ? Array.from(new Set([...state.selectedIds, ...ids])) : ids
+      const page = state.doc.pages[0]
+      return {
+        selectedIds: newIds,
+        selectedNode: newIds[0] ? findNode(page.root, newIds[0]) : null,
+      }
+    }),
+  clearSelect: () => set({ selectedIds: [], selectedNode: null }),
+  startEditingText: (id) => set({ editingTextId: id }),
+  stopEditingText: () => set({ editingTextId: null }),
+  setTextContent: (id, value) =>
+    set((s) => {
+      const page = s.doc.pages[0]
+      const node = findNode(page.root, id)
+      if (node) (node as any).text = value
+      return { doc: { ...s.doc } }
+    }),
+  setNodeRect: (id, patch) =>
+    set((s) => {
+      const page = s.doc.pages[0]
+      const node = findNode(page.root, id)
+      if (node) Object.assign(node, patch)
+      return { doc: { ...s.doc } }
+    }),
+  beginTransform: (_id) => {},
+  setGhostRect: (rect) => set({ ghostRect: rect }),
+  commitGhost: () =>
+    set((s) => {
+      const ghost = s.ghostRect
+      if (!ghost) return {}
+      const page = s.doc.pages[0]
+      const node = findNode(page.root, ghost.id)
+      if (node) Object.assign(node, ghost)
+      return { ghostRect: null, doc: { ...s.doc } }
+    }),
+  cancelGhost: () => set({ ghostRect: null }),
+  setNodeMotion: (id, patch) =>
+    set((s) => {
+      const page = s.doc.pages[0]
+      const node = findNode(page.root, id)
+      if (node) {
+        // shallow merge for motion + options (v0)
+        const base: any = (node as any).motion ?? {}
+        const merged = {
+          ...base,
+          ...patch,
+          options: { ...(base.options ?? {}), ...(patch.options ?? {}) },
+        }
+        ;(node as any).motion = merged
+      }
+      return { doc: { ...s.doc } }
+    }),
+  undo: () => {},
+  redo: () => {},
+}))


### PR DESCRIPTION
## Summary
- add motion type definitions to figma model and expose motion property on nodes
- support updating node motion through zustand store
- introduce MotionPanel and integrate into RightPanel

## Testing
- `pnpm test`
- `pnpm lint:all`


------
https://chatgpt.com/codex/tasks/task_e_68c14e2d5128832c9d64adce6451d0e3