### PR TITLE
feat(binding): add api scope preview support

### DIFF
--- a/apps/builder/components/rightpane/DataPanel.tsx
+++ b/apps/builder/components/rightpane/DataPanel.tsx
@@ -9,7 +9,7 @@ export default function DataPanel() {
   const { selectedNodeId, getBindingsForNode, setBinding } = useBuilderStore()
   const mode = useEnvStore((s) => s.mode)
   const [propId, setPropId] = React.useState('text')
-  const [kind, setKind] = React.useState<'local' | 'global'>('local')
+  const [kind, setKind] = React.useState<'local' | 'global' | 'api'>('local')
   const [path, setPath] = React.useState('')
   const [testOut, setTestOut] = React.useState<string>('')
   const [repeatPath, setRepeatPath] = React.useState('list.items')
@@ -57,9 +57,15 @@ export default function DataPanel() {
         <select value={kind} onChange={(e) => setKind(e.target.value as any)} className="border rounded px-2 py-1 text-xs">
           <option value="local">local</option>
           <option value="global">global</option>
+          <option value="api">api</option>
         </select>
         <label className="text-xs">Path</label>
-        <input value={path} onChange={(e) => setPath(e.target.value)} placeholder="user.name" className="border rounded px-2 py-1 text-xs" />
+        <input
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+          placeholder={kind === 'api' ? 'prefStats.0.value' : 'user.name'}
+          className="border rounded px-2 py-1 text-xs"
+        />
       </div>
       <div className="flex gap-2">
         <button data-testid="binding-apply" className="underline" onClick={onAdd}>Apply</button>

--- a/apps/builder/lib/binding/resolve.ts
+++ b/apps/builder/lib/binding/resolve.ts
@@ -2,18 +2,120 @@
 import type { BindingSource } from '@/types/binding'
 import type { EnvMode } from '@/stores/env'
 import { getRuntimeForMode } from '@/lib/dataSources'
-import type { Bindings } from '@chizu/types'
+import type { Bindings, Binding as RendererBinding } from '@chizu/types'
 import { resolveBinding as renderResolve } from '@chizu/renderer'
 
-export function toRendererBindings(map: Record<string, BindingSource | undefined>): Bindings | undefined {
+type ApiPreviewCacheEntry = { exp: number; data: any }
+const apiPreviewCache = new Map<string, ApiPreviewCacheEntry>()
+const apiPreviewPending = new Map<string, Promise<any>>()
+
+type DataSourceMetaCache = { exp: number; ttlByKey: Map<string, number> }
+let dataSourceMetaCache: DataSourceMetaCache | undefined
+
+type RendererBindingsResult = {
+  bindings: Bindings | undefined
+  apiRuntime?: Record<string, any>
+}
+
+function extractApiKey(path: string): string | undefined {
+  if (!path) return undefined
+  const match = path.trim().match(/^([a-zA-Z0-9_-]+)/)
+  return match?.[1]
+}
+
+async function loadDataSourceMeta(): Promise<Map<string, number>> {
+  const now = Date.now()
+  const cache = dataSourceMetaCache
+  if (cache && cache.exp > now) return cache.ttlByKey
+  if (typeof fetch !== 'function') {
+    const ttlByKey = cache?.ttlByKey ?? new Map<string, number>()
+    dataSourceMetaCache = { exp: now + 30_000, ttlByKey }
+    return ttlByKey
+  }
+  try {
+    const res = await fetch('/api/ds', { cache: 'no-store' })
+    if (res.ok) {
+      const json = (await res.json()) as { items?: Array<{ key?: string; ttlSec?: number }> }
+      const ttlByKey = new Map<string, number>()
+      for (const item of Array.isArray(json?.items) ? json.items : []) {
+        if (!item || typeof item.key !== 'string') continue
+        const ttlSec = typeof item.ttlSec === 'number' ? item.ttlSec : undefined
+        const ttlMs = ttlSec && ttlSec > 0 ? ttlSec * 1000 : 0
+        ttlByKey.set(item.key, ttlMs)
+      }
+      dataSourceMetaCache = { exp: now + 60_000, ttlByKey }
+      return ttlByKey
+    }
+  } catch {}
+  const ttlByKey = cache?.ttlByKey ?? new Map<string, number>()
+  dataSourceMetaCache = { exp: now + 30_000, ttlByKey }
+  return ttlByKey
+}
+
+async function fetchApiPreview(key: string): Promise<any> {
+  const now = Date.now()
+  const cached = apiPreviewCache.get(key)
+  if (cached && cached.exp > now) return cached.data
+  if (typeof fetch !== 'function') return null
+  const pending = apiPreviewPending.get(key)
+  if (pending) return pending
+  const fetchPromise = (async () => {
+    let data: any = null
+    try {
+      const res = await fetch(`/api/ds-preview?key=${encodeURIComponent(key)}`, { cache: 'no-store' })
+      if (res.ok) {
+        const json = (await res.json()) as { data?: any }
+        data = json?.data ?? null
+      }
+    } catch {
+      data = null
+    }
+    const ttlMap = await loadDataSourceMeta()
+    const ttlMs = ttlMap.get(key) ?? 0
+    if (ttlMs > 0) {
+      apiPreviewCache.set(key, { exp: Date.now() + ttlMs, data })
+    } else {
+      apiPreviewCache.delete(key)
+    }
+    return data
+  })()
+  apiPreviewPending.set(key, fetchPromise)
+  try {
+    return await fetchPromise
+  } finally {
+    apiPreviewPending.delete(key)
+  }
+}
+
+export async function toRendererBindings(map: Record<string, BindingSource | undefined>): Promise<RendererBindingsResult> {
   const entries = Object.entries(map).filter(([, v]) => v && v.path)
-  if (entries.length === 0) return undefined
-  const out: any = {}
+  if (entries.length === 0) return { bindings: undefined }
+  const out: Record<string, RendererBinding> = {}
+  const apiKeys = new Set<string>()
   for (const [prop, src] of entries) {
     if (!src) continue
-    out[prop] = { inputs: [{ scope: src.kind === 'local' ? 'page' : 'app', path: src.path }] }
+    if (src.kind === 'local') {
+      out[prop] = { inputs: [{ scope: 'page', path: src.path }] }
+    } else if (src.kind === 'global') {
+      out[prop] = { inputs: [{ scope: 'app', path: src.path }] }
+    } else if (src.kind === 'api') {
+      out[prop] = { inputs: [{ scope: 'api', path: src.path }] }
+      const key = extractApiKey(src.path)
+      if (key) apiKeys.add(key)
+    }
   }
-  return out
+  const bindings = Object.keys(out).length ? (out as Bindings) : undefined
+  let apiRuntime: Record<string, any> | undefined
+  if (apiKeys.size > 0) {
+    const pairs = await Promise.all(
+      Array.from(apiKeys).map(async (key) => [key, await fetchApiPreview(key)] as const)
+    )
+    apiRuntime = {}
+    for (const [key, data] of pairs) {
+      apiRuntime[key] = data
+    }
+  }
+  return { bindings, apiRuntime }
 }
 
 export async function resolvePropsWithBindings(
@@ -24,9 +126,10 @@ export async function resolvePropsWithBindings(
   item?: any
 ) {
   const runtime = await getRuntimeForMode(mode)
-  const runtimeWithItem = item === undefined ? runtime : { ...runtime, item }
-  const b = toRendererBindings(propBindings)
-  return renderResolve(runtimeWithItem, nodeId, props, b as any)
+  const { bindings, apiRuntime } = await toRendererBindings(propBindings)
+  const runtimeWithApi = apiRuntime ? { ...runtime, api: { ...(runtime as any).api, ...apiRuntime } } : runtime
+  const runtimeWithItem = item === undefined ? runtimeWithApi : { ...runtimeWithApi, item }
+  return renderResolve(runtimeWithItem, nodeId, props, bindings as any)
 }
 
 // Bridge for preview runtime (optional)

--- a/apps/builder/types/binding.ts
+++ b/apps/builder/types/binding.ts
@@ -1,6 +1,6 @@
 // apps/builder/types/binding.ts
 export type BindingSource = {
-  kind: 'local' | 'global'
+  kind: 'local' | 'global' | 'api'
   path: string
 }
 


### PR DESCRIPTION
## Summary
- add an `api` scope option to the DataPanel binding selector and adjust the form placeholder
- extend the binding types and resolver to hydrate api-scope bindings via `/api/ds-preview` with TTL-aware caching

## Testing
- pnpm test:unit


------
https://chatgpt.com/codex/tasks/task_e_68c91b93e180832c93bcc128648b9d6e