### PR TITLE
feat(builder): wire meta renderer with safe fallback

### DIFF
--- a/apps/builder/app/page.tsx
+++ b/apps/builder/app/page.tsx
@@ -1,10 +1,12 @@
 'use client'
 import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import type { Page, ComponentNode, Frame } from '@chizu/types'
 import * as REG from '@chizu/registry'
 import { AutosaveMountHashed } from '@/components/AutosaveMountHashed'
 import { ApplyLastSnippetButton } from '@/components/bindings/ApplyLastSnippetButton'
+import { CanvasRenderer } from '@/components/CanvasRenderer'
 
 const fetcher = (u: string) => fetch(u).then((r) => r.json())
 
@@ -61,6 +63,38 @@ const PREVIEW_API: Record<string, any> = {
     '01': { name: '北海道', population: 5224614 },
     '13': { name: '東京都', population: 14047594 },
   },
+}
+
+const FRAME_TYPE_MAP: Record<string, string> = {
+  'frame-basic': 'Frame_Basic',
+  'frame-top': 'Frame_Toponly',
+  'frame-wide': 'Frame_Wide',
+}
+
+function cloneNodes(nodes?: ComponentNode[] | null): ComponentNode[] {
+  if (!Array.isArray(nodes)) return []
+  try {
+    return structuredClone(nodes)
+  } catch {
+    return JSON.parse(JSON.stringify(nodes)) as ComponentNode[]
+  }
+}
+
+function buildPreviewTree(page: Page, frameId: string): ComponentNode[] {
+  const type = FRAME_TYPE_MAP[frameId] ?? 'Frame_Basic'
+  const slots: Record<string, ComponentNode[]> = {}
+  slots.content = cloneNodes(page.content)
+  const assignments = page.slotAssignments ?? {}
+  for (const [slot, nodes] of Object.entries(assignments)) {
+    slots[slot] = cloneNodes(nodes)
+  }
+  return [
+    {
+      id: 'frame-root',
+      type,
+      slots,
+    },
+  ]
 }
 
 // ---- diff utilities ----
