### PR TITLE
feat: add global keyboard help modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "@types/react": "^18.2.47",
         "cross-env": "^10.0.0",
         "glob": "^11.0.3",
+        "happy-dom": "^18.0.1",
         "jscodeshift": "^0.15.2",
         "start-server-and-test": "^2.1.0",
         "ts-node": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       glob:
         specifier: ^11.0.3
         version: 11.0.3
+      happy-dom:
+        specifier: ^18.0.1
+        version: 18.0.1
       jscodeshift:
         specifier: ^0.15.2
         version: 0.15.2
@@ -119,7 +122,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@22.18.1)
+        version: 2.1.9(@types/node@22.18.1)(happy-dom@18.0.1)
 
   apps/builder:
     dependencies:
@@ -2175,6 +2178,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node@20.19.14':
+    resolution: {integrity: sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==}
+
   '@types/node@22.18.1':
     resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
 
@@ -2189,6 +2195,9 @@ packages:
 
   '@types/react@18.3.24':
     resolution: {integrity: sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -3247,6 +3256,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  happy-dom@18.0.1:
+    resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -4341,6 +4354,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   split@0.3.3:
     resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
@@ -4771,6 +4785,10 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -6622,6 +6640,10 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node@20.19.14':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.18.1':
     dependencies:
       undici-types: 6.21.0
@@ -6643,6 +6665,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/whatwg-mimetype@3.0.2': {}
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -7970,6 +7994,12 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  happy-dom@18.0.1:
+    dependencies:
+      '@types/node': 20.19.14
+      '@types/whatwg-mimetype': 3.0.2
+      whatwg-mimetype: 3.0.0
 
   has-bigints@1.1.0: {}
 
@@ -9605,7 +9635,7 @@ snapshots:
       '@types/node': 22.18.1
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.18.1):
+  vitest@2.1.9(@types/node@22.18.1)(happy-dom@18.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@22.18.1))
@@ -9629,6 +9659,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.1
+      happy-dom: 18.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -9661,6 +9692,8 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@7.1.0:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['apps/builder/lib/**/*.spec.ts'],
-    environment: 'node',
+    include: ['apps/builder/lib/**/*.spec.ts', 'web/tests/**/*.spec.tsx'],
+    environment: 'happy-dom',
   },
 })
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,6 +6,7 @@ import SiteHeader from '@/components/layout/SiteHeader'
 import SiteFooter from '@/components/layout/SiteFooter'
 import ChromeController from '@/components/layout/ChromeController'
 import ErrorBoundary from '@/components/ErrorBoundary'
+import RootHotkeys from '@/components/RootHotkeys'
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
   const cookieStore = await cookies()
@@ -20,6 +21,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             <SiteHeader />
             <main className="min-h-[calc(100vh-6rem)]">{children}</main>
             <SiteFooter />
+            <RootHotkeys />
           </Providers>
         </ErrorBoundary>
       </body>

--- a/web/components/RootHotkeys.tsx
+++ b/web/components/RootHotkeys.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import React from 'react'
+import KeyboardHelpModal from './modals/KeyboardHelpModal'
+import { useHotkeysHelp } from '../hooks/useHotkeysHelp'
+
+export default function RootHotkeys() {
+  const { open, setOpen } = useHotkeysHelp()
+  return <KeyboardHelpModal open={open} onClose={() => setOpen(false)} />
+}
+

--- a/web/components/modals/KeyboardHelpModal.tsx
+++ b/web/components/modals/KeyboardHelpModal.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import React from 'react'
+
+export default function KeyboardHelpModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 grid place-items-center bg-black/50 z-[999]" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-[640px] max-w-[90vw] rounded-2xl p-6 bg-neutral-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-lg font-semibold mb-3">Keyboard Shortcuts</div>
+        <ul className="grid grid-cols-2 gap-2 text-sm opacity-90">
+          <li>
+            <kbd>Alt</kbd> + Drag … Duplicate (snap, ghost)
+          </li>
+          <li>
+            <kbd>←↑→↓</kbd> … Nudge
+          </li>
+          <li>
+            <kbd>Shift</kbd> + Nudge … 10px
+          </li>
+          <li>
+            <kbd>Ctrl/Cmd</kbd> + <kbd>C</kbd> … Copy
+          </li>
+          <li>
+            <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> … Copy CSS
+          </li>
+          <li>
+            <kbd>Ctrl/Cmd</kbd> + <kbd>?</kbd> … This help
+          </li>
+          {/* ほか：整列/ズーム/テーマ切替 等 */}
+        </ul>
+        <div className="mt-4 text-right">
+          <button className="btn" onClick={onClose}>
+            Close (Esc)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/web/hooks/useHotkeysHelp.ts
+++ b/web/hooks/useHotkeysHelp.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useHotkeysHelp() {
+  const [open, setOpen] = useState(false)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.ctrlKey || e.metaKey
+      const isQ = e.key === '?' || (e.shiftKey && e.key === '/')
+      if (mod && isQ) {
+        e.preventDefault()
+        setOpen((v) => !v)
+      }
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+  return { open, setOpen }
+}
+

--- a/web/tests/KeyboardHelpModal.spec.tsx
+++ b/web/tests/KeyboardHelpModal.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { describe, it, expect } from 'vitest'
+
+import RootHotkeys from '../components/RootHotkeys'
+
+describe('KeyboardHelpModal', () => {
+  it('opens with Ctrl+? and closes with Esc', () => {
+    const div = document.createElement('div')
+    document.body.appendChild(div)
+    const root = createRoot(div)
+
+    act(() => {
+      root.render(<RootHotkeys />)
+    })
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '/', ctrlKey: true, shiftKey: true })
+      )
+    })
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add `useHotkeysHelp` hook for Ctrl/Cmd+? shortcut handling
- show accessible `KeyboardHelpModal` via new `RootHotkeys` component
- wire modal into root layout and add happy-dom based unit test

## Testing
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c4d50624c8832c8c23664cc9fb8cbd