### PR TITLE
feat: add palette templates

### DIFF
--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { registry, type RegistryItem } from '@/lib/registry'
 import { usePresetStore } from '@/store/presetStore'
+import PresetsSection from '../palette/PresetsSection'
 
 function useVisibleDefs() {
   const rules = usePresetStore(s => s.active().palette)
@@ -55,11 +56,14 @@ function Item({ comp }: { comp: RegistryItem }) {
 export function Palette() {
   const defs = useVisibleDefs()
   return (
-    <div className="space-y-2">
-      <div className="text-xs opacity-70">Elements</div>
-      <div className="grid grid-cols-1 gap-2">
-        {defs.map((d) => <Item key={d.meta.id} comp={d} />)}
-      </div>
+    <div className="space-y-6">
+      <section className="space-y-2">
+        <div className="text-xs opacity-70">Elements</div>
+        <div className="grid grid-cols-1 gap-2">
+          {defs.map((d) => <Item key={d.meta.id} comp={d} />)}
+        </div>
+      </section>
+      <PresetsSection />
     </div>
   )
 }

--- a/web/components/palette/PresetsSection.tsx
+++ b/web/components/palette/PresetsSection.tsx
@@ -4,9 +4,34 @@ import { PRESETS, type PresetDef } from '@/lib/presets'
 import { useBuilderStore } from '@/store/builderStore'
 import PresetsFilterBar from './PresetsFilterBar'
 import { usePresetsFilter } from '@/store/presetsFilterStore'
+import { useDraggable } from '@dnd-kit/core'
+
+function PresetItem({ preset }: { preset: PresetDef }) {
+  const placePreset = useBuilderStore((s) => s.placePreset)
+  const { attributes, listeners, setNodeRef } = useDraggable({
+    id: 'preset:' + preset.id,
+    data: {
+      from: 'palette',
+      type: 'preset',
+      meta: { presetId: preset.id },
+    },
+  })
+  return (
+    <button
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      onClick={() => placePreset(preset.id)}
+      className="border rounded-lg p-2 text-left hover:bg-accent"
+      title={preset.tags.join(', ')}
+    >
+      <div className="text-sm font-medium">{preset.displayName}</div>
+      <div className="text-[10px] text-muted-foreground">{preset.id}</div>
+    </button>
+  )
+}
 
 export default function PresetsSection() {
-  const placePreset = useBuilderStore((s) => s.placePreset)
   const { activeDomains, alwaysShowCommon } = usePresetsFilter()
 
   const activeSet = useMemo(
@@ -28,15 +53,7 @@ export default function PresetsSection() {
       <PresetsFilterBar />
       <div className="grid grid-cols-2 gap-2">
         {list.map((p) => (
-          <button
-            key={p.id}
-            onClick={() => placePreset(p.id)}
-            className="border rounded-lg p-2 text-left hover:bg-accent"
-            title={p.tags.join(', ')}
-          >
-            <div className="text-sm font-medium">{p.displayName}</div>
-            <div className="text-[10px] text-muted-foreground">{p.id}</div>
-          </button>
+          <PresetItem key={p.id} preset={p} />
         ))}
       </div>
     </section>

--- a/web/lib/presets.ts
+++ b/web/lib/presets.ts
@@ -11,6 +11,50 @@ export const cloneSubtree = (node: ComponentNode): ComponentNode => {
   }
 }
 
+export const template_button: PresetDef = {
+  id: 'template.ui.button',
+  displayName: 'Button',
+  tags: ['common'],
+  tree: {
+    id: newId('n'),
+    type: 'ui.button',
+    props: { label: 'Button', variant: 'primary' } as any,
+  },
+}
+
+export const template_card: PresetDef = {
+  id: 'template.ui.card',
+  displayName: 'Card',
+  tags: ['common', 'card'],
+  tree: {
+    id: newId('n'),
+    type: 'ui.card',
+    props: {
+      title: 'Card title',
+      body: 'Card body',
+      bg: 'token:color.surface',
+      radius: 'token:radius.lg',
+      pad: 'token:space.4',
+    } as any,
+  },
+}
+
+export const template_hero: PresetDef = {
+  id: 'template.hero',
+  displayName: 'Hero',
+  tags: ['common'],
+  tree: {
+    id: newId('n'),
+    type: 'Hero',
+    props: {
+      title: 'Hero title',
+      subtitle: 'Subtitle text',
+      ctaText: 'Get Started',
+      ctaHref: '#',
+    } as any,
+  },
+}
+
 export const preset_japanMapCard_basic: PresetDef = {
   id: 'preset.jpmap.card.basic',
   displayName: 'JapanMap（カード/基本）',
@@ -120,6 +164,9 @@ export const preset_costSplitCard: PresetDef = {
 }
 
 export const PRESETS: PresetDef[] = [
+  template_button,
+  template_card,
+  template_hero,
   preset_japanMapCard_basic,
   preset_tripHeaderCard,
   preset_itineraryTimelineCard,

--- a/web/lib/registry.ts
+++ b/web/lib/registry.ts
@@ -22,6 +22,8 @@ import { MapThemeProvider } from '@/contexts/MapThemeContext';
 import AnimeOnMount from '@/components/anim/AnimeOnMount';
 import AnimeOnView from '@/components/anim/AnimeOnView';
 import InteractiveWrapper from '@/components/interactive/InteractiveWrapper';
+import UiButton from '@/components/defs/ui/Button';
+import UiCardDef from '@/components/defs/ui/Card';
 
 // JapanMap is optional (SVG variant lives in components/domain/maps)
 let JapanMap: any = null;
@@ -83,6 +85,30 @@ DEFAULT_COMPONENTS.forEach((c) => {
     },
     Render: () => null,
   });
+});
+
+register({
+  meta: {
+    id: UiButton.key,
+    displayName: UiButton.meta.displayName,
+    props: [],
+    allowChildren: false,
+    defaultW: UiButton.meta.defaultW,
+    defaultH: UiButton.meta.defaultH,
+  },
+  Render: UiButton.render,
+});
+
+register({
+  meta: {
+    id: UiCardDef.key,
+    displayName: UiCardDef.meta.displayName,
+    props: [],
+    allowChildren: true,
+    defaultW: UiCardDef.meta.defaultW,
+    defaultH: UiCardDef.meta.defaultH,
+  },
+  Render: UiCardDef.render,
 });
 
 register({
@@ -336,6 +362,8 @@ register({
 });
 
 export const REGISTRY = {
+  'ui.button': { component: UiButton.render, displayName: UiButton.meta.displayName },
+  'ui.card': { component: UiCardDef.render, displayName: UiCardDef.meta.displayName },
   Card: { component: Card, displayName: 'Card' },
   PrefShareBar: { component: PrefShareBar, displayName: 'PrefShareBar' },
   PrefGridMap: { component: PrefGridMap, displayName: 'PrefGridMap' },

--- a/web/store/builderStore.ts
+++ b/web/store/builderStore.ts
@@ -310,6 +310,11 @@ export const useBuilderStore = create<BuilderState & BuilderActions>(
           return;
         }
 
+        if (type === "preset" && meta?.presetId) {
+          get().placePreset(meta.presetId, { x, y });
+          return;
+        }
+
         const legacyMap: Record<string, string> = {
           header: "ui.header",
           footer: "ui.footer",


### PR DESCRIPTION
## Summary
- extend component registry with UI button and card
- add JSON-based templates for button, card and hero
- enable dragging presets from palette onto the canvas

## Testing
- `pnpm test:unit` *(fails: apps/builder/lib/save/stateMachine.spec.ts idle->queued test)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c888c62c832ca6152e1458d91b10