### PR TITLE
feat: add theme panel with token validators

### DIFF
--- a/apps/builder/components/ThemePanel.tsx
+++ b/apps/builder/components/ThemePanel.tsx
@@ -1,0 +1,89 @@
+'use client'
+import React from 'react'
+import { useFigmaStore } from '../lib/figma/store'
+import ColorInput from './ui/ColorInput'
+import { isColorLike, isPxLike } from '../lib/figma/tokenValidators'
+
+type TokenEntry = { key: string; value: any }
+
+export default function ThemePanel() {
+  const tokens = useFigmaStore((s) => s.doc.tokens || {})
+
+  const setToken = (name: string, value: string | number) => {
+    useFigmaStore.setState((s) => ({
+      doc: {
+        ...s.doc,
+        tokens: { ...(s.doc.tokens || {}), [name]: value },
+      },
+    }))
+  }
+
+  const grouped = React.useMemo(() => {
+    const g: Record<string, TokenEntry[]> = {}
+    Object.entries(tokens).forEach(([full, value]) => {
+      const [prefix, ...rest] = full.split('.')
+      const key = rest.join('.')
+      ;(g[prefix] || (g[prefix] = [])).push({ key, value })
+    })
+    return g
+  }, [tokens])
+
+  const renderToken = (group: string, key: string, value: any) => {
+    const fullKey = `${group}.${key}`
+    const warn =
+      group === 'color'
+        ? !isColorLike(String(value))
+        : group === 'radius' || group === 'stroke'
+        ? !isPxLike(value)
+        : false
+    return (
+      <div key={key} className="flex items-center space-x-2 py-1">
+        <label className="w-24 capitalize">{key}</label>
+        {group === 'color' ? (
+          <ColorInput value={String(value)} onChange={(v) => setToken(fullKey, v)} />
+        ) : group === 'shadow' ? (
+          <>
+            <input
+              type="text"
+              className="border rounded px-1 py-0.5 flex-1"
+              value={String(value)}
+              onChange={(e) => setToken(fullKey, e.target.value)}
+            />
+            <div className="w-6 h-6 border rounded" style={{ boxShadow: String(value) }} />
+          </>
+        ) : (
+          <input
+            type="text"
+            className="border rounded px-1 py-0.5 flex-1"
+            value={String(value)}
+            onChange={(e) => setToken(fullKey, e.target.value)}
+          />
+        )}
+        {warn && <span className="text-xs text-orange-600">!</span>}
+      </div>
+    )
+  }
+
+  const colorPins = ['base', 'main', 'accent']
+
+  return (
+    <div className="p-4 space-y-4 text-sm">
+      <div>
+        <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Color</div>
+        {colorPins.map((p) => renderToken('color', p, tokens[`color.${p}`] ?? ''))}
+        {grouped.color
+          ?.filter((t) => !colorPins.includes(t.key))
+          .map((t) => renderToken('color', t.key, t.value))}
+      </div>
+      {(['radius', 'stroke', 'shadow', 'font', 'opacity', 'blend'] as const).map(
+        (g) =>
+          grouped[g] && (
+            <div key={g}>
+              <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">{g}</div>
+              {grouped[g]!.map((t) => renderToken(g, t.key, t.value))}
+            </div>
+          )
+      )}
+    </div>
+  )
+}

--- a/apps/builder/components/ui/ColorInput.tsx
+++ b/apps/builder/components/ui/ColorInput.tsx
@@ -1,0 +1,30 @@
+'use client'
+import React from 'react'
+
+const HEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+type Props = {
+  value?: string
+  onChange: (v: string) => void
+}
+
+// Renders a color picker with text fallback for non-hex values.
+export default function ColorInput({ value = '', onChange }: Props) {
+  const isHex = HEX.test(value)
+  return (
+    <div className="flex items-center space-x-1">
+      <input
+        type="color"
+        value={isHex ? value : '#000000'}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-8 h-8 p-0 border rounded"
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="border rounded px-1 py-0.5 w-24"
+      />
+    </div>
+  )
+}

--- a/apps/builder/lib/figma/tokenValidators.ts
+++ b/apps/builder/lib/figma/tokenValidators.ts
@@ -1,0 +1,16 @@
+export function isColorLike(v: unknown): boolean {
+  if (typeof v !== 'string') return false
+  const s = v.trim()
+  return (
+    /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(s) ||
+    /^rgb(a)?\(/i.test(s) ||
+    /^hsl(a)?\(/i.test(s)
+  )
+}
+
+export function isPxLike(v: unknown): boolean {
+  if (typeof v === 'number') return true
+  if (typeof v !== 'string') return false
+  const s = v.trim()
+  return /^-?\d+(\.\d+)?px$/.test(s) || /^-?\d+(\.\d+)?$/.test(s)
+}


### PR DESCRIPTION
## Summary
- add ColorInput component for hex colors with text fallback
- implement ThemePanel with grouped tokens, pinned colors, and shadow previews
- add token validators for color and px values

## Testing
- `pnpm test:unit`
- `pnpm test:e2e apps/builder` (fails: MissingUnicodeEscape in playwright config)


------
https://chatgpt.com/codex/tasks/task_e_68c4c7e64b38832c8838e0c8b6ef3868