### PR TITLE
feat(builder): add transform controls

### DIFF
--- a/apps/builder/components/figma/Canvas.tsx
+++ b/apps/builder/components/figma/Canvas.tsx
@@ -38,10 +38,24 @@ function NodeBox({ node }: { node: Node }) {
           )
           .join(', ')
       : undefined
-    const transform = `translate(${node.x}px, ${node.y}px)` +
-      ` rotate(${s.rotateDeg ?? 0}deg)` +
-      ` skew(${s.skewXDeg ?? 0}deg, ${s.skewYDeg ?? 0}deg)` +
-      ` scale(${s.scaleX ?? 1}, ${s.scaleY ?? 1})`
+    const transform = [
+      `translate(${node.x}px, ${node.y}px)`,
+      `rotate(${s.rotateDeg ?? 0}deg)`,
+      `skew(${s.skewXDeg ?? 0}deg, ${s.skewYDeg ?? 0}deg)`,
+      `scale(${s.scaleX ?? 1}, ${s.scaleY ?? 1})`,
+    ].join(' ')
+    const originMap = {
+      TL: 'top left',
+      TC: 'top center',
+      TR: 'top right',
+      CL: 'center left',
+      C: 'center',
+      CR: 'center right',
+      BL: 'bottom left',
+      BC: 'bottom center',
+      BR: 'bottom right',
+    } as const
+    const transformOrigin = originMap[s.transformOrigin ?? 'TL']
     const transition = node.motion?.transition
       ?.map(
         (t) =>
@@ -53,7 +67,7 @@ function NodeBox({ node }: { node: Node }) {
       width: node.width,
       height: node.height,
       transform,
-      transformOrigin: 'top left',
+      transformOrigin,
       opacity: s.opacity,
       borderRadius: radius,
       background: bg,

--- a/apps/builder/components/figma/RightPanel.tsx
+++ b/apps/builder/components/figma/RightPanel.tsx
@@ -150,6 +150,52 @@ export default function RightPanel() {
         <NumberInput label="H" value={selected.height} onChange={(n) => updateNode(selected.id, { height: n })} />
       </div>
       <div className="space-y-1">
+        <div className="text-xs uppercase tracking-wider text-gray-400">Transform</div>
+        <NumberInput
+          label="Rotate"
+          value={selected.style?.rotateDeg ?? 0}
+          onChange={(v) => updateNodeStyle(selected.id, { rotateDeg: v })}
+        />
+        <NumberInput
+          label="ScaleX"
+          value={selected.style?.scaleX ?? 1}
+          onChange={(v) => updateNodeStyle(selected.id, { scaleX: v })}
+        />
+        <NumberInput
+          label="ScaleY"
+          value={selected.style?.scaleY ?? 1}
+          onChange={(v) => updateNodeStyle(selected.id, { scaleY: v })}
+        />
+        <NumberInput
+          label="SkewX"
+          value={selected.style?.skewXDeg ?? 0}
+          onChange={(v) => updateNodeStyle(selected.id, { skewXDeg: v })}
+        />
+        <NumberInput
+          label="SkewY"
+          value={selected.style?.skewYDeg ?? 0}
+          onChange={(v) => updateNodeStyle(selected.id, { skewYDeg: v })}
+        />
+        <label className="flex items-center justify-between py-1 text-sm">
+          <span className="text-gray-500">Origin</span>
+          <select
+            className="w-40 border rounded px-2 py-1 text-sm"
+            value={selected.style?.transformOrigin ?? 'TL'}
+            onChange={(e) =>
+              updateNodeStyle(selected.id, {
+                transformOrigin: e.target.value as any,
+              })
+            }
+          >
+            {['TL', 'TC', 'TR', 'CL', 'C', 'CR', 'BL', 'BC', 'BR'].map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="space-y-1">
         <div className="text-xs uppercase tracking-wider text-gray-400">Style</div>
         <ColorInput label="Fill" value={typeof selected.style?.fill === 'string' ? selected.style?.fill : ''} onChange={(v) => updateNodeStyle(selected.id, { fill: v })} />
         <ColorInput label="Stroke" value={selected.style?.stroke} onChange={(v) => updateNodeStyle(selected.id, { stroke: v })} />

--- a/apps/builder/lib/figma/model.ts
+++ b/apps/builder/lib/figma/model.ts
@@ -30,6 +30,7 @@ export type NodeStyle = {
   scaleY?: number
   skewXDeg?: number
   skewYDeg?: number
+  transformOrigin?: 'TL' | 'TC' | 'TR' | 'CL' | 'C' | 'CR' | 'BL' | 'BC' | 'BR'
   backgroundImage?: string
   backgroundSize?: string
   backgroundPosition?: string


### PR DESCRIPTION
## Summary
- add rotate/scale/skew/origin transform controls in RightPanel
- apply new transform properties and origin in Canvas
- extend NodeStyle with transform origin

## Testing
- `pnpm test:unit` *(fails: expected 'queued' state)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c82abf84832c84fbf2dfb833a476