@@ -551,6 +585,8 @@ function BindingsEditor({
 }
 
 export default function Builder() {
+  const searchParams = useSearchParams()
+  const isMetaMode = searchParams?.get('meta') === '1'
   const [page,setPage] = useState<Page>(() => {
     const p = DEFAULT_PAGE('map-home')
     p.content.push({ id:'hero_init', type:'Hero', props:{ title:'地図で集める旅' } })
@@ -787,6 +823,16 @@ export default function Builder() {
   }
 
   const selected = useMemo(() => currentNodes.find(n=>n.id===selId), [currentNodes, selId])
+  const previewTree = useMemo(() => buildPreviewTree(page, frameId), [page, frameId])
+  const previewRuntime = useMemo(
+    () => ({
+      page: { prefCode: (page as any)?.prefCode ?? '13' },
+      frame: { id: frameId },
+      api: PREVIEW_API,
+      app: {},
+    }),
+    [page, frameId],
+  )
 
   // keyboard shortcuts
   const SLOT_ORDER: SlotName[] = ['header','sidebar','content','footer']
@@ -974,6 +1020,14 @@ export default function Builder() {
       {/* 中央：キャンバス（選択中Slotの中身だけを表示） */}
       <div style={{padding:12}}>
         <h3 style={{margin:'8px 0'}}>Canvas ({selSlot})</h3>
+        <div style={{border:'1px solid #eee', borderRadius:12, padding:12, background:'#fff', marginBottom:12}}>
+          <CanvasRenderer
+            tree={previewTree}
+            runtime={previewRuntime}
+            builderManifest={isMetaMode ? previewTree : undefined}
+            isMetaMode={isMetaMode}
+          />
+        </div>
         <ul style={{listStyle:'none', padding:0, margin:0, display:'grid', gap:8}}>
           {currentNodes.map(n => (
             <li

--- a/apps/builder/components/CanvasRenderer.tsx
+++ b/apps/builder/components/CanvasRenderer.tsx
@@ -1,0 +1,273 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import type { ComponentNode, Bindings, Binding } from '@chizu/types'
+import { entries as registryEntries } from '@chizu/registry'
+import Repeat from '@/components/runtime/Repeat'
+
+export type RuntimeValue = {
+  page?: Record<string, any>
+  frame?: Record<string, any>
+  app?: Record<string, any>
+  api?: Record<string, any>
+}
+
+type CanvasRendererProps = {
+  tree: ComponentNode[]
+  runtime?: RuntimeValue
+  builderManifest?: ComponentNode[] | null
+  isMetaMode?: boolean
+  className?: string
+}
+
+const FACTORY_MANIFEST: ComponentNode[] = [
+  {
+    id: 'factory-frame',
+    type: 'Frame_Basic',
+    slots: {
+      header: [
+        {
+          id: 'factory-nav',
+          type: 'TopNav',
+        },
+      ],
+      sidebar: [
+        {
+          id: 'factory-pref-list',
+          type: 'PrefList',
+        },
+      ],
+      content: [
+        {
+          id: 'factory-hero',
+          type: 'Hero',
+          props: { title: 'Safe Mode' },
+        },
+        {
+          id: 'factory-text',
+          type: 'Text',
+          props: {
+            text: 'Builder manifest could not be loaded. Showing fallback layout.',
+          },
+        },
+      ],
+      footer: [],
+    },
+  },
+]
+
+type BindingScope = 'local' | 'page' | 'frame' | 'app' | 'api'
+
+type RepeatNode = ComponentNode & { kind?: 'Repeat'; dataPath?: string; itemKey?: string }
+
+function getRef(runtime: RuntimeValue, scope: BindingScope, path: string) {
+  const root =
+    scope === 'page'
+      ? runtime.page
+      : scope === 'frame'
+      ? runtime.frame
+      : scope === 'app'
+      ? runtime.app
+      : scope === 'api'
+      ? runtime.api
+      : undefined
+  if (!root) return undefined
+  if (!path) return root
+  const parts = path.split('.').filter(Boolean)
+  let cur: any = root
+  for (const p of parts) {
+    if (cur == null) return undefined
+    cur = cur[p]
+  }
+  return cur
+}
+
+function evalFormula(expr: string, inputs: any[]) {
+  // eslint-disable-next-line no-new-func
+  const f = new Function('$0', '$1', '$2', '$3', '$4', `return (${expr})`)
+  return f(inputs[0], inputs[1], inputs[2], inputs[3], inputs[4])
+}
+
+function resolveBindings(
+  runtime: RuntimeValue,
+  nodeId: string,
+  props: Record<string, any>,
+  bindings?: Bindings,
+) {
+  if (!bindings) return props
+  const out: Record<string, any> = { ...props }
+  for (const [prop, binding] of Object.entries(bindings)) {
+    const b = binding as Binding
+    try {
+      const ins = (b.inputs ?? []).map((input) =>
+        getRef(runtime, (input as any).scope as BindingScope, (input as any).path ?? ''),
+      )
+      const val = b.formula?.expr ? evalFormula(b.formula.expr, ins) : ins[0]
+      if (val !== undefined) out[prop] = val
+    } catch (err) {
+      console.warn(`[binding:${nodeId}.${prop}]`, err)
+    }
+  }
+  return out
+}
+
+function renderNode(node: ComponentNode, runtime: RuntimeValue): React.ReactNode {
+  if (!node) return null
+  const maybeRepeat = node as RepeatNode
+  if (maybeRepeat.kind === 'Repeat') {
+    const children = (maybeRepeat.children ?? []).map((child) => renderNode(child, runtime))
+    return (
+      <Repeat
+        key={maybeRepeat.id}
+        runtime={runtime}
+        dataPath={maybeRepeat.dataPath}
+        itemKey={maybeRepeat.itemKey}
+        data={(maybeRepeat as any).data as any[]}
+      >
+        {children}
+      </Repeat>
+    )
+  }
+
+  const entry = (registryEntries as any)[node.type]
+  if (!entry || typeof entry.render !== 'function') {
+    return (
+      <div
+        key={node.id}
+        style={{
+          padding: '12px',
+          border: '1px solid rgba(0,0,0,0.1)',
+          borderRadius: 8,
+          fontSize: 12,
+          color: '#b91c1c',
+        }}
+      >
+        Unknown component: {node.type}
+      </div>
+    )
+  }
+
+  const resolvedProps = resolveBindings(runtime, node.id, node.props ?? {}, node.bindings)
+  const slotNodes = node.slots
+    ? Object.fromEntries(
+        Object.entries(node.slots).map(([slotName, slotChildren]) => [
+          slotName,
+          (slotChildren ?? []).map((child) => renderNode(child, runtime)),
+        ]),
+      )
+    : undefined
+  const childNodes = (node.children ?? []).map((child) => renderNode(child, runtime))
+
+  let rendered: React.ReactNode
+  try {
+    rendered = entry.render(resolvedProps, slotNodes, runtime)
+  } catch (err) {
+    console.error(`[render:${node.type}]`, err)
+    rendered = (
+      <div
+        style={{
+          padding: '12px',
+          border: '1px solid rgba(0,0,0,0.1)',
+          borderRadius: 8,
+          fontSize: 12,
+          color: '#b91c1c',
+        }}
+      >
+        Render failed: {String(node.type)}
+      </div>
+    )
+  }
+
+  if (React.isValidElement(rendered) && childNodes.length > 0) {
+    return (
+      <React.Fragment key={node.id}>
+        {React.cloneElement(rendered, rendered.props, (
+          <>
+            {rendered.props?.children}
+            {childNodes}
+          </>
+        ))}
+      </React.Fragment>
+    )
+  }
+
+  if (childNodes.length > 0) {
+    return (
+      <React.Fragment key={node.id}>
+        {rendered}
+        {childNodes}
+      </React.Fragment>
+    )
+  }
+
+  return <React.Fragment key={node.id}>{rendered}</React.Fragment>
+}
+
+function isRenderableManifest(nodes: ComponentNode[] | null | undefined): nodes is ComponentNode[] {
+  if (!Array.isArray(nodes)) return false
+  const visit = (arr: ComponentNode[]): boolean => {
+    for (const node of arr) {
+      if (!node || typeof node !== 'object') return false
+      const maybeRepeat = node as RepeatNode
+      if (maybeRepeat.kind === 'Repeat') {
+        if (maybeRepeat.children && !visit(maybeRepeat.children)) return false
+        continue
+      }
+      if (typeof node.id !== 'string' || typeof node.type !== 'string') return false
+      const entry = (registryEntries as any)[node.type]
+      if (!entry || typeof entry.render !== 'function') return false
+      if (node.children && !visit(node.children)) return false
+      if (node.slots) {
+        for (const slotChildren of Object.values(node.slots)) {
+          if (slotChildren && !visit(slotChildren)) return false
+        }
+      }
+    }
+    return true
+  }
+  return visit(nodes)
+}
+
+export function CanvasRenderer({
+  tree,
+  runtime,
+  builderManifest,
+  isMetaMode = false,
+  className,
+}: CanvasRendererProps) {
+  const runtimeValue = useMemo(() => runtime ?? {}, [runtime])
+
+  const { nodesToRender, fallbackActive } = useMemo(() => {
+    if (isMetaMode) {
+      if (isRenderableManifest(builderManifest)) {
+        return { nodesToRender: builderManifest, fallbackActive: false }
+      }
+      return { nodesToRender: FACTORY_MANIFEST, fallbackActive: true }
+    }
+    const base = Array.isArray(tree) ? tree : []
+    return { nodesToRender: base, fallbackActive: false }
+  }, [builderManifest, isMetaMode, tree])
+
+  return (
+    <div className={className} data-safe-manifest={fallbackActive ? '1' : undefined}>
+      {fallbackActive ? (
+        <div
+          style={{
+            marginBottom: 12,
+            padding: '8px 12px',
+            border: '1px solid rgba(0,0,0,0.1)',
+            borderRadius: 8,
+            background: '#fff7ed',
+            color: '#9a3412',
+            fontSize: 12,
+          }}
+        >
+          Safe Mode: Builder manifest fallback applied. Please review your saved layout.
+        </div>
+      ) : null}
+      <div style={{ display: 'grid', gap: 12 }}>
+        {nodesToRender.map((node) => renderNode(node, runtimeValue))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a client-side CanvasRenderer that resolves bindings, supports Repeat nodes, and falls back to a factory manifest when meta rendering fails
- map builder pages into registry frame nodes and surface meta=1 flag to drive the new renderer on the main canvas with a safe-mode banner
- clone frame assignments into preview trees so runtime props stay isolated from editor state

## Testing
- pnpm --filter builder build *(fails: Conflicting app and page file was found, please remove the conflicting files to continue)*

------
https://chatgpt.com/codex/tasks/task_e_68c91b8e4b28832c8e1b3dc22e429937