### PR TITLE
feat(dev): add /dev/actions (list/editor/preview + store + mock api)

### DIFF
--- a/apps/builder/app/api/projects/[id]/actions/route.ts
+++ b/apps/builder/app/api/projects/[id]/actions/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import type { ActionPreset } from '@/lib/actions/types'
+
+type StoreShape = {
+  list: string[]
+  presets: Record<string, ActionPreset>
+  currentId?: string
+}
+
+const memory = new Map<string, StoreShape>()
+
+const emptyState = (): StoreShape => ({ list: [], presets: {}, currentId: undefined })
+
+function ensureArray<T>(input: any, mapper: (value: any, index: number) => T | undefined) {
+  if (!Array.isArray(input)) return []
+  const result: T[] = []
+  input.forEach((value, index) => {
+    const next = mapper(value, index)
+    if (next !== undefined) result.push(next)
+  })
+  return result
+}
+
+function toPreset(value: any, index: number): ActionPreset | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const id = typeof value.id === 'string' && value.id ? value.id : `import_${index}_${Math.random().toString(36).slice(2, 9)}`
+  const name = typeof value.name === 'string' && value.name ? value.name : `Preset ${index + 1}`
+  const triggers = Array.isArray(value.triggers) ? (value.triggers as string[]).filter((v) => typeof v === 'string') : []
+  const effects = Array.isArray(value.effects) ? value.effects : []
+  const when = Array.isArray(value.when) ? value.when : undefined
+  return {
+    id,
+    name,
+    description: typeof value.description === 'string' ? value.description : undefined,
+    triggers: triggers as any,
+    effects: effects as any,
+    transitionMs: typeof value.transitionMs === 'number' ? value.transitionMs : undefined,
+    easing: typeof value.easing === 'string' ? value.easing : undefined,
+    tags: Array.isArray(value.tags) ? value.tags.filter((tag: unknown) => typeof tag === 'string') : undefined,
+    updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : Date.now(),
+    createdAt: typeof value.createdAt === 'number' ? value.createdAt : undefined,
+    when: when as any,
+    actions: Array.isArray(value.actions) ? (value.actions as any) : undefined,
+  }
+}
+
+function normalizePayload(payload: any): StoreShape {
+  if (Array.isArray(payload)) {
+    const presets = ensureArray(payload, toPreset)
+    const list = presets.map((preset) => preset.id)
+    const map = Object.fromEntries(presets.map((preset) => [preset.id, preset]))
+    return { list, presets: map, currentId: list[0] }
+  }
+
+  if (payload && typeof payload === 'object') {
+    const mapInput = payload.presets && typeof payload.presets === 'object' ? payload.presets : {}
+    const listInput = Array.isArray(payload.list)
+      ? payload.list.filter((id: unknown): id is string => typeof id === 'string')
+      : []
+
+    const presetEntries: [string, ActionPreset][] = []
+    const seen = new Set<string>()
+
+    if (listInput.length) {
+      listInput.forEach((id, index) => {
+        const raw = (mapInput as Record<string, any>)[id]
+        const preset = raw ? toPreset({ id, ...raw }, index) : undefined
+        if (preset && !seen.has(preset.id)) {
+          seen.add(preset.id)
+          presetEntries.push([preset.id, preset])
+        }
+      })
+    } else {
+      Object.entries(mapInput as Record<string, any>).forEach(([id, raw], index) => {
+        const preset = toPreset({ id, ...raw }, index)
+        if (preset && !seen.has(preset.id)) {
+          seen.add(preset.id)
+          presetEntries.push([preset.id, preset])
+        }
+      })
+    }
+
+    const list = presetEntries.map(([id]) => id)
+    const map = Object.fromEntries(presetEntries)
+    const currentId =
+      typeof payload.currentId === 'string' && list.includes(payload.currentId)
+        ? payload.currentId
+        : list[0]
+
+    return { list, presets: map, currentId }
+  }
+
+  return emptyState()
+}
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const projectId = decodeURIComponent(params.id)
+  const state = memory.get(projectId) ?? emptyState()
+  return NextResponse.json(state)
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const projectId = decodeURIComponent(params.id)
+  let payload: any = null
+  try {
+    payload = await req.json()
+  } catch {
+    payload = null
+  }
+  const state = normalizePayload(payload)
+  memory.set(projectId, state)
+  return NextResponse.json({ ok: true, ...state })
+}
+
+export async function PUT(req: NextRequest, ctx: { params: { id: string } }) {
+  return POST(req, ctx)
+}

