### PR TITLE
feat(builder): persist /api/save to .data/drafts with lastWriteTs

### DIFF
--- a/apps/builder/app/api/save/route.ts
+++ b/apps/builder/app/api/save/route.ts
@@ -1,15 +1,35 @@
 import { NextResponse } from 'next/server'
+import { mkdirSync, writeFileSync } from 'fs'
+import path from 'path'
+
+import { sanitizeSlug } from '@/lib/utils/sanitize'
+
+const draftsDir = path.join(process.cwd(), '.data', 'drafts')
 
 export async function POST(req: Request) {
   try {
     const body = await req.json().catch(() => null)
-    const pageId = (typeof body === 'object' && body && 'id' in (body as any))
-      ? String((body as any).id)
-      : 'unknown'
+    if (typeof body !== 'object' || body === null) {
+      return NextResponse.json({ ok: false, error: 'Invalid body' }, { status: 400 })
+    }
 
-    // append-only: place to add persistence/audit later
+    const rawId = 'id' in body
+      ? String((body as any).id ?? 'unknown')
+      : typeof (body as any)?.page === 'object' && (body as any).page && 'id' in (body as any).page
+        ? String(((body as any).page as any).id ?? 'unknown')
+        : 'unknown'
+    const id = sanitizeSlug(rawId)
 
-    return NextResponse.json({ ok: true, pageId }, { status: 200 })
+    const savedAt = new Date().toISOString()
+    const lastWriteTs = typeof (body as any)?.lastWriteTs === 'number'
+      ? Number((body as any).lastWriteTs)
+      : Date.now()
+
+    mkdirSync(draftsDir, { recursive: true })
+    const targetPath = path.join(draftsDir, `${id}.json`)
+    writeFileSync(targetPath, JSON.stringify(body, null, 2), 'utf8')
+
+    return NextResponse.json({ ok: true, savedAt, lastWriteTs, id }, { status: 200 })
   } catch (e: any) {
     return NextResponse.json({ ok: false, error: String(e) }, { status: 500 })
   }

--- a/apps/builder/components/AutosaveBadge.tsx
+++ b/apps/builder/components/AutosaveBadge.tsx
@@ -1,9 +1,11 @@
 // apps/builder/components/AutosaveBadge.tsx
 'use client'
 import React from 'react'
+import { useSaveStore } from '@/stores/saveQueue'
 
 export function AutosaveBadge() {
   const [queued, setQueued] = React.useState(0)
+  const lastSavedAt = useSaveStore((s) => s.lastSavedAt)
   const onQueued  = (_e: Event) => setQueued((n) => n + 1)
   const onSaved   = (_e: Event) => setQueued((n) => Math.max(0, n - 1))
   const onError   = (_e: Event) => setQueued((n) => n)
@@ -26,13 +28,15 @@ export function AutosaveBadge() {
   }, [])
 
   const offline = typeof navigator !== 'undefined' && navigator.onLine === false
+  const savedLabel = lastSavedAt ? new Date(lastSavedAt).toLocaleTimeString() : null
+
   return (
     <div style={{
       position:'fixed', right:12, bottom:12, padding:'6px 10px',
       borderRadius:12, background: offline ? '#fee2e2' : (queued>0 ? '#fef9c3' : '#e2fbe2'),
       color:'#111', fontSize:12, boxShadow:'0 1px 4px rgba(0,0,0,0.12)', zIndex:9999
     }}>
-      {offline ? 'Offline' : 'Autosave'} {queued>0 ? `• Queue ${queued}` : '• OK'}
+      {offline ? 'Offline' : 'Autosave'} {queued>0 ? `• Queue ${queued}` : savedLabel ? `• Saved ${savedLabel}` : '• OK'}
     </div>
   )
 }

--- a/apps/builder/components/AutosaveMount.tsx
+++ b/apps/builder/components/AutosaveMount.tsx
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { useAutosave } from '@/src/hooks/useAutosave';
+import { recordSavedAt } from '@/stores/saveQueue';
 
 type Props = {
   page: any;             // 既存の page JSON（id を含む想定）
@@ -25,6 +26,19 @@ export function AutosaveMount({ page, debounceMs = 800 }: Props) {
         body: JSON.stringify(p),
       });
       if (!res.ok) throw new Error('save failed');
+      try {
+        const payload = await res.json();
+        const savedAtRaw = typeof payload?.savedAt === 'string'
+          ? Date.parse(payload.savedAt)
+          : typeof payload?.savedAt === 'number'
+            ? Number(payload.savedAt)
+            : Date.now();
+        const savedAt = Number.isFinite(savedAtRaw) ? savedAtRaw : Date.now();
+        const lastWriteTs = typeof payload?.lastWriteTs === 'number' ? Number(payload.lastWriteTs) : undefined;
+        recordSavedAt(savedAt, lastWriteTs);
+      } catch {
+        recordSavedAt(Date.now());
+      }
     },
     debounceMs,
   });

--- a/apps/builder/components/AutosaveMountHashed.tsx
+++ b/apps/builder/components/AutosaveMountHashed.tsx
@@ -2,6 +2,7 @@
 'use client'
 import * as React from 'react'
 import { useAutosave } from '@/src/hooks/useAutosave'
