### PR TITLE
feat: add dark theme preset and toggle

### DIFF
--- a/web/components/theme/ThemePanel.tsx
+++ b/web/components/theme/ThemePanel.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { useThemeStore } from '@/stores/themeStore'
+
+export default function ThemePanel() {
+  const themeId = useThemeStore((s) => s.themeId)
+  const setTheme = useThemeStore((s) => s.setTheme)
+  return (
+    <div className="flex gap-2">
+      <button
+        className={themeId === 'theme-default' ? 'font-bold' : ''}
+        onClick={() => setTheme('theme-default')}
+      >
+        Light
+      </button>
+      <button
+        className={themeId === 'theme-default-dark' ? 'font-bold' : ''}
+        onClick={() => setTheme('theme-default-dark')}
+      >
+        Dark
+      </button>
+    </div>
+  )
+}

--- a/web/stores/themeStore.ts
+++ b/web/stores/themeStore.ts
@@ -16,7 +16,21 @@ export type ThemeState = {
   applyUserSkin: (tokens: Partial<ThemeTokens>) => void;
 };
 
+const STORAGE_KEY = 'activeThemeId';
+
 const THEMES: Record<string, ThemeTokens> = {
+  'theme-default': {
+    color: { base: '#ffffff', main: '#111827', accent: '#2563eb' },
+    radius: { sm: 4, md: 8 },
+    spacing: { md: 8, lg: 16 },
+    font: { base: 'Inter, sans-serif' },
+  },
+  'theme-default-dark': {
+    color: { base: '#111827', main: '#f9fafb', accent: '#2563eb' },
+    radius: { sm: 4, md: 8 },
+    spacing: { md: 8, lg: 16 },
+    font: { base: 'Inter, sans-serif' },
+  },
   geokore: {
     color: { primary: '#2563eb' },
     radius: { sm: 4, md: 8 },
@@ -38,11 +52,14 @@ const THEMES: Record<string, ThemeTokens> = {
 };
 
 function detectInitialTheme(): string {
-  if (typeof window === 'undefined') return 'geokore';
+  if (typeof window === 'undefined') return 'theme-default';
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored && THEMES[stored]) return stored;
   const host = window.location.hostname;
   if (host.includes('tamadigi')) return 'tamadigi';
   if (host.includes('tamalogi')) return 'tamalogi';
-  return 'geokore';
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'theme-default-dark' : 'theme-default';
 }
 
 export const useThemeStore = create<ThemeState>((set) => {
@@ -51,7 +68,10 @@ export const useThemeStore = create<ThemeState>((set) => {
     themeId: id,
     themeTokens: THEMES[id],
     setTheme: (nextId) => {
-      const tokens = THEMES[nextId] ?? THEMES.geokore;
+      const tokens = THEMES[nextId] ?? THEMES['theme-default'];
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, nextId);
+      }
       set({ themeId: nextId, themeTokens: tokens });
     },
     applyUserSkin: (tokens) =>


### PR DESCRIPTION
## Summary
- add `theme-default-dark` theme preset and localStorage-backed selection
- provide ThemePanel component with Light/Dark switch

## Testing
- `pnpm test:unit` *(fails: apps/builder/lib/save/stateMachine.spec.ts - expected 'queued')*

------
https://chatgpt.com/codex/tasks/task_e_68c4c7f81108832cbf2a332ed96887d8