### PR TITLE
feat: add align and distribute actions

### DIFF
--- a/apps/builder/components/figma/RightPanel.tsx
+++ b/apps/builder/components/figma/RightPanel.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react'
 import { useFigmaStore } from '../../lib/figma/store'
 import type { Shadow } from '../../lib/figma/model'
+import { alignSelected, distributeSelected } from '../../lib/figma/alignActions'
 
 function NumberInput({
   label,
@@ -81,6 +82,7 @@ function Slider({
 }
 
 export default function RightPanel() {
+  const selectedIds = useFigmaStore((s) => s.selectedIds)
   const selected = useFigmaStore((s) => s.selectedNode)
   const updateNode = useFigmaStore((s) => s.updateNode)
   const updateNodeStyle = useFigmaStore((s) => s.updateNodeStyle)
@@ -93,11 +95,50 @@ export default function RightPanel() {
     setLinkedRadius(typeof selected?.style?.radius !== 'object')
   }, [selected?.id])
 
-  if (!selected) {
+  if (!selectedIds.length) {
     return (
       <div className="p-4 text-sm text-gray-500">
         <div className="font-semibold text-gray-700 mb-2">Properties</div>
         <p>No selection</p>
+      </div>
+    )
+  }
+
+  if (selectedIds.length > 1) {
+    const canDist = selectedIds.length >= 3
+    return (
+      <div className="p-4 space-y-2">
+        <div>
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Align</div>
+          <div className="flex flex-wrap gap-1">
+            <button className="border rounded px-2 h-7" onClick={() => alignSelected('left')}>L</button>
+            <button className="border rounded px-2 h-7" onClick={() => alignSelected('center')}>HC</button>
+            <button className="border rounded px-2 h-7" onClick={() => alignSelected('right')}>R</button>
+            <div className="w-[6px]" />
+            <button className="border rounded px-2 h-7" onClick={() => alignSelected('top')}>T</button>
+            <button className="border rounded px-2 h-7" onClick={() => alignSelected('middle')}>VC</button>
+            <button className="border rounded px-2 h-7" onClick={() => alignSelected('bottom')}>B</button>
+          </div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Distribute</div>
+          <div className="flex flex-wrap gap-1">
+            <button
+              className="border rounded px-2 h-7 disabled:opacity-50"
+              disabled={!canDist}
+              onClick={() => distributeSelected('horizontal')}
+            >
+              H
+            </button>
+            <button
+              className="border rounded px-2 h-7 disabled:opacity-50"
+              disabled={!canDist}
+              onClick={() => distributeSelected('vertical')}
+            >
+              V
+            </button>
+          </div>
+        </div>
       </div>
     )
   }

--- a/apps/builder/lib/figma/alignActions.spec.ts
+++ b/apps/builder/lib/figma/alignActions.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useFigmaStore } from './store'
+import { alignSelected, distributeSelected } from './alignActions'
+
+const baseDoc = structuredClone(useFigmaStore.getState().doc)
+
+beforeEach(() => {
+  useFigmaStore.setState({ doc: structuredClone(baseDoc), selectedIds: [] })
+})
+
+describe('alignSelected', () => {
+  it('aligns left', () => {
+    const page = useFigmaStore.getState().doc.pages[0]
+    page.root.children.push(
+      { id: 'r1', type: 'RECT', x: 100, y: 0, width: 10, height: 10 },
+      { id: 'r2', type: 'RECT', x: 150, y: 20, width: 10, height: 10 }
+    )
+    useFigmaStore.setState({ selectedIds: ['r1', 'r2'] })
+    alignSelected('left')
+    const n1: any = page.root.children.find((n) => n.id === 'r1')
+    const n2: any = page.root.children.find((n) => n.id === 'r2')
+    expect(n1.x).toBe(100)
+    expect(n2.x).toBe(100)
+  })
+})
+
+describe('distributeSelected', () => {
+  it('distributes horizontally', () => {
+    const page = useFigmaStore.getState().doc.pages[0]
+    page.root.children.push(
+      { id: 'a', type: 'RECT', x: 0, y: 0, width: 10, height: 10 },
+      { id: 'b', type: 'RECT', x: 40, y: 0, width: 10, height: 10 },
+      { id: 'c', type: 'RECT', x: 90, y: 0, width: 10, height: 10 }
+    )
+    useFigmaStore.setState({ selectedIds: ['a', 'b', 'c'] })
+    distributeSelected('horizontal')
+    const a: any = page.root.children.find((n) => n.id === 'a')
+    const b: any = page.root.children.find((n) => n.id === 'b')
+    const c: any = page.root.children.find((n) => n.id === 'c')
+    expect(a.x).toBe(0)
+    expect(b.x).toBeCloseTo(45)
+    expect(c.x).toBeCloseTo(90)
+  })
+})
+

--- a/apps/builder/lib/figma/alignActions.ts
+++ b/apps/builder/lib/figma/alignActions.ts
@@ -1,0 +1,87 @@
+import { useFigmaStore } from './store'
+import type { Node } from './model'
+
+function findNode(root: Node, id: string): Node | null {
+  if (root.id === id) return root
+  // @ts-expect-error runtime guard
+  if (root.children && Array.isArray(root.children)) {
+    for (const c of root.children) {
+      const r = findNode(c, id)
+      if (r) return r
+    }
+  }
+  return null
+}
+
+export type AlignMode = 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom'
+export type DistributeMode = 'horizontal' | 'vertical'
+
+export function alignSelected(mode: AlignMode) {
+  const s = useFigmaStore.getState()
+  const ids = s.selectedIds
+  if (ids.length < 2) return
+  const page = s.doc.pages[0]
+  const nodes = ids
+    .map((id) => findNode(page.root, id))
+    .filter(Boolean) as Node[]
+  if (nodes.length < 2) return
+  const xs = nodes.map((n) => n.x)
+  const ys = nodes.map((n) => n.y)
+  const rs = nodes.map((n) => n.x + n.width)
+  const bs = nodes.map((n) => n.y + n.height)
+  const minX = Math.min(...xs)
+  const minY = Math.min(...ys)
+  const maxR = Math.max(...rs)
+  const maxB = Math.max(...bs)
+  const cx = (minX + maxR) / 2
+  const cy = (minY + maxB) / 2
+  for (const n of nodes) {
+    const patch: { x?: number; y?: number } = {}
+    if (mode === 'left') patch.x = minX
+    if (mode === 'center') patch.x = cx - n.width / 2
+    if (mode === 'right') patch.x = maxR - n.width
+    if (mode === 'top') patch.y = minY
+    if (mode === 'middle') patch.y = cy - n.height / 2
+    if (mode === 'bottom') patch.y = maxB - n.height
+    s.updateNode(n.id, patch)
+  }
+}
+
+export function distributeSelected(mode: DistributeMode) {
+  const s = useFigmaStore.getState()
+  const ids = s.selectedIds
+  if (ids.length < 3) return
+  const page = s.doc.pages[0]
+  const nodes = ids
+    .map((id) => findNode(page.root, id))
+    .filter(Boolean) as Node[]
+  if (nodes.length < 3) return
+  if (mode === 'horizontal') {
+    const arr = nodes.slice().sort((a, b) => a.x - b.x)
+    const minX = Math.min(...arr.map((n) => n.x))
+    const maxR = Math.max(...arr.map((n) => n.x + n.width))
+    const totalW = arr.reduce((t, n) => t + n.width, 0)
+    const gap = (maxR - minX - totalW) / (arr.length - 1)
+    let cursor = minX
+    for (let i = 0; i < arr.length; i++) {
+      const n = arr[i]
+      const x = i === 0 ? n.x : cursor
+      s.updateNode(n.id, { x })
+      cursor = x + n.width + gap
+    }
+  } else {
+    const arr = nodes.slice().sort((a, b) => a.y - b.y)
+    const minY = Math.min(...arr.map((n) => n.y))
+    const maxB = Math.max(...arr.map((n) => n.y + n.height))
+    const totalH = arr.reduce((t, n) => t + n.height, 0)
+    const gap = (maxB - minY - totalH) / (arr.length - 1)
+    let cursor = minY
+    for (let i = 0; i < arr.length; i++) {
+      const n = arr[i]
+      const y = i === 0 ? n.y : cursor
+      s.updateNode(n.id, { y })
+      cursor = y + n.height + gap
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add align and distribute actions for multiple selections
- expose buttons in right panel to align or distribute nodes
- cover alignment helpers with tests

## Testing
- `pnpm test:unit` *(fails: apps/builder/lib/save/stateMachine.spec.ts: expected 'idle' to be 'queued')*
- `pnpm vitest apps/builder/lib/figma/alignActions.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c4c8235030832cafd0f409e5591fd5