+import { recordSavedAt } from '@/stores/saveQueue'
 
 function stableStringify(x: any) {
   try {
@@ -33,6 +34,19 @@ export function AutosaveMountHashed({ page, debounceMs = 800 }: { page: any; deb
         body: JSON.stringify(p),
       })
       if (!res.ok) throw new Error('save failed')
+      try {
+        const payload = await res.json()
+        const savedAtRaw = typeof payload?.savedAt === 'string'
+          ? Date.parse(payload.savedAt)
+          : typeof payload?.savedAt === 'number'
+            ? Number(payload.savedAt)
+            : Date.now()
+        const savedAt = Number.isFinite(savedAtRaw) ? savedAtRaw : Date.now()
+        const lastWriteTs = typeof payload?.lastWriteTs === 'number' ? Number(payload.lastWriteTs) : undefined
+        recordSavedAt(savedAt, lastWriteTs)
+      } catch {
+        recordSavedAt(Date.now())
+      }
       lastHash.current = next
     },
     debounceMs,

--- a/apps/builder/lib/save/applyAndSave.ts
+++ b/apps/builder/lib/save/applyAndSave.ts
@@ -1,5 +1,5 @@
 // apps/builder/lib/save/applyAndSave.ts
-import { useSaveStore } from '@/stores/saveQueue'
+import { recordSavedAt, useSaveStore } from '@/stores/saveQueue'
 import { debounce } from '@/lib/utils/debounce'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -46,5 +46,8 @@ export const saveDebounced = debounce(async (slug: string, draft: any) => {
       try { await fetch('/api/audit-log', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ op: 'gateBypass', slug, score, reason, at: new Date().toISOString() }) }) } catch {}
     }
     await useSaveStore.getState().queueChange(slug, draft)
+    const nowTs = Date.now()
+    const lastWriteTs = typeof (draft as any)?.lastWriteTs === 'number' ? Number((draft as any).lastWriteTs) : nowTs
+    recordSavedAt(nowTs, lastWriteTs)
   } catch {}
 }, 1000)

--- a/apps/builder/stores/saveQueue.ts
+++ b/apps/builder/stores/saveQueue.ts
@@ -8,6 +8,7 @@ type SaveState = {
   offline: boolean
   queued: number
   lastSavedAt?: number
+  lastWriteTs?: number
   queueChange: (id: string, data: any) => Promise<void>
   flush: () => Promise<void>
   boot: () => Promise<void>
@@ -34,33 +35,41 @@ export const useSaveStore = create<SaveState>(() => ({
       await db.outbox.add({ target: `/api/drafts/${id}`, method: 'PUT', body: { data, updatedAt: now() }, createdAt: now() })
     }
     const cnt = await db.outbox.count()
-    ;(useSaveStore as any).setState({ queued: cnt })
+    useSaveStore.setState({ queued: cnt })
   },
   async flush() {
     const items = await db.outbox.toArray()
+    let lastWrite: number | undefined
     for (const it of items) {
       try {
         await fetch(it.target, { method: it.method, headers: { 'content-type': 'application/json' }, body: JSON.stringify(it.body) })
         await db.outbox.delete(it.id!)
+        const candidate = typeof (it.body as any)?.updatedAt === 'number' ? Number((it.body as any).updatedAt) : undefined
+        lastWrite = typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : now()
       } catch {
         break
       }
     }
     const cnt = await db.outbox.count()
-    ;(useSaveStore as any).setState({ queued: cnt, lastSavedAt: now() })
+    const savedAt = now()
+    useSaveStore.setState({ queued: cnt, lastSavedAt: savedAt, lastWriteTs: lastWrite ?? savedAt })
   },
   async boot() {
     const cnt = await db.outbox.count()
-    ;(useSaveStore as any).setState({ queued: cnt })
+    useSaveStore.setState({ queued: cnt })
     if (typeof window !== 'undefined') {
       window.addEventListener('online', () => {
-        ;(useSaveStore as any).setState({ offline: false })
+        useSaveStore.setState({ offline: false })
         useSaveStore.getState().flush()
       })
       window.addEventListener('offline', () => {
-        ;(useSaveStore as any).setState({ offline: true })
+        useSaveStore.setState({ offline: true })
       })
     }
   },
 }))
+
+export function recordSavedAt(savedAt: number, lastWriteTs?: number) {
+  useSaveStore.setState({ lastSavedAt: savedAt, lastWriteTs })
+}
 


### PR DESCRIPTION
## Summary
- persist POST bodies from /api/save as .data/drafts/<id>.json and return saved timestamps
- push saved timestamps into the autosave store so the badge can display the last save time
- record savedAt/lastWriteTs from autosave responses, covering both plain and hashed autosave mounts

## Testing
- pnpm --filter builder build *(fails: Conflicting app and page file was found, please remove the conflicting files to continue: "pages/dev/figma.tsx" - "app/dev/figma/page.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68c91b9bb9f0832cb1c0fa9a73b4d448