### PR TITLE
feat: add gradient editor

### DIFF
--- a/apps/builder/components/figma/Canvas.tsx
+++ b/apps/builder/components/figma/Canvas.tsx
@@ -17,6 +17,7 @@ function NodeBox({ node }: { node: Node }) {
   const style: React.CSSProperties = useMemo(() => {
     const s = node.style ?? {}
     const bg = (() => {
+      if (node.type === 'TEXT') return undefined
       if (!s.fill) return undefined
       if (typeof s.fill === 'string') return s.fill
       const stops = s.fill.stops

--- a/apps/builder/components/figma/RightPanel.tsx
+++ b/apps/builder/components/figma/RightPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useState, useEffect } from 'react'
 import { useFigmaStore } from '../../lib/figma/store'
-import type { Shadow } from '../../lib/figma/model'
+import type { Shadow, GradientFill } from '../../lib/figma/model'
 
 function NumberInput({
   label,
@@ -48,6 +48,115 @@ function TextInput({
 }
 
 const ColorInput = TextInput
+
+function gradientToCss(g: GradientFill): string {
+  const stops = g.stops.map((st) => `${st.color} ${st.offset * 100}%`).join(', ')
+  return g.type === 'linear'
+    ? `linear-gradient(${g.angle ?? 0}deg, ${stops})`
+    : `radial-gradient(${stops})`
+}
+
+function parseGradient(str?: string): GradientFill | null {
+  if (!str) return null
+  const lin = str.match(/^linear-gradient\(([-0-9.]+)deg,\s*(.+)\)$/)
+  if (lin) {
+    const angle = parseFloat(lin[1])
+    const stops = lin[2].split(/,\s*/).map((s) => {
+      const [color, offset] = s.trim().split(/\s+/)
+      return { color, offset: parseFloat(offset) / 100 }
+    })
+    return { type: 'linear', angle, stops }
+  }
+  const rad = str.match(/^radial-gradient\((.+)\)$/)
+  if (rad) {
+    const stops = rad[1].split(/,\s*/).map((s) => {
+      const [color, offset] = s.trim().split(/\s+/)
+      return { color, offset: parseFloat(offset) / 100 }
+    })
+    return { type: 'radial', stops }
+  }
+  return null
+}
+
+function GradientEditor({
+  value,
+  onChange,
+}: {
+  value?: string
+  onChange: (v: string) => void
+}) {
+  const fallback: GradientFill = {
+    type: 'linear',
+    angle: 0,
+    stops: [
+      { color: '#ff0000', offset: 0 },
+      { color: '#0000ff', offset: 1 },
+    ],
+  }
+  const [grad, setGrad] = useState<GradientFill>(() => parseGradient(value) ?? fallback)
+  useEffect(() => {
+    const parsed = parseGradient(value)
+    if (parsed) setGrad(parsed)
+  }, [value])
+  const css = gradientToCss(grad)
+  const update = (patch: Partial<GradientFill>) => {
+    const g = { ...grad, ...patch }
+    setGrad(g)
+    onChange(gradientToCss(g))
+  }
+  const updateStop = (idx: number, patch: Partial<GradientFill['stops'][number]>) => {
+    const stops = grad.stops.map((st, i) => (i === idx ? { ...st, ...patch } : st))
+    update({ stops })
+  }
+  const addStop = () => update({ stops: [...grad.stops, { color: '#000000', offset: 0.5 }] })
+  const removeStop = (idx: number) => update({ stops: grad.stops.filter((_, i) => i !== idx) })
+  return (
+    <div className="py-1 text-sm space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-gray-500">Fill</span>
+        <div className="flex items-center space-x-1">
+          <div className="w-8 h-5 border" style={{ background: css }} />
+          <select
+            value={grad.type}
+            onChange={(e) => update({ type: e.target.value as 'linear' | 'radial' })}
+            className="border rounded px-1 text-xs"
+          >
+            <option value="linear">linear</option>
+            <option value="radial">radial</option>
+          </select>
+        </div>
+      </div>
+      {grad.type === 'linear' && (
+        <NumberInput label="Angle" value={grad.angle ?? 0} onChange={(v) => update({ angle: v })} />
+      )}
+      <div className="space-y-1">
+        {grad.stops.map((st, i) => (
+          <div key={i} className="flex items-center space-x-1">
+            <input
+              type="color"
+              value={st.color}
+              onChange={(e) => updateStop(i, { color: e.target.value })}
+            />
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={Math.round(st.offset * 100)}
+              onChange={(e) => updateStop(i, { offset: Number(e.target.value) / 100 })}
+              className="w-16 border rounded px-1 py-1 text-right"
+            />
+            <button className="border rounded px-1 text-xs" onClick={() => removeStop(i)}>
+              -
+            </button>
+          </div>
+        ))}
+        <button className="border rounded px-1 text-xs" onClick={addStop}>
+          + Stop
+        </button>
+      </div>
+    </div>
+  )
+}
 
 function Slider({
   label,
@@ -151,7 +260,10 @@ export default function RightPanel() {
       </div>
       <div className="space-y-1">
         <div className="text-xs uppercase tracking-wider text-gray-400">Style</div>
-        <ColorInput label="Fill" value={typeof selected.style?.fill === 'string' ? selected.style?.fill : ''} onChange={(v) => updateNodeStyle(selected.id, { fill: v })} />
+        <GradientEditor
+          value={typeof selected.style?.fill === 'string' ? selected.style?.fill : undefined}
+          onChange={(v) => updateNodeStyle(selected.id, { fill: v })}
+        />
         <ColorInput label="Stroke" value={selected.style?.stroke} onChange={(v) => updateNodeStyle(selected.id, { stroke: v })} />
         <NumberInput label="Stroke W" value={selected.style?.strokeWidth ?? 0} onChange={(v) => updateNodeStyle(selected.id, { strokeWidth: v })} />
         <div className="flex items-center justify-between py-1 text-sm">


### PR DESCRIPTION
## Summary
- add gradient editor with type, angle and color stops
- avoid background fill for text nodes

## Testing
- `pnpm test:unit` *(fails: expected 'idle' to be 'queued')*


------
https://chatgpt.com/codex/tasks/task_e_68c4c81372a8832cbd9b189a7f04e993