### PR TITLE
feat(builder): visible diagnostics for empty registry & hydration errors

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,20 +1,79 @@
 import './globals.css'
 import type { ReactNode } from 'react'
 import { cookies } from 'next/headers'
+import Script from 'next/script'
 import Providers from './providers'
 import SiteHeader from '@/components/layout/SiteHeader'
 import SiteFooter from '@/components/layout/SiteFooter'
 import ChromeController from '@/components/layout/ChromeController'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import RootHotkeys from '@/components/RootHotkeys'
+import DiagnosticsConsole from '@/components/dev/DiagnosticsConsole'
+import { DIAGNOSTICS_EVENT_NAME, isDiagnosticsEnabled } from '@/lib/diagnostics'
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
   const cookieStore = await cookies()
   const uiTheme = cookieStore.get('ui-theme')?.value ?? 'light'
+  const diagnosticsEnabled = isDiagnosticsEnabled()
+  const diagnosticsScript = `
+    window.__diag = window.__diag || { hydrationWarnings: [] }
+    ;(function () {
+      const EVENT_NAME = ${JSON.stringify(DIAGNOSTICS_EVENT_NAME)}
+      const diag = window.__diag
+      if (!Array.isArray(diag.hydrationWarnings)) {
+        diag.hydrationWarnings = []
+      }
+      if (diag._hydrationHookInstalled) return
+      diag._hydrationHookInstalled = true
+      const emit = () => {
+        try {
+          window.dispatchEvent(new CustomEvent(EVENT_NAME))
+        } catch (error) {
+          // noop
+        }
+      }
+      const toLine = (value) => {
+        if (typeof value === 'string') {
+          return value.replace(/\s+/g, ' ').trim()
+        }
+        try {
+          return JSON.stringify(value)
+        } catch (err) {
+          return String(value)
+        }
+      }
+      const shouldCapture = (value) =>
+        typeof value === 'string' &&
+        (/hydration/i.test(value) || /did not match/i.test(value) || /Expected server HTML/i.test(value))
+      const originalError = console.error
+      console.error = function (...args) {
+        if (shouldCapture(args[0])) {
+          try {
+            const line = args.map(toLine).join(' ')
+            if (!diag.hydrationWarnings.includes(line)) {
+              diag.hydrationWarnings.push(line)
+            }
+            emit()
+          } catch (err) {
+            // noop
+          }
+        }
+        return originalError.apply(console, args)
+      }
+    })()
+  `
 
   return (
     <html lang="ja" data-theme={uiTheme} suppressHydrationWarning>
       <body>
+        {diagnosticsEnabled && (
+          <>
+            <Script id="builder-diagnostics" strategy="beforeInteractive">
+              {diagnosticsScript}
+            </Script>
+            <DiagnosticsConsole />
+          </>
+        )}
         <ErrorBoundary>
           <Providers initialTheme={uiTheme}>
             <ChromeController />

--- a/web/components/builder/Palette.tsx
+++ b/web/components/builder/Palette.tsx
@@ -60,7 +60,13 @@ export function Palette() {
       <section className="space-y-2">
         <div className="text-xs opacity-70">Elements</div>
         <div className="grid grid-cols-1 gap-2">
-          {defs.map((d) => <Item key={d.meta.id} comp={d} />)}
+          {defs.length === 0 ? (
+            <div className="rounded border border-dashed border-zinc-700 px-2 py-2 text-xs text-zinc-400">
+              Registry 未解決/0件
+            </div>
+          ) : (
+            defs.map((d) => <Item key={d.meta.id} comp={d} />)
+          )}
         </div>
       </section>
       <PresetsSection />

--- a/web/components/dev/DiagnosticsConsole.tsx
+++ b/web/components/dev/DiagnosticsConsole.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { DIAGNOSTICS_EVENT_NAME } from '@/lib/diagnostics'
+
+declare global {
+  interface Window {
+    __diag?: {
+      hydrationWarnings: string[]
+      _hydrationHookInstalled?: boolean
+    }
+  }
+}
+
+export default function DiagnosticsConsole() {
+  const [warnings, setWarnings] = useState<string[]>([])
+  const [open, setOpen] = useState(true)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const diag = (window.__diag ??= { hydrationWarnings: [] })
+    if (!Array.isArray(diag.hydrationWarnings)) {
+      diag.hydrationWarnings = []
+    }
+    const update = () => {
+      setWarnings([...diag.hydrationWarnings])
+    }
+    update()
+    const handler: EventListener = () => {
+      update()
+    }
+    window.addEventListener(DIAGNOSTICS_EVENT_NAME, handler)
+    return () => {
+      window.removeEventListener(DIAGNOSTICS_EVENT_NAME, handler)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (warnings.length > 0) {
+      setOpen(true)
+    }
+  }, [warnings.length])
+
+  if (!warnings.length || !open) return null
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[9999] max-w-md rounded border border-amber-500 bg-amber-950/90 p-4 text-sm text-amber-50 shadow-lg backdrop-blur">
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-amber-200">Diagnostics</div>
+          <div className="font-semibold">Hydration warnings ({warnings.length})</div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-xs text-amber-200 transition hover:text-white"
+        >
+          閉じる
+        </button>
+      </div>
+      <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+        {warnings.join('\n')}
+      </pre>
+    </div>
+  )
+}

--- a/web/lib/diagnostics.ts
+++ b/web/lib/diagnostics.ts
@@ -1,0 +1,11 @@
+export const DIAGNOSTICS_EVENT_NAME = 'builder:diag-update'
+
+const DISABLED_VALUES = ['0', 'false', 'off']
+
+export function isDiagnosticsEnabled() {
+  if (process.env.NODE_ENV === 'production') return false
+  const flag = process.env.NEXT_PUBLIC_BUILDER_DIAGNOSTICS
+  if (!flag) return true
+  const normalized = flag.trim().toLowerCase()
+  return !DISABLED_VALUES.includes(normalized)
+}


### PR DESCRIPTION
## Summary
- show a Registry 未解決/0件 placeholder row whenever the palette filter resolves to zero entries
- add a dev-only diagnostics console that surfaces hydration warnings captured via window.__diag
- bootstrap the console in app/layout.tsx behind the NEXT_PUBLIC_BUILDER_DIAGNOSTICS flag so it can be toggled by environment

## Testing
- pnpm -C web lint (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_68c91ba8d534832c9a8232efe788eae6