### PR TITLE
feat: add basic keyboard shortcuts

### DIFF
--- a/web/components/builder/Canvas.tsx
+++ b/web/components/builder/Canvas.tsx
@@ -375,6 +375,11 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
   const align = useBuilderStore((s) => s.align)
   const undo = useBuilderStore((s) => s.undo)
   const redo = useBuilderStore((s) => s.redo)
+  const duplicate = useBuilderStore((s) => s.duplicate)
+  const group = useBuilderStore((s) => s.group)
+  const ungroup = useBuilderStore((s) => s.ungroup)
+  const bringForward = useBuilderStore((s) => s.bringForward)
+  const sendBackward = useBuilderStore((s) => s.sendBackward)
   const { setNodeRef } = useDroppable({ id: 'CANVAS' })
   const gridSize = useGridStore((s) => s.size)
   const gridVisible = useGridStore((s) => s.visible)
@@ -429,15 +434,40 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
         else undo()
         return
       }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'd') {
+        e.preventDefault()
+        duplicate()
+        return
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'g') {
+        e.preventDefault()
+        if (e.shiftKey) {
+          if (selectedIds.length === 1) ungroup(selectedIds[0])
+        } else {
+          if (selectedIds.length >= 2) group(selectedIds, { name: 'Group' })
+        }
+        return
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === ']') {
+        e.preventDefault()
+        if (selectedIds[0]) bringForward(selectedIds[0])
+        return
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === '[') {
+        e.preventDefault()
+        if (selectedIds[0]) sendBackward(selectedIds[0])
+        return
+      }
       if (e.altKey && e.shiftKey) {
         if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') align('hSpace')
         if (e.key === 'ArrowUp' || e.key === 'ArrowDown') align('vSpace')
         return
       }
-      if (e.key === 'ArrowUp') nudge(0, -gridSize)
-      if (e.key === 'ArrowDown') nudge(0, gridSize)
-      if (e.key === 'ArrowLeft') nudge(-gridSize, 0)
-      if (e.key === 'ArrowRight') nudge(gridSize, 0)
+      const delta = e.shiftKey ? 10 : 1
+      if (e.key === 'ArrowUp') nudge(0, -delta)
+      if (e.key === 'ArrowDown') nudge(0, delta)
+      if (e.key === 'ArrowLeft') nudge(-delta, 0)
+      if (e.key === 'ArrowRight') nudge(delta, 0)
     }
     window.addEventListener('keydown', onKey)
     window.addEventListener('keyup', onKey)
