### PR TITLE
feat(builder): add builder manifest storage

### DIFF
--- a/apps/builder/app/page.tsx
+++ b/apps/builder/app/page.tsx
@@ -5,10 +5,12 @@ import type { Page, ComponentNode, Frame } from '@chizu/types'
 import * as REG from '@chizu/registry'
 import { AutosaveMountHashed } from '@/components/AutosaveMountHashed'
 import { ApplyLastSnippetButton } from '@/components/bindings/ApplyLastSnippetButton'
+import { DEFAULT_BUILDER_MANIFEST } from '@/lib/meta/builderManifest'
+import { loadBuilderManifest, saveBuilderManifest } from '@/lib/meta/storage'
 
 const fetcher = (u: string) => fetch(u).then((r) => r.json())
 
-const FRAMES: Frame[] = [
+const BASE_FRAMES: Frame[] = [
   {
     id: 'frame-basic',
     name: 'Basic',
@@ -37,6 +39,16 @@ const FRAMES: Frame[] = [
   },
 ]
 
+const META_FRAME: Frame = {
+  id: 'frame-builder',
+  name: 'Builder UI',
+  slots: [
+    { name: 'leftSidebar' },
+    { name: 'canvas', required: true },
+    { name: 'rightPanel' },
+  ],
+}
+
 const DEFAULT_PAGE = (id = 'map-home'): Page => ({
   id,
   title: '新規ページ',
@@ -53,7 +65,17 @@ const CATALOG: Array<{type:string; label:string; defaultProps?:Record<string,any
   { type:'PrefList', label:'PrefList' }
 ]
 
-type SlotName = 'header'|'sidebar'|'content'|'footer'
+type SlotName = 'header'|'sidebar'|'content'|'footer'|'leftSidebar'|'rightPanel'|'canvas'
+
+const META_SLOTS: SlotName[] = ['leftSidebar', 'canvas', 'rightPanel']
+
+function clone<T>(value: T): T {
+  try {
+    return structuredClone(value)
+  } catch {
+    return JSON.parse(JSON.stringify(value)) as T
+  }
+}
 
 // Builder-side lightweight runtime preview data for bindings
 const PREVIEW_API: Record<string, any> = {
@@ -95,10 +117,13 @@ function diffPropsBindings(oldN?:ComponentNode, newN?:ComponentNode){
   return changes
 }
 function getSlotNodes(p: Page, slot: SlotName): ComponentNode[] {
-  return slot==='content' ? (p.content??[]) : (p.slotAssignments?.[slot] ?? [])
+  if (slot === 'content' || slot === 'canvas') {
+    return p.content ?? []
+  }
+  return p.slotAssignments?.[slot] ?? []
 }
 function diffPage(oldP: Page, newP: Page, frameIdOld: string, frameIdNew: string){
-  const slots: SlotName[] = ['header','sidebar','content','footer']
+  const slots: SlotName[] = ['header','sidebar','content','footer','leftSidebar','rightPanel']
   const slotDiffs = slots.map(slot=>{
     const o = getSlotNodes(oldP, slot)
     const n = getSlotNodes(newP, slot)
@@ -198,6 +223,7 @@ function BindingsEditor({
   const currentBindings = node.bindings ?? {}
   const { data: ds } = useSWR<{items:Array<{key:string;url:string;ttlSec?:number}>}>('/api/ds', fetcher)
   const apiKeys = (ds?.items ?? []).map(x=>x.key)
+  const isMetaMode = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('meta') === '1'
 
   const initialProp =
     (node.meta as any)?.lastBindingProp ||
@@ -545,24 +571,36 @@ function BindingsEditor({
         <button onClick={apply} style={{padding:'6px 10px', borderRadius:8, background:'#111', color:'#fff'}}>適用</button>
         <button onClick={remove} style={{padding:'6px 10px', border:'1px solid #ddd', borderRadius:8, background:'#fff'}}>解除</button>
       </div>
-      <AutosaveMountHashed page={page} debounceMs={800} />
+      {!isMetaMode && <AutosaveMountHashed page={pageRoot} debounceMs={800} />}
     </div>
   )
 }
 
 export default function Builder() {
-  const [page,setPage] = useState<Page>(() => {
+  const [isMetaMode] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return new URLSearchParams(window.location.search).get('meta') === '1'
+  })
+
+  const [page, setPage] = useState<Page>(() => {
+    const meta = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('meta') === '1'
+    if (meta) {
+      return clone(DEFAULT_BUILDER_MANIFEST)
+    }
     const p = DEFAULT_PAGE('map-home')
-    p.content.push({ id:'hero_init', type:'Hero', props:{ title:'地図で集める旅' } })
-    p.slotAssignments = { header:[{id:'nav',type:'TopNav'}], sidebar:[{id:'list',type:'PrefList'}] }
+    p.content.push({ id: 'hero_init', type: 'Hero', props: { title: '地図で集める旅' } })
+    p.slotAssignments = { header: [{ id: 'nav', type: 'TopNav' }], sidebar: [{ id: 'list', type: 'PrefList' }] }
     return p
   })
-  const [frameId, setFrameId] = useState<string>('frame-basic')
-  const currentFrame = useMemo(() => FRAMES.find(f => f.id === frameId)!, [frameId])
 
-  const [selSlot, setSelSlot] = useState<SlotName>('content')
+  const frames = useMemo(() => (isMetaMode ? [...BASE_FRAMES, META_FRAME] : BASE_FRAMES), [isMetaMode])
+  const primarySlot: SlotName = isMetaMode ? 'canvas' : 'content'
+  const [frameId, setFrameId] = useState<string>(() => (isMetaMode ? META_FRAME.id : 'frame-basic'))
+  const currentFrame = useMemo(() => frames.find((f) => f.id === frameId) ?? frames[0], [frames, frameId])
+
+  const [selSlot, setSelSlot] = useState<SlotName>(() => primarySlot)
   const currentNodes = useMemo(() => {
-    return selSlot === 'content'
+    return selSlot === 'content' || selSlot === 'canvas'
       ? (page.content ?? [])
       : (page.slotAssignments?.[selSlot] ?? [])
   }, [page, selSlot])
@@ -597,22 +635,44 @@ export default function Builder() {
   }, [diffs])
   const push = (next: Page) => { setHistory(h=>[...h.slice(-49), page]); setPage(next) }
 
+  useEffect(() => {
+    if (!isMetaMode) return
+    let cancelled = false
+    loadBuilderManifest()
+      .then((manifest) => {
+        if (cancelled) return
+        const next = clone(manifest)
+        const fid = next.frameId ?? META_FRAME.id
+        setPage(next)
+        setFrameId(fid)
+        setSelSlot(primarySlot)
+        setHistory([])
+        setSelId(undefined)
+        setLastSaved(JSON.stringify({ page: next, frameId: fid }))
+        setDirty(false)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [isMetaMode])
+
   const { data: list } = useSWR<{ ids: string[] }>(
-    '/api/pages',
+    isMetaMode ? null : '/api/pages',
     fetcher,
     { refreshInterval: 2000 }
   )
 
   useEffect(() => {
     const last = typeof window !== 'undefined' ? localStorage.getItem('chizu:lastPageId') : null
-    if (!last) return
+    if (!last || isMetaMode) return
     fetch(`/api/page?id=${encodeURIComponent(last)}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((j) => {
         if (j?.page) {
           setPage(j.page as Page)
           setSelId(undefined)
-          setSelSlot('content')
+          setSelSlot(primarySlot)
           setHistory([])
           if ((j.page as Page).frameId) setFrameId((j.page as Page).frameId as string)
           const fid = ((j.page as Page).frameId as string) || 'frame-basic'
@@ -623,12 +683,13 @@ export default function Builder() {
   }, [])
 
   const loadPage = async (id: string) => {
+    if (isMetaMode) return
     const res = await fetch(`/api/page?id=${encodeURIComponent(id)}`)
     if (!res.ok) return alert('読み込みに失敗しました')
     const { page: loaded } = (await res.json()) as { page: Page }
     setHistory([])
     setSelId(undefined)
-    setSelSlot('content')
+    setSelSlot(primarySlot)
     setPage(loaded)
     const fid = loaded.frameId ?? 'frame-basic'
     setFrameId(fid)
@@ -637,13 +698,14 @@ export default function Builder() {
   }
 
   const deletePage = async (id: string) => {
+    if (isMetaMode) return
     if (!confirm(`Delete page "${id}"? この操作は元に戻せません。`)) return
     const res = await fetch(`/api/page?id=${encodeURIComponent(id)}`, { method: 'DELETE' })
     if (!res.ok) return alert('削除に失敗しました')
     if (id === page.id) {
       setHistory([])
       setSelId(undefined)
-      setSelSlot('content')
+      setSelSlot(primarySlot)
       setPage(DEFAULT_PAGE('map-home'))
       setFrameId('frame-basic')
       localStorage.removeItem('chizu:lastPageId')
@@ -651,6 +713,7 @@ export default function Builder() {
   }
 
   const duplicatePage = async (id: string) => {
+    if (isMetaMode) return
     const to = prompt(`複製先の pageId`, `${id}-copy`)
     if (!to || to===id) return
     const res = await fetch('/api/duplicate', { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ sourceId: id, newId: to }) })
@@ -665,10 +728,10 @@ export default function Builder() {
   }
 
   function getSlotArray(p: Page, slot: SlotName) {
-    return slot === 'content' ? (p.content ?? []) : (p.slotAssignments?.[slot] ?? [])
+    return slot === 'content' || slot === 'canvas' ? (p.content ?? []) : (p.slotAssignments?.[slot] ?? [])
   }
   function setSlotArray(p: Page, slot: SlotName, arr: ComponentNode[]) {
-    if (slot === 'content') p.content = arr
+    if (slot === 'content' || slot === 'canvas') p.content = arr
     else { if(!p.slotAssignments) p.slotAssignments = {}; p.slotAssignments[slot] = arr }
   }
 
@@ -699,7 +762,7 @@ export default function Builder() {
     const id = `${type.toLowerCase()}_${Math.random().toString(36).slice(2,7)}`
     const def = CATALOG.find(c=>c.type===type)?.defaultProps ?? {}
     const n: ComponentNode = { id, type, props: def }
-    if (selSlot === 'content') {
+    if (selSlot === 'content' || selSlot === 'canvas') {
       push({ ...page, content: [...(page.content ?? []), n] })
     } else {
       const next = structuredClone(page)
@@ -712,7 +775,7 @@ export default function Builder() {
 
   const updateProp = (k:string, v:any) => {
     if (!selId) return
-    if (selSlot === 'content') {
+    if (selSlot === 'content' || selSlot === 'canvas') {
       push({ ...page, content: (page.content ?? []).map(n => n.id===selId ? ({ ...n, props: { ...(n.props??{}), [k]: v } }) : n ) })
     } else {
       const next = structuredClone(page)
@@ -724,7 +787,7 @@ export default function Builder() {
 
   const removeSel = () => {
     if (!selId) return
-    if (selSlot === 'content') {
+    if (selSlot === 'content' || selSlot === 'canvas') {
       push({ ...page, content: (page.content ?? []).filter(n=>n.id!==selId) })
     } else {
       const next = structuredClone(page)
@@ -737,13 +800,13 @@ export default function Builder() {
 
   const moveSel = (dir:-1|1) => {
     if (!selId) return
-    const arr = selSlot === 'content'
+    const arr = selSlot === 'content' || selSlot === 'canvas'
       ? [...(page.content ?? [])]
       : [...(page.slotAssignments?.[selSlot] ?? [])]
     const i = arr.findIndex(n=>n.id===selId); if(i<0) return
     const j = i + dir; if (j<0 || j>=arr.length) return
     ;[arr[i],arr[j]]=[arr[j],arr[i]]
-    if (selSlot === 'content') push({ ...page, content: arr })
+    if (selSlot === 'content' || selSlot === 'canvas') push({ ...page, content: arr })
     else {
       const next = structuredClone(page)
       ensureSlot(next, selSlot)
@@ -752,32 +815,122 @@ export default function Builder() {
     }
   }
 
-  const duplicateSel = () => {
-    if (!selId) return
-    const list = getSlotArray(page, selSlot)
-    const i = list.findIndex(n=>n.id===selId); if (i<0) return
+  const duplicateSel = (slotOverride?: SlotName, idOverride?: string) => {
+    const targetSlot = slotOverride ?? selSlot
+    const targetId = idOverride ?? selId
+    if (!targetId) return
+    const list = getSlotArray(page, targetSlot)
+    const i = list.findIndex((n) => n.id === targetId)
+    if (i < 0) return
     const src = list[i]
-    const copy: ComponentNode = structuredClone(src)
-    copy.id = `${src.type.toLowerCase()}_${Math.random().toString(36).slice(2,7)}`
-    const next = structuredClone(page)
-    const arr = getSlotArray(next, selSlot)
-    arr.splice(i+1, 0, copy)
-    setSlotArray(next, selSlot, arr)
-    push(next); setSelId(copy.id)
+    const copy: ComponentNode = clone(src)
+    copy.id = `${src.type.toLowerCase()}_${Math.random().toString(36).slice(2, 7)}`
+    const next = clone(page)
+    const arr = getSlotArray(next, targetSlot)
+    arr.splice(i + 1, 0, copy)
+    setSlotArray(next, targetSlot, arr)
+    push(next)
+    setSelSlot(targetSlot)
+    setSelId(copy.id)
   }
 
-  const moveSelToSlot = (dest: SlotName) => {
-    if (!selId || dest===selSlot) return
-    const next = structuredClone(page)
-    const fromArr = getSlotArray(next, selSlot)
-    const i = fromArr.findIndex(n=>n.id===selId); if (i<0) return
-    const [node] = fromArr.splice(i,1)
-    setSlotArray(next, selSlot, fromArr)
+  const moveSelToSlot = (dest: SlotName, sourceSlot?: SlotName, nodeId?: string) => {
+    const fromSlot = sourceSlot ?? selSlot
+    const id = nodeId ?? selId
+    if (!id || dest === fromSlot) return
+    const next = clone(page)
+    const fromArr = getSlotArray(next, fromSlot)
+    const i = fromArr.findIndex((n) => n.id === id)
+    if (i < 0) return
+    const [node] = fromArr.splice(i, 1)
+    setSlotArray(next, fromSlot, fromArr)
     const toArr = getSlotArray(next, dest)
     toArr.push(node)
     setSlotArray(next, dest, toArr)
-    push(next); setSelSlot(dest)
+    push(next)
+    setSelSlot(dest)
+    setSelId(node.id)
   }
+
+  const renderNodeList = (nodes: ComponentNode[], slot: SlotName) => (
+    <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
+      {nodes.map((n) => {
+        const isActive = selSlot === slot && selId === n.id
+        return (
+          <li
+            key={n.id}
+            onClick={() => {
+              setSelSlot(slot)
+              setSelId(n.id)
+            }}
+            style={{
+              padding: '10px',
+              border: '2px solid ' + (isActive ? '#111' : '#ddd'),
+              borderRadius: 10,
+              background: '#fafafa',
+              cursor: 'pointer',
+              outline: isActive ? '2px solid #111' : 'none',
+            }}
+            onMouseEnter={(e) => {
+              if (isActive) return
+              e.currentTarget.style.outline = '2px dashed #bbb'
+            }}
+            onMouseLeave={(e) => {
+              if (isActive) return
+              e.currentTarget.style.outline = 'none'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <div style={{ fontSize: 12, color: '#666' }}>{n.type}</div>
+                <div style={{ fontWeight: 600 }}>
+                  {n.type === 'Text'
+                    ? (n.props as any)?.text
+                    : n.type === 'Hero'
+                    ? (n.props as any)?.title
+                    : `[${n.type}]`}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setSelSlot(slot)
+                    setSelId(n.id)
+                    duplicateSel(slot, n.id)
+                  }}
+                >
+                  複製
+                </button>
+                <select
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => {
+                    const value = (e.target as HTMLSelectElement).value as SlotName
+                    if (!value) return
+                    setSelSlot(slot)
+                    setSelId(n.id)
+                    moveSelToSlot(value, slot, n.id)
+                  }}
+                >
+                  <option value="">→ slot</option>
+                  {slotOrder
+                    .filter((name) => name !== slot)
+                    .map((name) => (
+                      <option key={name} value={name}>
+                        {name}
+                      </option>
+                    ))}
+                </select>
+              </div>
+            </div>
+          </li>
+        )
+      })}
+      {nodes.length === 0 && (
+        <li style={{ color: '#888' }}>（このスロットにはまだ要素がありません）</li>
+      )}
+    </ul>
+  )
 
   const undo = () => {
     const prev = history.at(-1); if(!prev) return
@@ -789,7 +942,7 @@ export default function Builder() {
   const selected = useMemo(() => currentNodes.find(n=>n.id===selId), [currentNodes, selId])
 
   // keyboard shortcuts
-  const SLOT_ORDER: SlotName[] = ['header','sidebar','content','footer']
+  const slotOrder: SlotName[] = isMetaMode ? META_SLOTS : ['header','sidebar','content','footer']
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!selId) return
@@ -798,15 +951,15 @@ export default function Builder() {
       if (e.key === 'ArrowDown'){ e.preventDefault(); moveSel( 1) }
       if (e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
         e.preventDefault()
-        const idx = SLOT_ORDER.indexOf(selSlot)
-        const nextIdx = e.key === 'ArrowLeft' ? Math.max(0, idx-1) : Math.min(SLOT_ORDER.length-1, idx+1)
-        const dest = SLOT_ORDER[nextIdx]
+        const idx = slotOrder.indexOf(selSlot)
+        const nextIdx = e.key === 'ArrowLeft' ? Math.max(0, idx-1) : Math.min(slotOrder.length-1, idx+1)
+        const dest = slotOrder[nextIdx]
         if (dest !== selSlot) moveSelToSlot(dest)
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [selId, page, selSlot])
+  }, [selId, page, selSlot, slotOrder])
 
   // dirty tracking and save
   useEffect(()=>{
@@ -816,6 +969,13 @@ export default function Builder() {
 
   const save = async () => {
     if (!dirty) return
+    if (isMetaMode) {
+      const snapshot: Page = { ...page, frameId }
+      await saveBuilderManifest(snapshot)
+      const snap = JSON.stringify({ page: snapshot, frameId })
+      setLastSaved(snap)
+      return
+    }
     const frame = currentFrame
     await fetch('/api/save', {
       method:'POST',
@@ -841,10 +1001,11 @@ export default function Builder() {
   useEffect(()=>{ if (!dirty && showDiff) setShowDiff(false) }, [dirty, showDiff])
 
   const newPage = () => {
+    if (isMetaMode) return
     const id = prompt('新しい pageId を入力してください（例：map-about）','map-about')
     if (!id) return
     setHistory([])
-    setSelSlot('content')
+    setSelSlot(primarySlot)
     setSelId(undefined)
     const np = DEFAULT_PAGE(id)
     setPage(np)
@@ -857,9 +1018,10 @@ export default function Builder() {
       {/* 左ペイン：パレット＋Slot切替 */}
       <div style={{borderRight:'1px solid #eee', padding:12, display:'grid', gridTemplateRows:'auto auto auto 1fr auto', gap:12}}>
         <div style={{display:'flex', gap:8, alignItems:'center'}}>
-          <button onClick={newPage} style={{padding:'6px 10px', border:'1px solid #ddd', borderRadius:8, background:'#fff'}}>New Page</button>
+          <button onClick={newPage} disabled={isMetaMode} style={{padding:'6px 10px', border:'1px solid #ddd', borderRadius:8, background:'#fff', opacity: isMetaMode ? 0.6 : 1}}>New Page</button>
           <button
             onClick={async()=>{
+              if (isMetaMode) return
               const to = prompt('新しい pageId を入力', page.id)
               if(!to || to===page.id) return
               const res = await fetch('/api/rename', { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ oldId: page.id, newId: to }) })
@@ -870,7 +1032,8 @@ export default function Builder() {
               localStorage.setItem('chizu:lastPageId', j.id)
               show(`Renamed → ${j.id}`)
             }}
-            style={{padding:'6px 10px', border:'1px solid #ddd', borderRadius:8, background:'#fff'}}>Rename</button>
+            disabled={isMetaMode}
+            style={{padding:'6px 10px', border:'1px solid #ddd', borderRadius:8, background:'#fff', opacity: isMetaMode ? 0.6 : 1}}>Rename</button>
           <button
             onClick={()=>setShowDiff(v=>!v)}
             style={{padding:'6px 10px', border:'1px solid #ddd', borderRadius:8, background:'#fff'}}
@@ -882,10 +1045,11 @@ export default function Builder() {
 
           <select
             value={frameId}
+            disabled={isMetaMode}
             onChange={(e) => {
               const nextId = (e.target as HTMLSelectElement).value
-              const nextFrame = FRAMES.find(f => f.id === nextId)!
-              const prevFrame = FRAMES.find(f => f.id === frameId)!
+              const nextFrame = frames.find((f) => f.id === nextId)!
+              const prevFrame = frames.find((f) => f.id === frameId)!
               const missing = Object.keys(page.slotAssignments ?? {}).filter(s => !nextFrame.slots.some(ns => ns.name===s))
               if (missing.length) {
                 const ok = confirm(`次のslotが新しいFrameに存在しません: ${missing.join(', ')}\ncontent末尾へ退避します。続行しますか？`)
@@ -895,13 +1059,13 @@ export default function Builder() {
               setHistory(h=>[...h.slice(-49), page])
               setPage(remapped)
               setFrameId(nextId)
-              setSelSlot('content')
+              setSelSlot(primarySlot)
               setSelId(undefined)
             }}
             style={{marginLeft:'auto', padding:'6px 8px', border:'1px solid #ddd', borderRadius:8}}
             title="Frameを変更（未対応slotはcontentへ退避）"
           >
-            {FRAMES.map(f => <option key={f.id} value={f.id}>{f.name}</option>)}
+            {frames.map(f => <option key={f.id} value={f.id}>{f.name}</option>)}
           </select>
         </div>
 
@@ -914,22 +1078,25 @@ export default function Builder() {
                 <div key={id} style={{display:'grid', gridTemplateColumns:'1fr auto auto', gap:8}}>
                   <button
                     onClick={() => loadPage(id)}
+                    disabled={isMetaMode}
                     style={{
                       padding:'6px 8px', border:'1px solid #ddd', borderRadius:8,
-                      background: id===page.id ? '#eef' : '#fff', textAlign:'left'
+                      background: id===page.id ? '#eef' : '#fff', textAlign:'left', opacity: isMetaMode ? 0.6 : 1
                     }}
                   >
                     {id}
                   </button>
                   <button
                     onClick={() => duplicatePage(id)}
-                    style={{padding:'6px 8px', border:'1px solid #ddd', borderRadius:8, background:'#fff'}}
+                    disabled={isMetaMode}
+                    style={{padding:'6px 8px', border:'1px solid #ddd', borderRadius:8, background:'#fff', opacity: isMetaMode ? 0.6 : 1}}
                   >
                     複製
                   </button>
                   <button
                     onClick={() => deletePage(id)}
-                    style={{padding:'6px 8px', border:'1px solid #f0c', color:'#c00', background:'#fff', borderRadius:8}}
+                    disabled={isMetaMode}
+                    style={{padding:'6px 8px', border:'1px solid #f0c', color:'#c00', background:'#fff', borderRadius:8, opacity: isMetaMode ? 0.6 : 1}}
                   >
                     削除
                   </button>
@@ -943,9 +1110,22 @@ export default function Builder() {
 
         <div>
           <h3 style={{margin:'8px 0'}}>Slots</h3>
-          <div style={{display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:8}}>
-            {(['header','sidebar','content','footer'] as SlotName[]).map(s => (
-              <button key={s} onClick={()=>{setSelSlot(s); setSelId(undefined)}} style={{padding:'6px 8px', border:'1px solid #ddd', borderRadius:8, background: selSlot===s ? '#111' : '#fff', color: selSlot===s ? '#fff' : '#111'}}>
+          <div style={{display:'grid', gridTemplateColumns:`repeat(${slotOrder.length},1fr)`, gap:8}}>
+            {slotOrder.map((s) => (
+              <button
+                key={s}
+                onClick={() => {
+                  setSelSlot(s)
+                  setSelId(undefined)
+                }}
+                style={{
+                  padding: '6px 8px',
+                  border: '1px solid #ddd',
+                  borderRadius: 8,
+                  background: selSlot === s ? '#111' : '#fff',
+                  color: selSlot === s ? '#fff' : '#111',
+                }}
+              >
                 {s}
               </button>
             ))}
@@ -971,45 +1151,23 @@ export default function Builder() {
         </div>
       </div>
 
-      {/* 中央：キャンバス（選択中Slotの中身だけを表示） */}
-      <div style={{padding:12}}>
-        <h3 style={{margin:'8px 0'}}>Canvas ({selSlot})</h3>
-        <ul style={{listStyle:'none', padding:0, margin:0, display:'grid', gap:8}}>
-          {currentNodes.map(n => (
-            <li
-              key={n.id}
-              onClick={()=>setSelId(n.id)}
-              style={{
-                padding:'10px',
-                border:'2px solid ' + (n.id===selId ? '#111' : '#ddd'),
-                borderRadius:10,
-                background:'#fafafa',
-                cursor:'pointer',
-                outline: n.id===selId ? '2px solid #111' : 'none'
-              }}
-              onMouseEnter={e=>{ if (n.id!==selId) (e.currentTarget.style.outline='2px dashed #bbb') }}
-              onMouseLeave={e=>{ if (n.id!==selId) (e.currentTarget.style.outline='none') }}
-            >
-              <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
-                <div>
-                  <div style={{fontSize:12,color:'#666'}}>{n.type}</div>
-                  <div style={{fontWeight:600}}>{n.type==='Text' ? (n.props as any)?.text : n.type==='Hero' ? (n.props as any)?.title : `[${n.type}]`}</div>
-                </div>
-                <div style={{display:'flex', gap:6}}>
-                  <button onClick={(e)=>{e.stopPropagation(); setSelId(n.id); duplicateSel()}}>複製</button>
-                  <select onClick={e=>e.stopPropagation()} onChange={e=>{setSelId(n.id); moveSelToSlot((e.target as HTMLSelectElement).value as any)}}>
-                    <option value="">→ slot</option>
-                    <option value="header">header</option>
-                    <option value="sidebar">sidebar</option>
-                    <option value="content">content</option>
-                    <option value="footer">footer</option>
-                  </select>
-                </div>
+      {/* 中央：キャンバス */}
+      <div style={{ padding: 12 }}>
+        {isMetaMode ? (
+          <div style={{ display: 'grid', gridTemplateColumns: '260px 1fr 320px', gap: 12 }}>
+            {META_SLOTS.map((slot) => (
+              <div key={slot} style={{ border: '1px solid #eee', borderRadius: 12, padding: 12, background: '#fff' }}>
+                <h3 style={{ margin: '8px 0' }}>Canvas ({slot})</h3>
+                {renderNodeList(getSlotNodes(page, slot), slot)}
               </div>
-            </li>
-          ))}
-          {currentNodes.length===0 && <li style={{color:'#888'}}>（このスロットにはまだ要素がありません）</li>}
-        </ul>
+            ))}
+          </div>
+        ) : (
+          <>
+            <h3 style={{ margin: '8px 0' }}>Canvas ({selSlot})</h3>
+            {renderNodeList(currentNodes, selSlot)}
+          </>
+        )}
       </div>
 
       {/* 右：Inspector（Props / Bindings タブ） */}
@@ -1028,7 +1186,7 @@ export default function Builder() {
             <PropsEditor node={selected} onChange={(k,v)=>updateProp(k,v)} />
           ) : (
             <BindingsEditor pageRoot={page} node={selected} onChange={(next)=>{
-              if (selSlot === 'content') {
+              if (selSlot === 'content' || selSlot === 'canvas') {
                 push({ ...page, content: (page.content ?? []).map(n => n.id===selected.id ? next : n) })
               } else {
                 const draft = structuredClone(page)

--- a/apps/builder/lib/meta/builderManifest.ts
+++ b/apps/builder/lib/meta/builderManifest.ts
@@ -1,0 +1,32 @@
+import type { ComponentNode, Page } from '@chizu/types'
+
+export type BuilderManifest = Page
+
+const leftSidebarPlaceholder: ComponentNode = {
+  id: 'builder-left-placeholder',
+  type: 'Text',
+  props: { text: 'Left Sidebar' },
+}
+
+const canvasPlaceholder: ComponentNode = {
+  id: 'builder-canvas-placeholder',
+  type: 'Text',
+  props: { text: 'Canvas Area' },
+}
+
+const rightPanelPlaceholder: ComponentNode = {
+  id: 'builder-right-placeholder',
+  type: 'Text',
+  props: { text: 'Right Panel' },
+}
+
+export const DEFAULT_BUILDER_MANIFEST: BuilderManifest = {
+  id: 'builder-ui',
+  title: 'Builder UI Layout',
+  frameId: 'frame-builder',
+  content: [canvasPlaceholder],
+  slotAssignments: {
+    leftSidebar: [leftSidebarPlaceholder],
+    rightPanel: [rightPanelPlaceholder],
+  },
+}

--- a/apps/builder/lib/meta/storage.ts
+++ b/apps/builder/lib/meta/storage.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import Dexie, { type Table } from 'dexie'
+import type { Page } from '@chizu/types'
+import { DEFAULT_BUILDER_MANIFEST } from './builderManifest'
+
+const STORAGE_KEY = 'builder-ui-v1'
+
+type ManifestRecord = {
+  key: string
+  data: Page
+  updatedAt: number
+}
+
+class BuilderMetaDB extends Dexie {
+  manifests!: Table<ManifestRecord, string>
+
+  constructor() {
+    super('builder-meta')
+    this.version(1).stores({
+      manifests: '&key,updatedAt',
+    })
+  }
+}
+
+const db = new BuilderMetaDB()
+
+function clone<T>(value: T): T {
+  try {
+    return structuredClone(value)
+  } catch {
+    return JSON.parse(JSON.stringify(value)) as T
+  }
+}
+
+export async function loadBuilderManifest(): Promise<Page> {
+  try {
+    const record = await db.manifests.get(STORAGE_KEY)
+    if (record?.data) {
+      return clone(record.data)
+    }
+  } catch {}
+  return clone(DEFAULT_BUILDER_MANIFEST)
+}
+
+export async function saveBuilderManifest(manifest: Page): Promise<void> {
+  await db.manifests.put({
+    key: STORAGE_KEY,
+    data: clone(manifest),
+    updatedAt: Date.now(),
+  })
+}


### PR DESCRIPTION
## Summary
- add a default builder manifest with left/canvas/right placeholders
- provide Dexie-backed helpers to load and save the manifest
- update the builder page to support meta mode slots, render all three columns, and persist via Dexie

## Testing
- pnpm lint:all

------
https://chatgpt.com/codex/tasks/task_e_68c91b866df4832cb7f18192eae819f9