### PR TITLE
feat(audit): fetch UI audit data via API and link from audit log

### DIFF
--- a/apps/builder/app/audit/page.tsx
+++ b/apps/builder/app/audit/page.tsx
@@ -638,14 +638,20 @@ export default function AuditPage() {
     try { obj = JSON.parse(li.textContent || '{}') } catch { obj = null }
     const op = typeof obj?.op === 'string' ? obj.op : ''
     const hash = typeof obj?.contentHash === 'string' ? obj.contentHash : ''
+    const slug =
+      (typeof obj?.slug === 'string' && obj.slug) ||
+      (typeof obj?.id === 'string' && obj.id) ||
+      (typeof obj?.page?.id === 'string' ? obj.page.id : '')
     if (op) li.dataset.op = op
     if (hash) li.dataset.hash = hash
+    if (slug) li.dataset.slug = slug
 
     // Inject a shadow-based badge host so li.textContent stays as raw JSON
     const host = document.createElement('span')
     host.setAttribute('data-audit-badges', '1')
     host.style.position = 'relative'
     host.style.display = 'inline-block'
+    if (slug) host.dataset.slug = slug
     // no text nodes in light DOM
     li.appendChild(host)
     const shadow = host.attachShadow({ mode: 'open' })
@@ -679,8 +685,18 @@ export default function AuditPage() {
     shadow.appendChild(style)
     const wrap = document.createElement('span')
     wrap.style.marginLeft = '6px'
+    wrap.style.display = 'inline-flex'
+    wrap.style.alignItems = 'center'
+    wrap.style.gap = '4px'
     if (op) wrap.appendChild(makeBadge('op', op, 'op'))
     if (hash) wrap.appendChild(makeBadge('contentHash', hash, 'hash'))
+    const issueWrap = document.createElement('span')
+    issueWrap.setAttribute('data-ui-audit-issue-badges', '1')
+    issueWrap.style.display = 'inline-flex'
+    issueWrap.style.alignItems = 'center'
+    issueWrap.style.gap = '4px'
+    issueWrap.style.marginLeft = '4px'
+    wrap.appendChild(issueWrap)
     shadow.appendChild(wrap)
 
     ;(li as any).__auditAnno = true
@@ -761,4 +777,129 @@ export default function AuditPage() {
   setInterval(() => {
     const h = getHash(); if (h !== currentHash) tick()
   }, 500)
+})()
+
+// --- append-only: UI-Audit issue badges linking to /dev/ui-audit ---
+;(() => {
+  if (typeof window === 'undefined') return
+
+  type Issue = { id: string; kind: string; nodeId: string; slug: string; message?: string; scoreImpact?: number }
+
+  const goto = (slug: string, nodeId: string) => {
+    if (!slug || !nodeId) return
+    try {
+      const url = new URL('/dev/ui-audit', window.location.origin)
+      url.searchParams.set('slug', slug)
+      url.searchParams.set('highlight', nodeId)
+      window.location.href = url.toString()
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const labelFor = (kind: string) => {
+    if (kind === 'contrast') return 'contrast'
+    if (kind === 'grid8') return 'grid'
+    if (kind === 'alignment') return 'align'
+    return kind
+  }
+
+  const colorFor = (kind: string) => {
+    if (kind === 'contrast') return '#b91c1c'
+    if (kind === 'grid8') return '#b45309'
+    if (kind === 'alignment') return '#2563eb'
+    return '#2563eb'
+  }
+
+  const cache = new Map<string, Issue[] | null>()
+  const pending = new Map<string, Promise<Issue[] | null>>()
+
+  const fetchIssues = async (slug: string): Promise<Issue[] | null> => {
+    try {
+      const res = await fetch(`/api/ui-audit/issues?slug=${encodeURIComponent(slug)}`, { cache: 'no-store' })
+      if (!res.ok) return null
+      const data = await res.json()
+      return Array.isArray(data) ? (data as Issue[]) : null
+    } catch {
+      return null
+    }
+  }
+
+  const getIssues = async (slug: string): Promise<Issue[]> => {
+    if (cache.has(slug)) return cache.get(slug) ?? []
+    let task = pending.get(slug)
+    if (!task) {
+      task = fetchIssues(slug)
+      pending.set(slug, task)
+    }
+    const data = await task
+    pending.delete(slug)
+    cache.set(slug, data ?? [])
+    return data ?? []
+  }
+
+  const ensureBadges = async (li: HTMLLIElement) => {
+    const slug = li.dataset.slug || ''
+    if (!slug) return
+    const host = li.querySelector('[data-audit-badges]') as HTMLElement | null
+    if (!host) return
+    const shadow = host.shadowRoot
+    if (!shadow) return
+    const container = shadow.querySelector('[data-ui-audit-issue-badges]') as HTMLElement | null
+    if (!container || container.dataset.loading === '1') return
+    container.dataset.loading = '1'
+    const issues = await getIssues(slug)
+    container.innerHTML = ''
+    if (issues.length > 0) {
+      container.style.display = 'inline-flex'
+      container.style.gap = '4px'
+      issues
+        .slice()
+        .sort((a, b) => (b.scoreImpact ?? 0) - (a.scoreImpact ?? 0))
+        .slice(0, 6)
+        .forEach((iss) => {
+          const btn = document.createElement('button')
+          btn.type = 'button'
+          btn.textContent = `${labelFor(iss.kind)}:${iss.nodeId}`
+          btn.title = iss.message || ''
+          btn.style.fontSize = '10px'
+          btn.style.textDecoration = 'underline'
+          btn.style.cursor = 'pointer'
+          btn.style.background = 'transparent'
+          btn.style.border = 'none'
+          btn.style.color = colorFor(iss.kind)
+          btn.addEventListener('click', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            goto(slug, iss.nodeId)
+          })
+          container.appendChild(btn)
+        })
+      if (issues.length > 6) {
+        const more = document.createElement('span')
+        more.textContent = `+${issues.length - 6}`
+        more.style.fontSize = '10px'
+        more.style.color = '#6b7280'
+        container.appendChild(more)
+      }
+    }
+    container.dataset.loading = '0'
+  }
+
+  const apply = () => {
+    const list = document.querySelector('ol') as HTMLOListElement | null
+    if (!list) return
+    const rows = Array.from(list.querySelectorAll('li')) as HTMLLIElement[]
+    rows.forEach((li) => {
+      void ensureBadges(li)
+    })
+  }
+
+  const schedule = () => { apply() }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', schedule, { once: true })
+  else schedule()
+
+  const mo = new MutationObserver(schedule)
+  mo.observe(document.body, { childList: true, subtree: true })
 })()

--- a/apps/builder/app/dev/ui-audit/page.tsx
+++ b/apps/builder/app/dev/ui-audit/page.tsx
@@ -1,6 +1,7 @@
 // apps/builder/app/dev/ui-audit/page.tsx
 // SSR page: UI design audit (initial skeleton)
 import React from 'react'
+import { headers } from 'next/headers'
 
 // --- Types (temporary, append-only) ---
 type ComponentNode = {
@@ -47,6 +48,56 @@ function loadMockNodes(): ComponentNode[] {
     },
   ]
 }
+
+type ApiScores = {
+  contrast: number
+  fontVariety: number
+  gridSpacing: number
+  alignment: number
+  average: number
+}
+
+type ApiIssues = {
+  contrast: string[]
+  fontVariety: string[]
+  gridSpacing: string[]
+  alignment: string[]
+}
+
+type ApiContrastDetail = {
+  id: string
+  ratio: number | null
+  required: number
+  level: 'warning' | 'error'
+  textColor?: string
+  bgColor?: string
+}
+
+type AuditScoreResponse = {
+  slug: string
+  scores: ApiScores
+  issues: ApiIssues
+  issuesDetail?: { contrast?: ApiContrastDetail[] }
+  warning?: string
+  error?: string
+}
+
+const defaultScores: ApiScores = {
+  contrast: 0,
+  fontVariety: 0,
+  gridSpacing: 0,
+  alignment: 0,
+  average: 0,
+}
+
+const defaultIssues: ApiIssues = {
+  contrast: [],
+  fontVariety: [],
+  gridSpacing: [],
+  alignment: [],
+}
+
+const colorForScore = (v: number) => (v >= 80 ? 'text-green-700' : v >= 50 ? 'text-amber-700' : 'text-rose-700')
 
 // --- Helpers: color parsing and WCAG contrast ---
 function parseHexColor(s: string): [number, number, number] | null {
@@ -115,62 +166,88 @@ function walk(nodes: ComponentNode[], fn: (n: ComponentNode) => void) {
   }
 }
 
-export default async function Page() {
-  const nodes = loadMockNodes()
+export const dynamic = 'force-dynamic'
 
-  // Metrics containers
-  const fontSizes = new Set<number>()
-  const spacingValues: number[] = []
-  type ContrastRow = { id: string; type: string; ratio: number | null; text?: string; bg?: string }
-  const contrastRows: ContrastRow[] = []
+export default async function Page({ searchParams }: { searchParams?: { slug?: string } }) {
+  const slugParam = typeof searchParams?.slug === 'string' ? searchParams.slug.trim() : ''
+  const slug = slugParam || 'sample'
 
-  walk(nodes, (n) => {
-    // font-size
-    const fs = n.props?.fontSize
-    if (typeof fs === 'number' && isFinite(fs)) fontSizes.add(fs)
-    if (typeof fs === 'string') {
-      const m = fs.trim().match(/^(\d+\.?\d*)px$/)
-      if (m) fontSizes.add(parseFloat(m[1]))
+  const hdrs = headers()
+  const hostHeader = hdrs.get('x-forwarded-host') ?? hdrs.get('host') ?? 'localhost:3000'
+  const protoHeader = hdrs.get('x-forwarded-proto')
+  const fallbackProto = /localhost|127\.0\.0\.1/.test(hostHeader) ? 'http' : 'https'
+  const origin = (process.env.NEXT_PUBLIC_UI_AUDIT_ORIGIN || `${protoHeader ?? fallbackProto}://${hostHeader}`).replace(/\/$/, '')
+  const apiUrl = `${origin}/api/ui-audit/score?slug=${encodeURIComponent(slug)}`
+
+  let apiData: AuditScoreResponse | null = null
+  try {
+    const res = await fetch(apiUrl, { cache: 'no-store' })
+    if (res.ok) {
+      apiData = (await res.json()) as AuditScoreResponse
     }
-    // spacing
-    extractPxValues(n.style?.margin).forEach((v) => spacingValues.push(v))
-    extractPxValues(n.style?.padding).forEach((v) => spacingValues.push(v))
-    // contrast
-    const tc = parseColor(n.props?.textColor || '')
-    const bg = parseColor(n.props?.bgColor || '')
-    const ratio = tc && bg ? contrastRatio(tc, bg) : null
-    contrastRows.push({ id: n.id, type: n.type, ratio, text: n.props?.textColor, bg: n.props?.bgColor })
-  })
+  } catch {
+    // ignore network failures; fallback below
+  }
 
-  // Compute 8px grid adherence
-  const onGridCount = spacingValues.filter((v) => Math.abs(v % 8) < 0.01).length
-  const spacingRate = spacingValues.length ? Math.round((onGridCount / spacingValues.length) * 100) : 100
+  const data = apiData ?? {
+    slug,
+    scores: defaultScores,
+    issues: defaultIssues,
+    issuesDetail: { contrast: [] },
+    warning: apiData ? apiData.warning : 'UI-Audit API response unavailable',
+    error: apiData?.error,
+  }
 
-  // Contrast evaluation (AA normal text threshold 4.5)
-  const contrastFails = contrastRows.filter((r) => r.ratio !== null && (r.ratio as number) < 4.5)
+  const scores = data.scores ?? defaultScores
+  const issues = data.issues ?? defaultIssues
+  const contrastDetails = data.issuesDetail?.contrast ?? []
+  const contrastRows = contrastDetails.map((d) => ({
+    id: d.id,
+    ratio: typeof d.ratio === 'number' ? d.ratio : null,
+    required: d.required,
+    level: d.level,
+    textColor: d.textColor,
+    bgColor: d.bgColor,
+  }))
+
+  const contrastIssueCount = contrastRows.length || issues.contrast.length
+  const gridIssueCount = issues.gridSpacing.length
+  const alignmentIssueCount = issues.alignment.length
 
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-lg font-semibold">UI Audit (prototype)</h1>
-      <p className="text-sm text-gray-600">SSR mock metrics. Will be wired to builder store later.</p>
+      <div className="text-sm text-gray-600 space-y-1">
+        <p>
+          API-driven metrics for <code className="font-mono">{data.slug}</code>.
+        </p>
+        <p className="text-xs text-blue-600">データソース: API</p>
+        {data.warning ? <p className="text-xs text-amber-600">{data.warning}</p> : null}
+        {data.error ? <p className="text-xs text-rose-600">{data.error}</p> : null}
+      </div>
 
       <section className="space-y-2">
         <h2 className="font-semibold">Summary</h2>
-        <div className="grid grid-cols-3 gap-3 text-sm">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
           <div className="border rounded p-2">
-            <div className="text-xs opacity-70">font-size 種類数</div>
-            <div className="text-xl font-semibold">{fontSizes.size}</div>
-            <div className="text-xs text-gray-600">[{Array.from(fontSizes).sort((a,b)=>a-b).join(', ')}]</div>
+            <div className="text-xs opacity-70">平均スコア</div>
+            <div className={`text-xl font-semibold ${colorForScore(scores.average)}`}>{Math.round(scores.average)}</div>
+            <div className="text-xs text-gray-600">font variety score <span className={colorForScore(scores.fontVariety)}>{Math.round(scores.fontVariety)}</span></div>
           </div>
           <div className="border rounded p-2">
-            <div className="text-xs opacity-70">8pxグリッド適合率 (margin/padding)</div>
-            <div className="text-xl font-semibold">{spacingRate}%</div>
-            <div className="text-xs text-gray-600">総数 {spacingValues.length} / on-grid {onGridCount}</div>
+            <div className="text-xs opacity-70">コントラスト</div>
+            <div className={`text-xl font-semibold ${colorForScore(scores.contrast)}`}>{Math.round(scores.contrast)}</div>
+            <div className="text-xs text-gray-600">issues {contrastIssueCount}</div>
           </div>
           <div className="border rounded p-2">
-            <div className="text-xs opacity-70">コントラスト不適合 (AA 4.5未満)</div>
-            <div className="text-xl font-semibold">{contrastFails.length}</div>
-            <div className="text-xs text-gray-600">対象 {contrastRows.filter(r=>r.ratio!==null).length} ノード</div>
+            <div className="text-xs opacity-70">8pxグリッド適合率</div>
+            <div className={`text-xl font-semibold ${colorForScore(scores.gridSpacing)}`}>{Math.round(scores.gridSpacing)}</div>
+            <div className="text-xs text-gray-600">off-grid {gridIssueCount}</div>
+          </div>
+          <div className="border rounded p-2">
+            <div className="text-xs opacity-70">Alignment</div>
+            <div className={`text-xl font-semibold ${colorForScore(scores.alignment)}`}>{Math.round(scores.alignment)}</div>
+            <div className="text-xs text-gray-600">misaligned {alignmentIssueCount}</div>
           </div>
         </div>
       </section>
@@ -178,23 +255,33 @@ export default async function Page() {
       <section className="space-y-2">
         <h2 className="font-semibold">Contrast details</h2>
         <div className="space-y-1 text-xs">
-          {contrastRows.map((r) => {
-            const fail = r.ratio !== null && r.ratio < 4.5
-            return (
-              <div key={r.id} className={`border rounded p-2 ${fail ? 'border-rose-300 bg-rose-50' : 'border-gray-200'}`}>
-                <div className="font-mono text-[11px]">{r.id} <span className="opacity-60">({r.type})</span></div>
-                <div>ratio: <b>{r.ratio ? r.ratio.toFixed(2) : '-'}</b> <span className="opacity-70">(text {r.text || '-'} on {r.bg || '-'})</span></div>
-              </div>
-            )
-          })}
+          {contrastRows.length === 0 ? (
+            <div className="border border-gray-200 rounded p-2 text-gray-500">No contrast issues detected by API.</div>
+          ) : (
+            contrastRows.map((r) => {
+              const fail = r.ratio !== null && r.ratio < r.required
+              const cls = fail ? (r.level === 'error' ? 'border-rose-300 bg-rose-50' : 'border-amber-300 bg-amber-50') : 'border-gray-200'
+              return (
+                <div key={r.id} className={`border rounded p-2 ${cls}`}>
+                  <div className="font-mono text-[11px]">{r.id}</div>
+                  <div>
+                    ratio: <b>{r.ratio !== null ? r.ratio.toFixed(2) : '-'}</b>
+                    <span className="ml-2">required: <b>{r.required.toFixed(1)}</b></span>
+                    <span className="ml-2 uppercase">{r.level}</span>
+                  </div>
+                  <div className="opacity-70">text {r.textColor || '-'} / bg {r.bgColor || '-'}</div>
+                </div>
+              )
+            })
+          )}
         </div>
       </section>
 
       <section className="space-y-2">
         <h2 className="font-semibold">Notes</h2>
         <ul className="list-disc pl-5 text-sm text-gray-700 space-y-1">
-          <li>閾値: AA 通常テキスト 4.5。大きなテキストの場合は 3.0 を許容（後続で判定に font-size を反映予定）。</li>
-          <li>8px グリッドは margin/padding の px 値のみ評価。% / rem などは今後対応。</li>
+          <li>閾値: AA 通常テキスト 4.5。大きなテキストの場合は 3.0 を許容（API 応答の required を参照）。</li>
+          <li>8px グリッド/Alignment は API の issues 情報を基に集計しています。</li>
           <li>実データ連携後は、ノード選択と連動したハイライトやジャンプも提供予定。</li>
         </ul>
       </section>
@@ -1580,4 +1667,50 @@ export default async function Page() {
   const init = () => { renderReal(); renderMock() }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init, { once: true })
   else init()
+})()
+
+// --- append-only: Highlight node when navigated with ?highlight=... (from /audit) ---
+;(() => {
+  if (typeof window === 'undefined') return
+
+  const focusNode = (id: string) => {
+    if (!id) return
+    const w = window as any
+    try { w.__panel = 'lineage' } catch {}
+    try { if (typeof w.__builderStore?.select === 'function') w.__builderStore.select(id) } catch {}
+    try { w.__chizuSel = id } catch {}
+
+    const mark = () => {
+      const el = document.getElementById(id)
+      if (!el) return false
+      const prev = el.style.boxShadow
+      const prevOutline = el.style.outline
+      el.style.outline = '2px solid rgba(59,130,246,0.8)'
+      el.style.boxShadow = '0 0 0 4px rgba(59,130,246,0.35)'
+      try { el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' }) } catch {}
+      setTimeout(() => {
+        el.style.outline = prevOutline
+        el.style.boxShadow = prev
+      }, 2000)
+      return true
+    }
+
+    if (!mark()) {
+      const obs = new MutationObserver(() => {
+        if (mark()) obs.disconnect()
+      })
+      obs.observe(document.body, { childList: true, subtree: true })
+      setTimeout(() => obs.disconnect(), 4000)
+    }
+  }
+
+  const apply = () => {
+    const params = new URLSearchParams(window.location.search)
+    const id = params.get('highlight') || params.get('node') || ''
+    if (!id) return
+    focusNode(id)
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', apply, { once: true })
+  else apply()
 })()


### PR DESCRIPTION
## Summary
- render the /dev/ui-audit page with /api/ui-audit/score data and note the API data source
- add highlight support for ?highlight=... so deep links from /audit focus specific nodes
- surface UI audit issues as badges in /audit that jump to /dev/ui-audit with the affected node selected

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c91ba1441c832ca5a9c1d3f0ccbd00