### PR TITLE
feat: add grid and ruler overlays

### DIFF
--- a/web/components/hud/GridOverlay.tsx
+++ b/web/components/hud/GridOverlay.tsx
@@ -7,8 +7,10 @@ export function GridOverlay() {
   const zoom = useHudStore((s) => s.zoom)
   if (!show) return null
 
-  const base = 8 * zoom
-  const fine = Math.max(1, base)
+  // 基本ピッチ（8px）にズームを掛ける
+  const minor = Math.max(1, 8 * zoom)
+  // メジャーはマイナーの 5 倍間隔
+  const major = minor * 5
 
   return (
     <div
@@ -16,9 +18,16 @@ export function GridOverlay() {
       style={{
         backgroundImage: `
           linear-gradient(0deg, rgba(148,163,184,0.12) 1px, transparent 1px),
-          linear-gradient(90deg, rgba(148,163,184,0.12) 1px, transparent 1px)
+          linear-gradient(90deg, rgba(148,163,184,0.12) 1px, transparent 1px),
+          linear-gradient(0deg, rgba(148,163,184,0.3) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(148,163,184,0.3) 1px, transparent 1px)
         `,
-        backgroundSize: `${fine}px ${fine}px`,
+        backgroundSize: `
+          ${minor}px ${minor}px,
+          ${minor}px ${minor}px,
+          ${major}px ${major}px,
+          ${major}px ${major}px
+        `,
       }}
     />
   )

--- a/web/components/hud/RulersOverlay.tsx
+++ b/web/components/hud/RulersOverlay.tsx
@@ -202,6 +202,15 @@ export function RulersOverlay({ containerRef, offset, thickness = 24 }: Props) {
               background: 'rgba(14,165,233,0.55)',
             }}
           />
+          <div
+            className="absolute text-[10px] leading-none bg-cyan-500 text-black px-1 py-[1px] rounded"
+            style={{
+              left: Math.max(mouse.x + thickness + 4, thickness + 4),
+              top: Math.max(mouse.y + thickness + 4, thickness + 4),
+            }}
+          >
+            {Math.round((mouse.x + offX * zoom) / zoom)}, {Math.round((mouse.y + offY * zoom) / zoom)}
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add major/minor grid lines for canvas overlay
- show current mouse coordinates on rulers

## Testing
- `pnpm test:unit` *(fails: expected 'queued' to be 'idle')*
- `pnpm lint:all`


------
https://chatgpt.com/codex/tasks/task_e_68c4c83131ac832c835296e5b7a0ebf5