--- a/apps/builder/app/dev/actions/page.tsx
+++ b/apps/builder/app/dev/actions/page.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import * as React from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ActionPresetList } from '@/components/actions/ActionPresetList'
+import { ActionPresetEditor } from '@/components/actions/ActionPresetEditor'
+import { ActionPreview } from '@/components/actions/ActionPreview'
+import type { ActionPreset } from '@/lib/actions/types'
+import { useActionsStore } from '@/stores/actions'
+
+type SaveStatus = 'idle' | 'saving' | 'error'
+
+type StoreSnapshot = {
+  list: string[]
+  presets: Record<string, ActionPreset>
+  currentId?: string
+}
+
+const DEFAULT_PROJECT_ID = 'dev-actions'
+
+const emptySnapshot: StoreSnapshot = { list: [], presets: {}, currentId: undefined }
+
+export default function DevActionsPage() {
+  const searchParams = useSearchParams()
+  const projectId = React.useMemo(
+    () => searchParams?.get('project')?.trim() || DEFAULT_PROJECT_ID,
+    [searchParams],
+  )
+
+  const currentId = useActionsStore((state) => state.currentId)
+  const presets = useActionsStore((state) => state.presets)
+  const currentPreset = currentId ? presets[currentId] : undefined
+
+  const [loading, setLoading] = React.useState(true)
+  const [status, setStatus] = React.useState<SaveStatus>('idle')
+  const loadedRef = React.useRef(false)
+
+  React.useEffect(() => {
+    let active = true
+    loadedRef.current = false
+    setLoading(true)
+    setStatus('idle')
+
+    const applyState = (input: any) => {
+      if (!active) return
+      let list: string[] = []
+      const presetsMap: Record<string, ActionPreset> = {}
+      let current: string | undefined
+
+      if (Array.isArray(input)) {
+        input.forEach((item: any) => {
+          if (item && typeof item.id === 'string') {
+            list.push(item.id)
+            presetsMap[item.id] = item as ActionPreset
+          }
+        })
+      } else if (input && typeof input === 'object') {
+        const rawList = Array.isArray(input.list) ? input.list : []
+        const rawPresets =
+          input.presets && typeof input.presets === 'object' ? (input.presets as Record<string, any>) : {}
+        rawList.forEach((id: any) => {
+          if (typeof id === 'string' && rawPresets[id]) {
+            list.push(id)
+            presetsMap[id] = rawPresets[id] as ActionPreset
+          }
+        })
+        if (!list.length) {
+          Object.entries(rawPresets).forEach(([id, preset]) => {
+            if (typeof id === 'string') {
+              list.push(id)
+              presetsMap[id] = preset as ActionPreset
+            }
+          })
+        }
+        if (typeof input.currentId === 'string') current = input.currentId
+      }
+
+      list = Array.from(new Set(list))
+      if (current && !list.includes(current)) current = list[0]
+      if (!current && list.length) current = list[0]
+
+      useActionsStore.setState({ list, presets: presetsMap, currentId: current })
+    }
+
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/actions`, {
+          cache: 'no-store',
+        })
+        if (!active) return
+        if (res.ok) {
+          const data = await res.json()
+          applyState(data)
+        } else {
+          applyState(emptySnapshot)
+        }
+      } catch (err) {
+        console.error('Failed to load action presets', err)
+        applyState(emptySnapshot)
+      } finally {
+        if (active) {
+          loadedRef.current = true
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      active = false
+    }
+  }, [projectId])
+
+  React.useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let abortController: AbortController | undefined
+
+    const persist = (snapshot: StoreSnapshot) => {
+      if (!loadedRef.current) return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(async () => {
+        abortController?.abort()
+        abortController = new AbortController()
+        setStatus('saving')
+        try {
+          const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/actions`, {
+            method: 'PUT',
+            body: JSON.stringify(snapshot),
+            headers: { 'Content-Type': 'application/json' },
+            signal: abortController.signal,
+          })
+          if (!res.ok) throw new Error('Failed to persist presets')
+          setStatus('idle')
+        } catch (err: any) {
+          if (err?.name === 'AbortError') return
+          console.error('Failed to save action presets', err)
+          setStatus('error')
+        }
+      }, 400)
+    }
+
+    const unsubscribe = useActionsStore.subscribe(
+      (state) => ({ list: state.list, presets: state.presets, currentId: state.currentId }),
+      persist,
+    )
+
+    return () => {
+      unsubscribe()
+      if (timer) clearTimeout(timer)
+      abortController?.abort()
+    }
+  }, [projectId])
+
+  const handleAction = React.useCallback((action: any, preset: ActionPreset) => {
+    console.log(`[dev/actions] ${action}`, preset)
+  }, [])
+
+  return (
+    <main className="flex min-h-screen flex-col bg-neutral-950 text-neutral-100">
+      <header className="border-b border-neutral-800 px-6 py-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-3">
+          <h1 className="text-xl font-semibold text-white">/dev/actions</h1>
+          <span className="text-xs text-neutral-500">Project: {projectId}</span>
+        </div>
+        <p className="mt-1 text-sm text-neutral-400">
+          Manage action presets, preview interactions, and import/export JSON definitions.
+        </p>
+      </header>
+
+      <div className="flex flex-1 overflow-hidden">
+        <aside className="w-full max-w-xs border-r border-neutral-800 bg-neutral-950 p-4">
+          <ActionPresetList status={status} />
+        </aside>
+        <section className="flex flex-1 flex-col overflow-hidden lg:flex-row">
+          <div className="flex-1 overflow-hidden border-b border-neutral-800 bg-neutral-950 p-4 lg:border-b-0 lg:border-r">
+            <ActionPresetEditor preset={currentPreset} onAction={handleAction} />
+          </div>
+          <div className="w-full max-w-md border-t border-neutral-800 bg-neutral-950 p-4 lg:h-full lg:border-l lg:border-t-0">
+            <ActionPreview preset={currentPreset} />
+          </div>
+        </section>
+      </div>
+
+      {loading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-neutral-950/70 text-sm text-neutral-300">
+          Loading presets…
+        </div>
+      )}
+    </main>
+  )
+}