@@ -445,7 +475,7 @@ export function Canvas({ canvasRef }: { canvasRef: React.RefObject<HTMLDivElemen
       window.removeEventListener('keydown', onKey)
       window.removeEventListener('keyup', onKey)
     }
-  }, [nudge, align, gridSize, undo, redo, spaceDown])
+  }, [nudge, align, undo, redo, spaceDown, duplicate, group, ungroup, bringForward, sendBackward, selectedIds])
 
   const onWheel: React.WheelEventHandler<HTMLDivElement> = (e) => {
     if (e.ctrlKey || e.metaKey) {

--- a/web/components/hud/BuilderHUD.tsx
+++ b/web/components/hud/BuilderHUD.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '@/store/uiStore'
 import { usePageStore } from '@/store/pageStore'
 import { toast } from '@/lib/toast'
 import { saveTemplate } from '../../../src/lib/pageTemplates'
+import { ShortcutsHelp } from './ShortcutsHelp'
 
 function IconBtn(props: React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean }) {
   const { active, className, ...rest } = props
@@ -37,6 +38,8 @@ export function BuilderHUD() {
     toggleSnap,
   } = useHudStore()
   const { showRulers, toggleRulers } = useUIStore()
+
+  const [showHelp, setShowHelp] = React.useState(false)
 
   const saveAsTemplate = React.useCallback(() => {
     const name = window.prompt('Template name?')
@@ -78,6 +81,7 @@ export function BuilderHUD() {
 
   return (
     <>
+      {showHelp && <ShortcutsHelp onClose={() => setShowHelp(false)} />}
       <div className="pointer-events-auto fixed left-1/2 top-2 -translate-x-1/2 z-50 flex items-center gap-1">
         <IconBtn onClick={zoomOut}>−</IconBtn>
         <span className="px-2 text-xs text-zinc-300 tabular-nums">{Math.round(zoom * 100)}%</span>
@@ -90,6 +94,7 @@ export function BuilderHUD() {
         <IconBtn active={showOutline} onClick={toggleOutline} title="Outline (O)">Out</IconBtn>
         <IconBtn active={snapToPixel} onClick={toggleSnap} title="Snap (P)">Snap</IconBtn>
         <IconBtn onClick={saveAsTemplate} title="Save as Template">SaveTpl</IconBtn>
+        <IconBtn onClick={() => setShowHelp(true)} title="Shortcuts">Help</IconBtn>
         <div className="mx-1 w-px h-6 bg-zinc-800" />
         <DeviceBtn d="free" label="Free" />
         <DeviceBtn d="desktop" label="Desktop" />

--- a/web/components/hud/ShortcutsHelp.tsx
+++ b/web/components/hud/ShortcutsHelp.tsx
@@ -1,0 +1,32 @@
+'use client'
+import React from 'react'
+
+export function ShortcutsHelp({ onClose }: { onClose: () => void }) {
+  const items = [
+    ['Arrow', 'Move 1px'],
+    ['Shift+Arrow', 'Move 10px'],
+    ['Ctrl/Cmd+D', 'Duplicate'],
+    ['Ctrl/Cmd+G', 'Group'],
+    ['Ctrl/Cmd+Shift+G', 'Ungroup'],
+    ['Ctrl/Cmd+]', 'Bring Forward'],
+    ['Ctrl/Cmd+[', 'Send Backward'],
+  ]
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-zinc-900 text-zinc-200 p-4 rounded border border-zinc-700 w-64 text-sm">
+        <h2 className="text-base font-semibold mb-2">Shortcuts</h2>
+        <ul className="space-y-1">
+          {items.map(([k, v]) => (
+            <li key={k} className="flex justify-between"><span className="font-mono">{k}</span><span>{v}</span></li>
+          ))}
+        </ul>
+        <button
+          className="mt-3 px-2 py-1 border border-zinc-600 rounded bg-zinc-800 hover:bg-zinc-700 w-full"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -124,9 +124,12 @@ type BuilderActions = {
   rename: (id: string, name: string) => void;
   group: (ids: string[], opts?: { name?: string }) => string;
   ungroup: (id: string) => void;
+  duplicate: (ids?: string[]) => void;
   deleteSelected: () => void;
   bringToFront: (id: string) => void;
   sendToBack: (id: string) => void;
+  bringForward: (id: string) => void;
+  sendBackward: (id: string) => void;
   nudge: (dx: number, dy: number) => void;
   setElements: (els: Elm[]) => void;
   serialize: () => string;
@@ -774,6 +777,54 @@ export const useBuilderStore = create<BuilderState & BuilderActions>(
         });
       },
 
+      duplicate(ids) {
+        apply((draft: BuilderState) => {
+          const targets = ids ?? draft.selectedIds;
+          if (!targets.length) return;
+          const newIds: string[] = [];
+          const cloneRec = (el: Elm, parentId: string | null, acc: Elm[]): Elm => {
+            const cloned: Elm = {
+              ...el,
+              id: newId("n"),
+              x: el.x + 10,
+              y: el.y + 10,
+              parentId,
+              children: el.children ? [] : undefined,
+            };
+            acc.push(cloned);
+            el.children?.forEach((cid) => {
+              const child = draft.elements.find((e) => e.id === cid);
+              if (child) {
+                const c = cloneRec(child, cloned.id, acc);
+                cloned.children!.push(c.id);
+              }
+            });
+            return cloned;
+          };
+          targets.forEach((id) => {
+            const src = draft.elements.find((e) => e.id === id);
+            if (!src) return;
+            const clones: Elm[] = [];
+            const rootClone = cloneRec(src, src.parentId ?? null, clones);
+            const insertIdx = draft.elements.findIndex((e) => e.id === id);
+            draft.elements.splice(insertIdx + 1, 0, ...clones);
+            if (src.parentId) {
+              const parent = draft.elements.find((e) => e.id === src.parentId);
+              if (parent && parent.children) {
+                const ci = parent.children.indexOf(id);
+                if (ci >= 0) parent.children.splice(ci + 1, 0, rootClone.id);
+              }
+            } else {
+              const ti = draft.tree.findIndex((e) => e.id === id);
+              draft.tree.splice(ti + 1, 0, rootClone);
+            }
+            newIds.push(rootClone.id);
+          });
+          draft.selectedIds = newIds;
+          draft.selectedId = newIds[newIds.length - 1] ?? null;
+        });
+      },
+
       deleteSelected() {
         const id = get().selectedId;
         if (!id) return;
@@ -799,6 +850,78 @@ export const useBuilderStore = create<BuilderState & BuilderActions>(
           if (i < 0) return;
           const [e] = draft.elements.splice(i, 1);
           draft.elements.unshift(e);
+        });
+      },
+
+      bringForward(id) {
+        apply((draft: BuilderState) => {
+          const idx = draft.elements.findIndex((e) => e.id === id);
+          if (idx < 0) return;
+          const el = draft.elements[idx];
+          const parentId = el.parentId ?? null;
+          for (let i = idx + 1; i < draft.elements.length; i++) {
+            const nxt = draft.elements[i];
+            if ((nxt.parentId ?? null) === parentId) {
+              draft.elements[idx] = nxt;
+              draft.elements[i] = el;
+              if (parentId) {
+                const p = draft.elements.find((e) => e.id === parentId);
+                if (p && p.children) {
+                  const ci = p.children.indexOf(id);
+                  const ni = p.children.indexOf(nxt.id);
+                  if (ci >= 0 && ni >= 0) {
+                    p.children[ci] = nxt.id;
+                    p.children[ni] = id;
+                  }
+                }
+              } else {
+                const ci = draft.tree.findIndex((e) => e.id === id);
+                const ni = draft.tree.findIndex((e) => e.id === nxt.id);
+                if (ci >= 0 && ni >= 0) {
+                  const tmp = draft.tree[ci];
+                  draft.tree[ci] = draft.tree[ni];
+                  draft.tree[ni] = tmp;
+                }
+              }
+              break;
+            }
+          }
+        });
+      },
+
+      sendBackward(id) {
+        apply((draft: BuilderState) => {
+          const idx = draft.elements.findIndex((e) => e.id === id);
+          if (idx < 0) return;
+          const el = draft.elements[idx];
+          const parentId = el.parentId ?? null;
+          for (let i = idx - 1; i >= 0; i--) {
+            const prev = draft.elements[i];
+            if ((prev.parentId ?? null) === parentId) {
+              draft.elements[idx] = prev;
+              draft.elements[i] = el;
+              if (parentId) {
+                const p = draft.elements.find((e) => e.id === parentId);
+                if (p && p.children) {
+                  const ci = p.children.indexOf(id);
+                  const pi = p.children.indexOf(prev.id);
+                  if (ci >= 0 && pi >= 0) {
+                    p.children[ci] = prev.id;
+                    p.children[pi] = id;
+                  }
+                }
+              } else {
+                const ci = draft.tree.findIndex((e) => e.id === id);
+                const pi = draft.tree.findIndex((e) => e.id === prev.id);
+                if (ci >= 0 && pi >= 0) {
+                  const tmp = draft.tree[ci];
+                  draft.tree[ci] = draft.tree[pi];
+                  draft.tree[pi] = tmp;
+                }
+              }
+              break;
+            }
+          }
         });
       },
 


### PR DESCRIPTION
## Summary
- support duplication, grouping, and ordering shortcuts
- nudge by 1px or 10px with arrow keys
- add help modal listing keyboard shortcuts

## Testing
- `pnpm test` *(fails: expected 'idle' to be 'queued')*


------
https://chatgpt.com/codex/tasks/task_e_68c4c8765d64832cabeba90518b5efad