### PR TITLE
feat: add shadow array UI

### DIFF
--- a/apps/builder/components/figma/Canvas.tsx
+++ b/apps/builder/components/figma/Canvas.tsx
@@ -31,13 +31,23 @@ function NodeBox({ node }: { node: Node }) {
       if (typeof s.radius === 'number') return s.radius
       return `${s.radius.tl}px ${s.radius.tr}px ${s.radius.br}px ${s.radius.bl}px`
     })()
-    const boxShadow = s.shadows
-      ? s.shadows
-          .map((sh) =>
-            `${sh.x}px ${sh.y}px ${sh.blur}px ${sh.spread}px ${sh.color}`
+    const boxShadow = (() => {
+      if (s.shadows) {
+        return s.shadows
+          .map(
+            (sh) =>
+              `${sh.x}px ${sh.y}px ${sh.blur}px ${sh.spread}px ${sh.color}`
           )
           .join(', ')
-      : undefined
+      }
+      const sh: any = s.shadow
+      if (sh) {
+        return typeof sh === 'string'
+          ? sh
+          : `${sh.x}px ${sh.y}px ${sh.blur}px ${sh.spread}px ${sh.color}`
+      }
+      return undefined
+    })()
     const transform = `translate(${node.x}px, ${node.y}px)` +
       ` rotate(${s.rotateDeg ?? 0}deg)` +
       ` skew(${s.skewXDeg ?? 0}deg, ${s.skewYDeg ?? 0}deg)` +

--- a/apps/builder/components/figma/RightPanel.tsx
+++ b/apps/builder/components/figma/RightPanel.tsx
@@ -86,6 +86,7 @@ export default function RightPanel() {
   const updateNodeStyle = useFigmaStore((s) => s.updateNodeStyle)
   const pushShadow = useFigmaStore((s) => s.pushShadow)
   const removeShadowAt = useFigmaStore((s) => s.removeShadowAt)
+  const moveShadow = useFigmaStore((s) => s.moveShadow)
   const setNodeMotion = useFigmaStore((s) => s.setNodeMotion)
 
   const [linkedRadius, setLinkedRadius] = useState(true)
@@ -119,7 +120,14 @@ export default function RightPanel() {
 
   const updateShadow = (idx: number, patch: Partial<Shadow>) => {
     const shadows = selected.style?.shadows ? [...selected.style.shadows] : []
-    const base = shadows[idx] || { x: 0, y: 0, blur: 0, spread: 0, color: '#000000' }
+    const base =
+      shadows[idx] || {
+        x: 0,
+        y: 4,
+        blur: 12,
+        spread: 0,
+        color: 'rgba(0,0,0,0.1)',
+      }
     shadows[idx] = { ...base, ...patch }
     updateNodeStyle(selected.id, { shadows })
   }
@@ -199,10 +207,10 @@ export default function RightPanel() {
           <div className="flex items-center justify-between py-1 text-sm">
             <span className="text-gray-500">Shadows</span>
             <button className="border rounded px-1 text-xs" onClick={() => pushShadow(selected.id)}>
-              + Add
+              + Add Shadow
             </button>
           </div>
-          {(selected.style?.shadows ?? []).map((sh, i) => (
+          {(selected.style?.shadows ?? []).map((sh, i, arr) => (
             <div key={i} className="flex items-center space-x-1">
               <input
                 type="number"
@@ -234,9 +242,28 @@ export default function RightPanel() {
                 value={sh.color}
                 onChange={(e) => updateShadow(i, { color: e.target.value })}
               />
-              <button className="border rounded px-1 text-xs" onClick={() => removeShadowAt(selected.id, i)}>
-                -
-              </button>
+              <div className="flex items-center space-x-1">
+                <button
+                  className="border rounded px-1 text-xs"
+                  disabled={i === 0}
+                  onClick={() => moveShadow(selected.id, i, i - 1)}
+                >
+                  ↑
+                </button>
+                <button
+                  className="border rounded px-1 text-xs"
+                  disabled={i === arr.length - 1}
+                  onClick={() => moveShadow(selected.id, i, i + 1)}
+                >
+                  ↓
+                </button>
+                <button
+                  className="border rounded px-1 text-xs"
+                  onClick={() => removeShadowAt(selected.id, i)}
+                >
+                  -
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/apps/builder/lib/figma/model.ts
+++ b/apps/builder/lib/figma/model.ts
@@ -21,6 +21,7 @@ export type NodeStyle = {
   strokeWidth?: number
   radius?: CornerRadius
   opacity?: number
+  shadow?: Shadow | string
   shadows?: Shadow[]
   mixBlendMode?: React.CSSProperties['mixBlendMode']
   filter?: string

--- a/apps/builder/lib/figma/store.spec.ts
+++ b/apps/builder/lib/figma/store.spec.ts
@@ -34,4 +34,17 @@ describe('shadow helpers', () => {
     node = useFigmaStore.getState().doc.pages[0].root.children[0]
     expect(node.style.shadows.length).toBe(0)
   })
+
+  it('reorders shadows', () => {
+    const id = 't1'
+    useFigmaStore.getState().updateNodeStyle(id, {
+      shadows: [
+        { x: 1, y: 1, blur: 2, spread: 0, color: '#111' },
+        { x: 2, y: 2, blur: 4, spread: 0, color: '#222' },
+      ],
+    })
+    useFigmaStore.getState().moveShadow(id, 0, 1)
+    const node: any = useFigmaStore.getState().doc.pages[0].root.children[0]
+    expect(node.style.shadows[0].color).toBe('#222')
+  })
 })

--- a/apps/builder/lib/figma/store.ts
+++ b/apps/builder/lib/figma/store.ts
@@ -67,6 +67,7 @@ type State = {
   updateNodeStyle: (id: string, patch: Partial<NodeStyle>) => void
   pushShadow: (id: string, shadow?: Shadow) => void
   removeShadowAt: (id: string, idx: number) => void
+  moveShadow: (id: string, from: number, to: number) => void
   beginTransform: (id: string) => void
   setGhostRect: (rect: { id: string; x: number; y: number; width: number; height: number }) => void
   commitGhost: () => void
@@ -168,7 +169,13 @@ export const useFigmaStore = create<State>()(
             const style = node.style ?? (node.style = {})
             const arr: Shadow[] = style.shadows ?? (style.shadows = [])
             arr.push(
-              shadow ?? { x: 0, y: 0, blur: 0, spread: 0, color: 'rgba(0,0,0,0.25)' }
+              shadow ?? {
+                x: 0,
+                y: 4,
+                blur: 12,
+                spread: 0,
+                color: 'rgba(0,0,0,0.1)',
+              }
             )
           }
           return { doc: { ...s.doc } }
@@ -179,6 +186,20 @@ export const useFigmaStore = create<State>()(
           const node: any = findNode(page.root, id)
           if (node?.style?.shadows) {
             node.style.shadows = node.style.shadows.filter((_: any, i: number) => i !== idx)
+          }
+          return { doc: { ...s.doc } }
+        }),
+      moveShadow: (id, from, to) =>
+        set((s) => {
+          const page = s.doc.pages[0]
+          const node: any = findNode(page.root, id)
+          if (node?.style?.shadows) {
+            const arr = node.style.shadows
+            const len = arr.length
+            if (from >= 0 && from < len && to >= 0 && to < len && from !== to) {
+              const [sp] = arr.splice(from, 1)
+              arr.splice(to, 0, sp)
+            }
           }
           return { doc: { ...s.doc } }
         }),


### PR DESCRIPTION
## Summary
- support legacy `style.shadow` with new `shadow?` style type
- allow adding, removing, and reordering multiple shadows
- handle shadow array in canvas rendering and store

## Testing
- `pnpm test:unit` *(fails: save state machine idle→queued→offline→flushing→saved)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c80b7b94832c8d70dc4aa69037bf