--- a/apps/builder/components/actions/ActionPresetEditor.tsx
+++ b/apps/builder/components/actions/ActionPresetEditor.tsx
@@ -1,0 +1,440 @@
+'use client'
+
+import * as React from 'react'
+import type {
+  ActionPreset,
+  BehaviorTrigger,
+  Effect,
+  Trigger,
+} from '@/lib/actions/types'
+import { defaultEffect } from '@/lib/actions/types'
+import { useActionsStore } from '@/stores/actions'
+
+type EditorAction =
+  | 'replaceSelection'
+  | 'appendSelection'
+  | 'removeSelection'
+  | 'replaceAll'
+  | 'appendAll'
+  | 'setProjectDefault'
+  | 'addToDefaults'
+
+type Props = {
+  preset?: ActionPreset
+  onAction?: (action: EditorAction, preset: ActionPreset) => void
+}
+
+const VISUAL_TRIGGERS: Trigger[] = [
+  'hover',
+  'active',
+  'focus',
+  'focusWithin',
+  'groupHover',
+]
+
+const BEHAVIOR_TRIGGERS: BehaviorTrigger[] = ['click', 'inView']
+
+const EFFECT_OPTIONS: Effect['kind'][] = [
+  'scale',
+  'bgColor',
+  'cursor',
+  'translate',
+  'rotate',
+]
+
+const CURSOR_VALUES: Effect & { kind: 'cursor' }['value'][] = [
+  'pointer',
+  'default',
+  'move',
+  'grab',
+  'text',
+]
+
+const ACTION_BUTTONS: { key: EditorAction; label: string }[] = [
+  { key: 'replaceSelection', label: 'Replace Selection' },
+  { key: 'appendSelection', label: 'Append Selection' },
+  { key: 'removeSelection', label: 'Remove Selection' },
+  { key: 'replaceAll', label: 'Replace All' },
+  { key: 'appendAll', label: 'Append All' },
+  { key: 'setProjectDefault', label: 'Set as Project Default' },
+  { key: 'addToDefaults', label: 'Add to Defaults' },
+]
+
+export function ActionPresetEditor({ preset, onAction }: Props) {
+  const update = useActionsStore((state) => state.update)
+  const [effectKind, setEffectKind] = React.useState<Effect['kind']>('scale')
+  const [tagInput, setTagInput] = React.useState('')
+
+  React.useEffect(() => {
+    if (!preset) {
+      setTagInput('')
+      return
+    }
+    setTagInput((preset.tags ?? []).join(', '))
+  }, [preset?.id, preset?.tags])
+
+  const emitAction = (action: EditorAction) => {
+    if (!preset) return
+    if (onAction) onAction(action, preset)
+    else console.log(`[actions:${action}]`, preset)
+  }
+
+  const toggleVisual = (trigger: Trigger) => {
+    if (!preset) return
+    const current = preset.triggers ?? []
+    const next = current.includes(trigger)
+      ? current.filter((item) => item !== trigger)
+      : [...current, trigger]
+    update(preset.id, { triggers: next })
+  }
+
+  const toggleBehavior = (trigger: BehaviorTrigger) => {
+    if (!preset) return
+    const current = preset.when ?? []
+    const next = current.includes(trigger)
+      ? current.filter((item) => item !== trigger)
+      : [...current, trigger]
+    update(preset.id, { when: next })
+  }
+
+  const handleEffectChange = (index: number, nextEffect: Effect) => {
+    if (!preset) return
+    const next = preset.effects.map((effect, idx) => (idx === index ? nextEffect : effect))
+    update(preset.id, { effects: next })
+  }
+
+  const handleRemoveEffect = (index: number) => {
+    if (!preset) return
+    const next = preset.effects.filter((_, idx) => idx !== index)
+    update(preset.id, { effects: next })
+  }
+
+  const handleAddEffect = () => {
+    if (!preset) return
+    const effect = defaultEffect(effectKind)
+    const next = [...preset.effects, effect]
+    update(preset.id, { effects: next })
+  }
+
+  if (!preset) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-dashed border-neutral-700 bg-neutral-950 text-sm text-neutral-400">
+        Select a preset to edit.
+      </div>
+    )
+  }
+
+  const when = preset.when ?? []
+
+  return (
+    <div className="flex h-full flex-col gap-6 overflow-y-auto rounded-lg border border-neutral-800 bg-neutral-950 p-6">
+      <section className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          {ACTION_BUTTONS.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs font-medium text-neutral-200 transition hover:border-sky-500 hover:text-white"
+              onClick={() => emitAction(action.key)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <label className="block text-xs font-medium text-neutral-300">
+          Name
+          <input
+            type="text"
+            value={preset.name}
+            onChange={(event) => update(preset.id, { name: event.target.value })}
+            className="mt-1 w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-sky-500 focus:outline-none"
+          />
+        </label>
+        <label className="block text-xs font-medium text-neutral-300">
+          Description
+          <textarea
+            value={preset.description ?? ''}
+            onChange={(event) => update(preset.id, { description: event.target.value || undefined })}
+            className="mt-1 h-20 w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-sky-500 focus:outline-none"
+          />
+        </label>
+        <label className="block text-xs font-medium text-neutral-300">
+          Tags (comma separated)
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(event) => {
+              const value = event.target.value
+              setTagInput(value)
+              const tags = value
+                .split(',')
+                .map((tag) => tag.trim())
+                .filter(Boolean)
+              update(preset.id, { tags })
+            }}
+            className="mt-1 w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-sky-500 focus:outline-none"
+            placeholder="marketing, hero, hover"
+          />
+        </label>
+        <div className="text-[11px] text-neutral-500">
+          Updated {new Date(preset.updatedAt).toLocaleString()}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+          Triggers
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {VISUAL_TRIGGERS.map((trigger) => {
+            const active = preset.triggers.includes(trigger)
+            return (
+              <button
+                key={trigger}
+                type="button"
+                className={`rounded-md border px-3 py-1 ${
+                  active
+                    ? 'border-sky-400 bg-sky-500/10 text-sky-100'
+                    : 'border-neutral-700 bg-neutral-900 text-neutral-300 hover:border-neutral-500'
+                }`}
+                onClick={() => toggleVisual(trigger)}
+              >
+                {trigger}
+              </button>
+            )
+          })}
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {BEHAVIOR_TRIGGERS.map((trigger) => {
+            const active = when.includes(trigger)
+            return (
+              <button
+                key={trigger}
+                type="button"
+                className={`rounded-md border px-3 py-1 ${
+                  active
+                    ? 'border-amber-400 bg-amber-500/10 text-amber-100'
+                    : 'border-neutral-700 bg-neutral-900 text-neutral-300 hover:border-neutral-500'
+                }`}
+                onClick={() => toggleBehavior(trigger)}
+              >
+                {trigger}
+              </button>
+            )
+          })}
+        </div>
+        <div className="flex flex-wrap items-center gap-4 text-xs">
+          <label className="flex items-center gap-2">
+            <span>Transition</span>
+            <input
+              type="number"
+              min={0}
+              value={preset.transitionMs ?? ''}
+              onChange={(event) =>
+                update(preset.id, {
+                  transitionMs: event.target.value
+                    ? Number.parseInt(event.target.value, 10)
+                    : undefined,
+                })
+              }
+              className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+            />
+            <span>ms</span>
+          </label>
+          <label className="flex-1">
+            <span className="mr-2">Easing</span>
+            <input
+              type="text"
+              value={preset.easing ?? ''}
+              onChange={(event) => update(preset.id, { easing: event.target.value || undefined })}
+              placeholder="cubic-bezier(.2,.8,.2,1)"
+              className="w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+            />
+          </label>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+            Effects
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <select
+              value={effectKind}
+              onChange={(event) => setEffectKind(event.target.value as Effect['kind'])}
+              className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+            >
+              {EFFECT_OPTIONS.map((kind) => (
+                <option key={kind} value={kind}>
+                  {kind}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handleAddEffect}
+              className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs hover:border-sky-500 hover:text-white"
+            >
+              + Add
+            </button>
+          </div>
+        </div>
+        {preset.effects.length === 0 ? (
+          <div className="rounded border border-dashed border-neutral-700 bg-neutral-950/60 p-4 text-center text-xs text-neutral-500">
+            No effects yet. Add an effect to define the visual behavior.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {preset.effects.map((effect, index) => (
+              <div key={index} className="rounded-md border border-neutral-800 bg-neutral-900/60 p-4">
+                <div className="mb-3 flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-neutral-400">
+                  <span>{effect.kind}</span>
+                  <button
+                    type="button"
+                    className="text-[11px] text-rose-400 hover:text-rose-200"
+                    onClick={() => handleRemoveEffect(index)}
+                  >
+                    Remove
+                  </button>
+                </div>
+
+                {effect.kind === 'scale' && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <label className="flex items-center gap-2">
+                      scale
+                      <input
+                        type="number"
+                        step="0.01"
+                        value={effect.value}
+                        onChange={(event) =>
+                          handleEffectChange(index, {
+                            kind: 'scale',
+                            value: Number.parseFloat(event.target.value || '0'),
+                          })
+                        }
+                        className="w-24 rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+                      />
+                    </label>
+                  </div>
+                )}
+
+                {effect.kind === 'bgColor' && (
+                  <div className="flex items-center gap-3 text-xs">
+                    <label className="flex items-center gap-2">
+                      color
+                      <input
+                        type="text"
+                        value={effect.value}
+                        onChange={(event) =>
+                          handleEffectChange(index, {
+                            kind: 'bgColor',
+                            value: event.target.value,
+                          })
+                        }
+                        className="w-32 rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+                        placeholder="#0f172a"
+                      />
+                    </label>
+                    <input
+                      type="color"
+                      value={effect.value}
+                      onChange={(event) =>
+                        handleEffectChange(index, {
+                          kind: 'bgColor',
+                          value: event.target.value,
+                        })
+                      }
+                      className="h-8 w-12 cursor-pointer rounded border border-neutral-700 bg-neutral-900"
+                    />
+                  </div>
+                )}
+
+                {effect.kind === 'cursor' && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <label className="flex items-center gap-2">
+                      cursor
+                      <select
+                        value={effect.value}
+                        onChange={(event) =>
+                          handleEffectChange(index, {
+                            kind: 'cursor',
+                            value: event.target.value as (typeof CURSOR_VALUES)[number],
+                          })
+                        }
+                        className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+                      >
+                        {CURSOR_VALUES.map((value) => (
+                          <option key={value} value={value}>
+                            {value}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                )}
+
+                {effect.kind === 'translate' && (
+                  <div className="flex items-center gap-4 text-xs">
+                    <label className="flex items-center gap-2">
+                      x
+                      <input
+                        type="number"
+                        value={effect.x ?? 0}
+                        onChange={(event) =>
+                          handleEffectChange(index, {
+                            kind: 'translate',
+                            x: Number.parseFloat(event.target.value || '0'),
+                            y: effect.y,
+                          })
+                        }
+                        className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+                      />
+                    </label>
+                    <label className="flex items-center gap-2">
+                      y
+                      <input
+                        type="number"
+                        value={effect.y ?? 0}
+                        onChange={(event) =>
+                          handleEffectChange(index, {
+                            kind: 'translate',
+                            x: effect.x,
+                            y: Number.parseFloat(event.target.value || '0'),
+                          })
+                        }
+                        className="w-20 rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+                      />
+                    </label>
+                  </div>
+                )}
+
+                {effect.kind === 'rotate' && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <label className="flex items-center gap-2">
+                      deg
+                      <input
+                        type="number"
+                        value={effect.deg}
+                        onChange={(event) =>
+                          handleEffectChange(index, {
+                            kind: 'rotate',
+                            deg: Number.parseFloat(event.target.value || '0'),
+                          })
+                        }
+                        className="w-24 rounded border border-neutral-700 bg-neutral-900 px-2 py-1"
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/builder/components/actions/ActionPresetList.tsx
+++ b/apps/builder/components/actions/ActionPresetList.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import * as React from 'react'
+import { useActionsStore } from '@/stores/actions'
+import type { ActionPreset } from '@/lib/actions/types'
+
+type Props = {
+  status?: 'idle' | 'saving' | 'error'
+}
+
+const fmt = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+export function ActionPresetList({ status = 'idle' }: Props) {
+  const list = useActionsStore((state) => state.list)
+  const presets = useActionsStore((state) => state.presets)
+  const currentId = useActionsStore((state) => state.currentId)
+  const createPreset = useActionsStore((state) => state.createPreset)
+  const duplicatePreset = useActionsStore((state) => state.duplicate)
+  const removePreset = useActionsStore((state) => state.remove)
+  const setCurrent = useActionsStore((state) => state.setCurrent)
+  const importPresets = useActionsStore((state) => state.import)
+  const exportPresets = useActionsStore((state) => state.export)
+
+  const [query, setQuery] = React.useState('')
+  const [activeTags, setActiveTags] = React.useState<string[]>([])
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null)
+
+  const toggleTag = React.useCallback((tag: string) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((item) => item !== tag) : [...prev, tag],
+    )
+  }, [])
+
+  const allPresets = React.useMemo(() => {
+    return list
+      .map((id) => presets[id])
+      .filter((preset): preset is ActionPreset => !!preset)
+  }, [list, presets])
+
+  const allTags = React.useMemo(() => {
+    const tags = new Set<string>()
+    allPresets.forEach((preset) => {
+      preset.tags?.forEach((tag) => {
+        if (tag.trim()) tags.add(tag)
+      })
+    })
+    return Array.from(tags).sort((a, b) => a.localeCompare(b))
+  }, [allPresets])
+
+  const filtered = React.useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    return allPresets.filter((preset) => {
+      const matchesQuery = normalizedQuery
+        ? preset.name.toLowerCase().includes(normalizedQuery) ||
+          (preset.description ?? '').toLowerCase().includes(normalizedQuery)
+        : true
+      if (!matchesQuery) return false
+      if (!activeTags.length) return true
+      const tags = preset.tags ?? []
+      return activeTags.every((tag) => tags.includes(tag))
+    })
+  }, [allPresets, activeTags, query])
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    try {
+      const text = await file.text()
+      const data = JSON.parse(text)
+      if (Array.isArray(data)) {
+        importPresets(data)
+      } else if (Array.isArray(data?.presets)) {
+        importPresets(data.presets)
+      } else if (Array.isArray(data?.list) && typeof data.presets === 'object') {
+        const arr = (data.list as string[])
+          .map((id) => (data.presets as Record<string, ActionPreset | undefined>)[id])
+          .filter(Boolean)
+        importPresets(arr as ActionPreset[])
+      } else {
+        throw new Error('Invalid JSON format')
+      }
+    } catch (err) {
+      console.error('Failed to import presets', err)
+      window.alert('Import failed. Please provide a JSON array of presets.')
+    }
+  }
+
+  const handleExport = () => {
+    try {
+      const ids = filtered.map((preset) => preset.id)
+      const json = exportPresets(ids)
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = `action-presets-${new Date()
+        .toISOString()
+        .replace(/[:.]/g, '-')}.json`
+      anchor.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      console.error('Failed to export presets', err)
+      window.alert('Export failed. Please try again.')
+    }
+  }
+
+  const handleRemove = (id: string) => {
+    if (window.confirm('Remove this preset?')) removePreset(id)
+  }
+
+  const statusLabel =
+    status === 'saving'
+      ? 'Saving…'
+      : status === 'error'
+      ? 'Save failed'
+      : undefined
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="space-y-3 pb-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+            Presets
+          </h2>
+          {statusLabel && (
+            <span
+              className={`text-[11px] font-medium ${
+                status === 'error' ? 'text-rose-400' : 'text-neutral-400'
+              }`}
+            >
+              {statusLabel}
+            </span>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={createPreset}
+            className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs font-medium hover:bg-neutral-800"
+          >
+            + New
+          </button>
+          <button
+            type="button"
+            onClick={handleImportClick}
+            className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs hover:bg-neutral-800"
+          >
+            Import
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs hover:bg-neutral-800"
+            disabled={!filtered.length}
+          >
+            Export
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            onChange={handleImportFile}
+            className="hidden"
+          />
+        </div>
+        <div>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search preset names or descriptions"
+            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs text-neutral-200 placeholder:text-neutral-500 focus:border-sky-500 focus:outline-none"
+          />
+        </div>
+        {allTags.length > 0 && (
+          <div className="flex flex-wrap gap-2 text-[11px]">
+            {allTags.map((tag) => {
+              const active = activeTags.includes(tag)
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  className={`rounded-full border px-3 py-1 ${
+                    active
+                      ? 'border-sky-400 bg-sky-500/10 text-sky-200'
+                      : 'border-neutral-700 bg-neutral-900 text-neutral-400 hover:border-neutral-500'
+                  }`}
+                  onClick={() => toggleTag(tag)}
+                >
+                  #{tag}
+                </button>
+              )
+            })}
+            {activeTags.length > 0 && (
+              <button
+                type="button"
+                className="rounded-full border border-neutral-700 px-3 py-1 text-neutral-400 hover:border-neutral-500"
+                onClick={() => setActiveTags([])}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <div className="rounded-md border border-dashed border-neutral-700 bg-neutral-950/40 p-6 text-center text-xs text-neutral-500">
+            {query || activeTags.length
+              ? 'No presets match the current filters.'
+              : 'Create a preset to get started.'}
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {filtered.map((preset) => {
+              const isActive = preset.id === currentId
+              return (
+                <li key={preset.id}>
+                  <button
+                    type="button"
+                    onClick={() => setCurrent(preset.id)}
+                    className={`group w-full rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                      isActive
+                        ? 'border-sky-500 bg-sky-500/10'
+                        : 'border-neutral-800 bg-neutral-950 hover:border-neutral-600 hover:bg-neutral-900'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="font-medium text-neutral-100 group-hover:text-white">
+                          {preset.name || 'Untitled preset'}
+                        </div>
+                        {preset.tags?.length ? (
+                          <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-neutral-400">
+                            {preset.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="rounded-full bg-neutral-800/70 px-2 py-[1px]"
+                              >
+                                #{tag}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                      <div className="flex flex-col items-end gap-1 text-[10px] text-neutral-500">
+                        <span>{fmt.format(new Date(preset.updatedAt))}</span>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            className="text-xs text-neutral-400 hover:text-neutral-200"
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              duplicatePreset(preset.id)
+                            }}
+                          >
+                            Duplicate
+                          </button>
+                          <button
+                            type="button"
+                            className="text-xs text-rose-400 hover:text-rose-200"
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              handleRemove(preset.id)
+                            }}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    {preset.description && (
+                      <p className="mt-2 line-clamp-2 text-[11px] text-neutral-400">
+                        {preset.description}
+                      </p>
+                    )}
+                    <div className="mt-3 flex flex-wrap gap-2 text-[10px] uppercase tracking-wide text-neutral-500">
+                      {preset.triggers.map((trigger) => (
+                        <span key={trigger} className="rounded bg-neutral-800 px-2 py-[1px]">
+                          {trigger}
+                        </span>
+                      ))}
+                      {preset.when?.map((trigger) => (
+                        <span key={`when-${trigger}`} className="rounded bg-neutral-800 px-2 py-[1px]">
+                          {trigger}
+                        </span>
+                      ))}
+                    </div>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/builder/components/actions/ActionPreview.tsx
+++ b/apps/builder/components/actions/ActionPreview.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import * as React from 'react'
+import type { ActionPreset } from '@/lib/actions/types'
+import { ActionEngine } from '@/lib/actions/engine'
+
+const PREVIEW_NODE_ID = 'action-preview-node'
+
+type Props = {
+  preset?: ActionPreset
+}
+
+export function ActionPreview({ preset }: Props) {
+  const rootRef = React.useRef<HTMLDivElement | null>(null)
+  const bindingRef = React.useRef<ReturnType<typeof ActionEngine.bind> | null>(null)
+  const [groupEnabled, setGroupEnabled] = React.useState(false)
+
+  React.useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    const binding = ActionEngine.bind(root, {
+      nodeId: PREVIEW_NODE_ID,
+      presets: preset ? [preset] : [],
+    })
+    bindingRef.current = binding
+    return () => {
+      binding.destroy()
+      if (bindingRef.current === binding) bindingRef.current = null
+    }
+  }, [])
+
+  React.useEffect(() => {
+    bindingRef.current?.update(preset ? [preset] : [])
+  }, [preset])
+
+  const hasGroupHover = React.useMemo(
+    () => (preset?.triggers ?? []).includes('groupHover'),
+    [preset?.triggers],
+  )
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950">
+      <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+          Preview
+        </h2>
+        <label className="flex items-center gap-2 text-xs text-neutral-400">
+          <input
+            type="checkbox"
+            checked={groupEnabled}
+            onChange={(event) => setGroupEnabled(event.target.checked)}
+            className="h-3 w-3 rounded border border-neutral-600 bg-neutral-900"
+          />
+          <span>.group wrapper</span>
+        </label>
+      </div>
+      <div ref={rootRef} className="relative flex-1 overflow-hidden px-4 py-6">
+        <div className={`mx-auto max-w-sm transition ${groupEnabled ? 'group' : ''}`}>
+          <div className="rounded-xl border border-neutral-800 bg-neutral-900/80 p-6 shadow-inner">
+            <div
+              data-node-id={PREVIEW_NODE_ID}
+              className="flex flex-col items-center justify-center gap-4 rounded-lg border border-neutral-800 bg-neutral-950 px-6 py-10 text-center text-sm text-neutral-200"
+            >
+              <span className="text-lg font-semibold text-white">Hover me</span>
+              <p className="max-w-[220px] text-xs text-neutral-400">
+                {hasGroupHover
+                  ? 'With group hover enabled, try hovering the surrounding card as well.'
+                  : 'Hover this element to preview the preset.'}
+              </p>
+              <button
+                type="button"
+                className="rounded-md border border-neutral-700 bg-neutral-900 px-4 py-1 text-xs text-neutral-300 hover:border-neutral-500"
+              >
+                Secondary action
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      {preset ? (
+        <div className="border-t border-neutral-800 px-4 py-3 text-[11px] text-neutral-400">
+          <div className="flex flex-wrap gap-2">
+            {(preset.triggers ?? []).map((trigger) => (
+              <span key={trigger} className="rounded bg-neutral-800 px-2 py-[1px]">
+                {trigger}
+              </span>
+            ))}
+            {(preset.when ?? []).map((trigger) => (
+              <span key={`when-${trigger}`} className="rounded bg-neutral-800 px-2 py-[1px]">
+                {trigger}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/builder/lib/actions/engine.ts
+++ b/apps/builder/lib/actions/engine.ts
@@ -1,0 +1,124 @@
+import type { ActionPreset, Effect, Trigger } from './types'
+
+const visualTriggers: Trigger[] = ['hover', 'active', 'focus', 'focusWithin', 'groupHover']
+const selectorForTrigger: Record<Trigger, (base: string) => string> = {
+  hover: (base) => `${base}:hover`,
+  active: (base) => `${base}:active`,
+  focus: (base) => `${base}:focus`,
+  focusWithin: (base) => `${base}:focus-within`,
+  groupHover: (base) => `.group:hover ${base}`,
+}
+
+const shadowMap = {
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+} as const
+
+const esc = (value: string) => {
+  try {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(value)
+    }
+  } catch (err) {
+    console.warn('Failed to escape CSS selector', err)
+  }
+  return value
+}
+
+function effectsToDecls(
+  effects: Effect[],
+  ms = 150,
+  easing = 'cubic-bezier(.2,.8,.2,1)',
+) {
+  const decls: string[] = []
+  const transforms: string[] = []
+
+  for (const ef of effects) {
+    if (ef.kind === 'bgColor') decls.push(`background-color:${ef.value} !important`)
+    else if (ef.kind === 'textColor') decls.push(`color:${ef.value} !important`)
+    else if (ef.kind === 'borderColor') decls.push(`border-color:${ef.value} !important`)
+    else if (ef.kind === 'shadow') decls.push(`box-shadow:${shadowMap[ef.value]} !important`)
+    else if (ef.kind === 'scale') transforms.push(`scale(${ef.value})`)
+    else if (ef.kind === 'opacity') decls.push(`opacity:${ef.value}`)
+    else if (ef.kind === 'translate')
+      transforms.push(`translate(${ef.x ?? 0}px, ${ef.y ?? 0}px)`)
+    else if (ef.kind === 'rotate') transforms.push(`rotate(${ef.deg}deg)`)
+    else if (ef.kind === 'outline') {
+      decls.push(
+        `outline:${ef.width}px ${ef.style ?? 'solid'} ${ef.color}`,
+      )
+      decls.push('outline-offset:0')
+    } else if (ef.kind === 'cursor') decls.push(`cursor:${ef.value}`)
+  }
+
+  if (transforms.length) {
+    decls.push(`transform:${transforms.join(' ')} !important`)
+  }
+  decls.push(`transition: all ${ms}ms ${easing}`)
+  return decls.join(';')
+}
+
+function buildPresetCss(nodeId: string, preset: ActionPreset) {
+  if (!Array.isArray(preset.effects) || preset.effects.length === 0) return ''
+  const triggers = Array.isArray(preset.triggers)
+    ? preset.triggers.filter((t): t is Trigger => visualTriggers.includes(t))
+    : []
+  if (!triggers.length) return ''
+
+  const baseSelector = `[data-node-id="${esc(nodeId)}"]`
+  const decls = effectsToDecls(
+    preset.effects,
+    preset.transitionMs ?? 150,
+    preset.easing ?? 'cubic-bezier(.2,.8,.2,1)',
+  )
+  return triggers
+    .map((trigger) => `${selectorForTrigger[trigger](baseSelector)}{${decls}}`)
+    .join('\n')
+}
+
+function buildCombinedCss(nodeId: string, presets: ActionPreset[] = []) {
+  if (!Array.isArray(presets)) return ''
+  return presets
+    .map((preset) => buildPresetCss(nodeId, preset))
+    .filter(Boolean)
+    .join('\n')
+}
+
+type Binding = {
+  update: (presets: ActionPreset[]) => void
+  destroy: () => void
+}
+
+export class ActionEngine {
+  static bind(root: HTMLElement, opts: { nodeId: string; presets?: ActionPreset[] }): Binding {
+    const styleId = `action-engine-${opts.nodeId}`
+    let styleEl = root.querySelector(
+      `style[data-action-engine="${styleId}"]`,
+    ) as HTMLStyleElement | null
+
+    if (!styleEl) {
+      styleEl = document.createElement('style')
+      styleEl.dataset.actionEngine = styleId
+      root.appendChild(styleEl)
+    }
+
+    const apply = (presets: ActionPreset[] = []) => {
+      styleEl!.textContent = buildCombinedCss(opts.nodeId, presets)
+    }
+
+    apply(opts.presets ?? [])
+
+    return {
+      update(nextPresets) {
+        apply(nextPresets)
+      },
+      destroy() {
+        styleEl?.remove()
+      },
+    }
+  }
+}
+
+export { buildCombinedCss }

--- a/apps/builder/lib/actions/types.ts
+++ b/apps/builder/lib/actions/types.ts
@@ -1,0 +1,111 @@
+export type Effect =
+  | { kind: 'bgColor'; value: string }
+  | { kind: 'textColor'; value: string }
+  | { kind: 'borderColor'; value: string }
+  | { kind: 'shadow'; value: 'sm' | 'md' | 'lg' | 'xl' }
+  | { kind: 'scale'; value: number }
+  | { kind: 'opacity'; value: number }
+  | { kind: 'translate'; x?: number; y?: number }
+  | { kind: 'rotate'; deg: number }
+  | { kind: 'outline'; color: string; width: number; style?: 'solid' | 'dashed' | 'dotted' }
+  | { kind: 'cursor'; value: 'default' | 'pointer' | 'move' | 'grab' | 'text' }
+
+export type Trigger = 'hover' | 'active' | 'focus' | 'focusWithin' | 'groupHover'
+
+export type BehaviorTrigger =
+  | 'click'
+  | 'doubleClick'
+  | 'mount'
+  | 'delay'
+  | 'inView'
+
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [k: string]: Json }
+
+export type Logic =
+  | { '==': [Json, Json] }
+  | { '===': [Json, Json] }
+  | { '!=': [Json, Json] }
+  | { '!==': [Json, Json] }
+  | { '<': [Json, Json] }
+  | { '<=': [Json, Json] }
+  | { '>': [Json, Json] }
+  | { '>=': [Json, Json] }
+  | { and: Logic[] }
+  | { or: Logic[] }
+  | { '!': [Logic] }
+  | { '+': Json[] }
+  | { '-': Json[] }
+  | { '*': Json[] }
+  | { '/': Json[] }
+  | { '%': [Json, Json] }
+  | { var: string }
+  | Json
+
+export type ActionKind = 'openUrl' | 'navigate' | 'emitEvent' | 'setProp'
+
+export type Target =
+  | { type: 'nodeId'; value: string }
+  | { type: 'query'; value: string }
+
+export type ActionBase = {
+  if?: Logic
+  throttleMs?: number
+  debounceMs?: number
+}
+
+export type Action =
+  | (ActionBase & { kind: 'openUrl'; url: string; target?: '_blank' | '_self' })
+  | (ActionBase & { kind: 'navigate'; to: string })
+  | (ActionBase & { kind: 'emitEvent'; name: string; payload?: Json })
+  | (ActionBase & {
+      kind: 'setProp'
+      selector?: Target
+      prop: string
+      value: Json | string
+    })
+
+export type ActionPreset = {
+  id: string
+  name: string
+  description?: string
+  triggers: Trigger[]
+  effects: Effect[]
+  transitionMs?: number
+  easing?: string
+  tags?: string[]
+  updatedAt: number
+  createdAt?: number
+  when?: BehaviorTrigger[]
+  actions?: Action[]
+}
+
+export const defaultEffect = (k: Effect['kind']): Effect => {
+  switch (k) {
+    case 'bgColor':
+      return { kind: 'bgColor', value: '#0f172a' }
+    case 'textColor':
+      return { kind: 'textColor', value: '#e5e7eb' }
+    case 'borderColor':
+      return { kind: 'borderColor', value: '#334155' }
+    case 'shadow':
+      return { kind: 'shadow', value: 'md' }
+    case 'scale':
+      return { kind: 'scale', value: 1.05 }
+    case 'opacity':
+      return { kind: 'opacity', value: 0.9 }
+    case 'translate':
+      return { kind: 'translate', x: 0, y: -2 }
+    case 'rotate':
+      return { kind: 'rotate', deg: 1 }
+    case 'outline':
+      return { kind: 'outline', color: '#22d3ee', width: 1, style: 'dashed' }
+    case 'cursor':
+      return { kind: 'cursor', value: 'pointer' }
+  }
+}

--- a/apps/builder/stores/actions.ts
+++ b/apps/builder/stores/actions.ts
@@ -1,0 +1,281 @@
+'use client'
+
+import { create } from 'zustand'
+import type { ActionPreset, BehaviorTrigger, Effect, Trigger } from '@/lib/actions/types'
+import { defaultEffect } from '@/lib/actions/types'
+
+type ActionsStore = {
+  list: string[]
+  presets: Record<string, ActionPreset>
+  currentId?: string
+  createPreset: () => string
+  duplicate: (id: string) => string
+  update: (id: string, patch: Partial<ActionPreset>) => void
+  remove: (id: string) => void
+  setCurrent: (id?: string) => void
+  import: (json: ActionPreset[]) => void
+  export: (ids?: string[]) => string
+}
+
+const visualTriggers: Trigger[] = ['hover', 'active', 'focus', 'focusWithin', 'groupHover']
+const behaviorTriggers: BehaviorTrigger[] = ['click', 'doubleClick', 'mount', 'delay', 'inView']
+
+const cursorKinds: Effect & { kind: 'cursor' }['value'][] = [
+  'default',
+  'pointer',
+  'move',
+  'grab',
+  'text',
+]
+
+const shadowKinds: Effect & { kind: 'shadow' }['value'][] = ['sm', 'md', 'lg', 'xl']
+
+const newId = () => `ap_${Math.random().toString(36).slice(2, 9)}`
+
+const clone = <T,>(value: T): T => {
+  try {
+    return structuredClone(value)
+  } catch {
+    return JSON.parse(JSON.stringify(value))
+  }
+}
+
+const sanitizeTriggers = (input: any): Trigger[] => {
+  if (!Array.isArray(input)) return []
+  const uniq = new Set<Trigger>()
+  input.forEach((item) => {
+    if (visualTriggers.includes(item as Trigger)) {
+      uniq.add(item as Trigger)
+    }
+  })
+  return Array.from(uniq)
+}
+
+const sanitizeBehavior = (input: any): BehaviorTrigger[] => {
+  if (!Array.isArray(input)) return []
+  const uniq = new Set<BehaviorTrigger>()
+  input.forEach((item) => {
+    if (behaviorTriggers.includes(item as BehaviorTrigger)) uniq.add(item as BehaviorTrigger)
+  })
+  return Array.from(uniq)
+}
+
+const sanitizeTags = (input: any): string[] => {
+  if (!Array.isArray(input)) return []
+  const uniq = new Set<string>()
+  input.forEach((item) => {
+    if (typeof item === 'string' && item.trim()) uniq.add(item.trim())
+  })
+  return Array.from(uniq)
+}
+
+const sanitizeEffect = (input: any): Effect | undefined => {
+  if (!input || typeof input !== 'object') return undefined
+  const kind = input.kind
+  switch (kind) {
+    case 'bgColor':
+    case 'textColor':
+    case 'borderColor':
+      if (typeof input.value === 'string') return { kind, value: input.value }
+      return undefined
+    case 'shadow':
+      if (shadowKinds.includes(input.value)) return { kind, value: input.value }
+      return undefined
+    case 'scale':
+      if (typeof input.value === 'number' && Number.isFinite(input.value)) return { kind, value: input.value }
+      return undefined
+    case 'opacity':
+      if (typeof input.value === 'number' && Number.isFinite(input.value)) return { kind, value: input.value }
+      return undefined
+    case 'translate': {
+      const x = typeof input.x === 'number' && Number.isFinite(input.x) ? input.x : 0
+      const y = typeof input.y === 'number' && Number.isFinite(input.y) ? input.y : 0
+      return { kind, x, y }
+    }
+    case 'rotate': {
+      const deg = typeof input.deg === 'number' && Number.isFinite(input.deg) ? input.deg : 0
+      return { kind, deg }
+    }
+    case 'outline':
+      if (
+        typeof input.color === 'string' &&
+        typeof input.width === 'number' &&
+        Number.isFinite(input.width)
+      ) {
+        return {
+          kind,
+          color: input.color,
+          width: input.width,
+          style: typeof input.style === 'string' ? input.style : undefined,
+        }
+      }
+      return undefined
+    case 'cursor':
+      if (cursorKinds.includes(input.value)) return { kind, value: input.value }
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+const sanitizeEffects = (input: any): Effect[] => {
+  if (!Array.isArray(input)) return []
+  const result: Effect[] = []
+  input.forEach((item) => {
+    const next = sanitizeEffect(item)
+    if (next) result.push(next)
+  })
+  return result
+}
+
+const ensurePreset = (partial: Partial<ActionPreset> & { id?: string }, fallbackName?: string): ActionPreset => {
+  const id = typeof partial.id === 'string' ? partial.id : newId()
+  const name = typeof partial.name === 'string' && partial.name.trim()
+    ? partial.name.trim()
+    : fallbackName ?? 'Untitled preset'
+  const triggers = sanitizeTriggers(partial.triggers)
+  const when = sanitizeBehavior(partial.when)
+  const effects = sanitizeEffects(partial.effects)
+  const tags = sanitizeTags(partial.tags)
+  const transitionMs = typeof partial.transitionMs === 'number' && Number.isFinite(partial.transitionMs)
+    ? partial.transitionMs
+    : undefined
+  const easing = typeof partial.easing === 'string' && partial.easing.trim()
+    ? partial.easing
+    : undefined
+  const updatedAt = typeof partial.updatedAt === 'number' ? partial.updatedAt : Date.now()
+  const createdAt = typeof partial.createdAt === 'number' ? partial.createdAt : undefined
+
+  return {
+    id,
+    name,
+    description: typeof partial.description === 'string' ? partial.description : undefined,
+    triggers: triggers.length ? triggers : ['hover'],
+    when,
+    effects: effects.length ? effects : [defaultEffect('scale')],
+    transitionMs,
+    easing,
+    tags,
+    updatedAt,
+    createdAt,
+    actions: Array.isArray(partial.actions) ? clone(partial.actions) : undefined,
+  }
+}
+
+export const useActionsStore = create<ActionsStore>((set, get) => ({
+  list: [],
+  presets: {},
+  currentId: undefined,
+
+  createPreset() {
+    const preset = ensurePreset({ triggers: ['hover'], when: [], effects: [defaultEffect('scale')], name: 'New preset' })
+    set((state) => ({
+      list: [...state.list, preset.id],
+      presets: { ...state.presets, [preset.id]: preset },
+      currentId: preset.id,
+    }))
+    return preset.id
+  },
+
+  duplicate(id) {
+    const src = get().presets[id]
+    if (!src) {
+      return get().createPreset()
+    }
+    const copy = ensurePreset({
+      ...clone(src),
+      id: undefined,
+      name: src.name ? `${src.name} Copy` : 'Preset Copy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    })
+    set((state) => ({
+      list: [...state.list, copy.id],
+      presets: { ...state.presets, [copy.id]: copy },
+      currentId: copy.id,
+    }))
+    return copy.id
+  },
+
+  update(id, patch) {
+    set((state) => {
+      const current = state.presets[id]
+      if (!current) return {}
+      const next: ActionPreset = {
+        ...current,
+        updatedAt: Date.now(),
+      }
+
+      if (patch.name !== undefined) {
+        next.name = typeof patch.name === 'string' ? patch.name : current.name
+      }
+      if (patch.description !== undefined) {
+        next.description = typeof patch.description === 'string' ? patch.description : undefined
+      }
+      if (patch.triggers !== undefined) {
+        const triggers = sanitizeTriggers(patch.triggers)
+        next.triggers = triggers.length ? triggers : []
+      }
+      if (patch.when !== undefined) {
+        next.when = sanitizeBehavior(patch.when)
+      }
+      if (patch.effects !== undefined) {
+        const effects = sanitizeEffects(patch.effects)
+        next.effects = effects.length ? effects : []
+      }
+      if (patch.transitionMs !== undefined) {
+        next.transitionMs =
+          typeof patch.transitionMs === 'number' && Number.isFinite(patch.transitionMs)
+            ? patch.transitionMs
+            : undefined
+      }
+      if (patch.easing !== undefined) {
+        next.easing = typeof patch.easing === 'string' && patch.easing.trim() ? patch.easing : undefined
+      }
+      if (patch.tags !== undefined) {
+        next.tags = sanitizeTags(patch.tags)
+      }
+      if (patch.actions !== undefined) {
+        next.actions = Array.isArray(patch.actions) ? clone(patch.actions) : undefined
+      }
+
+      return { presets: { ...state.presets, [id]: next } }
+    })
+  },
+
+  remove(id) {
+    set((state) => {
+      if (!state.presets[id]) return {}
+      const nextList = state.list.filter((item) => item !== id)
+      const nextPresets = { ...state.presets }
+      delete nextPresets[id]
+      const currentId = state.currentId === id ? nextList[0] : state.currentId
+      return { list: nextList, presets: nextPresets, currentId }
+    })
+  },
+
+  setCurrent(id) {
+    set({ currentId: id })
+  },
+
+  import(json) {
+    const arr = Array.isArray(json) ? json : []
+    const normalized = arr.map((item, idx) => ensurePreset(item ?? {}, `Preset ${idx + 1}`))
+    const list = normalized.map((preset) => preset.id)
+    const presets: Record<string, ActionPreset> = {}
+    normalized.forEach((preset) => {
+      presets[preset.id] = preset
+    })
+    set({ list, presets, currentId: list[0] })
+  },
+
+  export(ids) {
+    const state = get()
+    const targets = Array.isArray(ids) && ids.length ? ids : state.list
+    const payload = targets
+      .map((id) => state.presets[id])
+      .filter((preset): preset is ActionPreset => !!preset)
+      .map((preset) => clone(preset))
+    return JSON.stringify(payload, null, 2)
+  },
+}))


### PR DESCRIPTION
## Summary
- add action preset types, zustand store, and runtime helpers for builder
- implement /dev/actions page with list, editor UI, and live preview wiring
- provide a mock project actions API endpoint for GET/PUT/POST persistence

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d3c37b2170832cadc257b082fe3bba