### PR TITLE
feat: add experimental figma dev page

### DIFF
--- a/apps/builder/components/figma/Canvas.tsx
+++ b/apps/builder/components/figma/Canvas.tsx
@@ -3,6 +3,8 @@ import { useFigmaStore } from '../../lib/figma/store'
 import InlineTextEditor from './InlineTextEditor'
 import type { Node } from '../../lib/figma/model'
 import { useMemo } from 'react'
+import { useState } from 'react'
+import { useFigmaDevStore, type FigmaDevNode } from '../../lib/figma/store'
 
 function NodeBox({ node }: { node: Node }) {
   const select = useFigmaStore((s) => s.select)
@@ -65,6 +67,71 @@ export default function Canvas() {
         boxShadow: '0 0 0 1px rgba(0,0,0,0.06), 0 2px 12px rgba(0,0,0,0.08)',
       }}>
         <NodeBox node={root} />
+      </div>
+    </div>
+  )
+}
+
+function DevNodeBox({ node }: { node: FigmaDevNode }) {
+  const selectNode = useFigmaDevStore((s) => s.selectNode)
+  const selectedId = useFigmaDevStore((s) => s.selectedId)
+  const updateNode = useFigmaDevStore((s) => s.updateNode)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(node.text ?? '')
+  const isSelected = selectedId === node.id
+  const onDoubleClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation()
+    if (node.type === 'TEXT') {
+      setEditing(true)
+      setDraft(node.text ?? '')
+    }
+  }
+  const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === 'Enter') {
+      updateNode(node.id, { text: draft })
+      setEditing(false)
+    } else if (e.key === 'Escape') {
+      setEditing(false)
+      setDraft(node.text ?? '')
+    }
+  }
+  return (
+    <div
+      data-node-id={node.id}
+      style={{ position: 'absolute', left: node.x, top: node.y, width: node.w, height: node.h }}
+      onClick={(e) => {
+        e.stopPropagation()
+        selectNode(node.id)
+      }}
+      onDoubleClick={onDoubleClick}
+      className={isSelected ? 'outline outline-1 outline-blue-500' : ''}
+    >
+      {node.type === 'TEXT' && (
+        editing ? (
+          <input
+            className="w-full h-full text-sm"
+            value={draft}
+            autoFocus
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onKeyDown}
+          />
+        ) : (
+          <div className="text-sm select-none cursor-text">{node.text}</div>
+        )
+      )}
+    </div>
+  )
+}
+
+export function DevCanvas() {
+  const nodes = useFigmaDevStore((s) => s.nodes)
+  const selectNode = useFigmaDevStore((s) => s.selectNode)
+  return (
+    <div className="flex-1 overflow-auto bg-white" onClick={() => selectNode(null)}>
+      <div className="relative w-[2000px] h-[2000px]">
+        {nodes.map((n) => (
+          <DevNodeBox key={n.id} node={n} />
+        ))}
       </div>
     </div>
   )

--- a/apps/builder/lib/figma/store.ts
+++ b/apps/builder/lib/figma/store.ts
@@ -152,3 +152,32 @@ export const useFigmaStore = create<State>((set, get) => ({
     /* stub */
   },
 }))
+
+export type FigmaDevNode = {
+  id: string
+  type: 'TEXT' | 'RECT'
+  x: number
+  y: number
+  w: number
+  h: number
+  text?: string
+}
+
+type FigmaDevState = {
+  nodes: FigmaDevNode[]
+  selectedId: string | null
+  addNode: (node: FigmaDevNode) => void
+  updateNode: (id: string, patch: Partial<FigmaDevNode>) => void
+  selectNode: (id: string | null) => void
+}
+
+export const useFigmaDevStore = create<FigmaDevState>((set) => ({
+  nodes: [],
+  selectedId: null,
+  addNode: (node) => set((s) => ({ nodes: [...s.nodes, node] })),
+  updateNode: (id, patch) =>
+    set((s) => ({
+      nodes: s.nodes.map((n) => (n.id === id ? { ...n, ...patch } : n)),
+    })),
+  selectNode: (id) => set({ selectedId: id }),
+}))

--- a/apps/builder/pages/dev/figma.tsx
+++ b/apps/builder/pages/dev/figma.tsx
@@ -1,0 +1,24 @@
+import { DevCanvas } from '../../components/figma/Canvas'
+import { useFigmaDevStore } from '../../lib/figma/store'
+
+export default function FigmaDevPage() {
+  if (process.env.NEXT_PUBLIC_FIGMA !== '1') {
+    return null
+  }
+  const addNode = useFigmaDevStore((s) => s.addNode)
+  const addText = () => {
+    const id = `node-${Date.now()}`
+    addNode({ id, type: 'TEXT', x: 40, y: 40, w: 120, h: 24, text: 'Text' })
+  }
+  return (
+    <div className="flex h-screen">
+      <div className="w-48 border-r p-2">
+        <button onClick={addText} className="mb-2 rounded border px-2 py-1 text-sm">
+          + Text
+        </button>
+      </div>
+      <DevCanvas />
+      <div className="w-60 border-l" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/dev/figma` dev page with simple layout and text node palette
- extend figma store with minimal node management helpers
- expose `DevCanvas` component with inline text editing and node IDs

## Testing
- `pnpm test:unit` *(fails: save state machine idle→queued test)*

------
https://chatgpt.com/codex/tasks/task_e_68c163aa2088832c8d23bb1fc8ea17a2