### PR TITLE
feat: autosave staging and crash recovery

### DIFF
--- a/apps/builder/lib/save/stateMachine.ts
+++ b/apps/builder/lib/save/stateMachine.ts
@@ -1,19 +1,23 @@
-export type SaveState = 'idle' | 'saving' | 'saved' | 'error'
+export type SaveState = 'idle' | 'queued' | 'offline' | 'flushing' | 'saved'
 
 export function nextState(state: SaveState, event: string): SaveState {
   switch (state) {
     case 'idle':
-      if (event === 'start') return 'saving'
+      if (event === 'enqueue') return 'queued'
       return state
-    case 'saving':
-      if (event === 'success') return 'saved'
-      if (event === 'fail') return 'error'
+    case 'queued':
+      if (event === 'offline') return 'offline'
+      if (event === 'flush') return 'flushing'
+      return state
+    case 'offline':
+      if (event === 'reconnect') return 'flushing'
+      return state
+    case 'flushing':
+      if (event === 'done') return 'saved'
+      if (event === 'offline') return 'offline'
       return state
     case 'saved':
-      if (event === 'start') return 'saving'
-      return state
-    case 'error':
-      if (event === 'reset') return 'idle'
+      if (event === 'enqueue') return 'queued'
       return state
     default:
       return state

--- a/web/lib/persist/snapshot.ts
+++ b/web/lib/persist/snapshot.ts
@@ -25,8 +25,32 @@ class SnapshotDB extends Dexie {
 
 const db = new SnapshotDB();
 
-export async function saveLatestSnapshot(doc: SnapshotDoc): Promise<number> {
-  const ts = Date.now();
+let staged: { doc: SnapshotDoc; ts: number } | null = null;
+let flushHandle: any = null;
+const IDLE_TIMEOUT = 1000;
+
+function scheduleFlush() {
+  if (flushHandle != null) {
+    try {
+      if (typeof (globalThis as any).cancelIdleCallback === "function") {
+        (globalThis as any).cancelIdleCallback(flushHandle);
+      } else {
+        clearTimeout(flushHandle);
+      }
+    } catch {}
+  }
+  const cb = () => {
+    flushHandle = null;
+    flushStagedSnapshot().catch(() => {});
+  };
+  if (typeof (globalThis as any).requestIdleCallback === "function") {
+    flushHandle = (globalThis as any).requestIdleCallback(cb, { timeout: IDLE_TIMEOUT });
+  } else {
+    flushHandle = setTimeout(cb, IDLE_TIMEOUT);
+  }
+}
+
+async function commitSnapshot(doc: SnapshotDoc, ts: number) {
   const payload = { v: 1, ts, doc };
   const bytes = new TextEncoder().encode(JSON.stringify(payload));
   const compressed = await tryGzip(bytes);
@@ -44,7 +68,38 @@ export async function saveLatestSnapshot(doc: SnapshotDoc): Promise<number> {
   try {
     localStorage.setItem("ui.snapshot.latestTs", String(ts));
   } catch {}
+}
+
+export async function flushStagedSnapshot(): Promise<void> {
+  if (flushHandle != null) {
+    try {
+      if (typeof (globalThis as any).cancelIdleCallback === "function") {
+        (globalThis as any).cancelIdleCallback(flushHandle);
+      } else {
+        clearTimeout(flushHandle);
+      }
+    } catch {}
+    flushHandle = null;
+  }
+  if (!staged) return;
+  const { doc, ts } = staged;
+  staged = null;
+  await commitSnapshot(doc, ts);
+}
+
+export async function saveLatestSnapshot(doc: SnapshotDoc): Promise<number> {
+  const ts = Date.now();
+  staged = { doc, ts };
+  scheduleFlush();
   return ts;
+}
+
+if (typeof window !== "undefined") {
+  const onHide = () => {
+    flushStagedSnapshot().catch(() => {});
+  };
+  window.addEventListener("pagehide", onHide);
+  window.addEventListener("beforeunload", onHide);
 }
 
 export async function loadLatestSnapshot(): Promise<


### PR DESCRIPTION
## Summary
- throttle snapshot writes by staging in memory and flushing during idle
- add unload listeners to flush staged snapshots for crash recovery
- align save state machine with queued/offline/flushing workflow

## Testing
- `pnpm test:unit`
- `pnpm -F ui-builder-web lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4c87e940c832c98f1267159c19b5a