### PR TITLE
feat(export,preview): deterministic action embedding + preview ActionBoot

### DIFF
--- a/apps/builder/lib/actions/engine.spec.ts
+++ b/apps/builder/lib/actions/engine.spec.ts
@@ -1,0 +1,189 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
+import { ActionEngine, collectRulesFromDataAttrs } from './engine'
+import type { ActionRule } from './types'
+
+declare global {
+  interface Window {
+    __lastObserver?: FakeIntersectionObserver
+  }
+}
+
+type FakeEntry = { target: Element; isIntersecting: boolean }
+
+class FakeIntersectionObserver {
+  private callback: IntersectionObserverCallback
+  private observed = new Set<Element>()
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    window.__lastObserver = this
+  }
+
+  observe(target: Element) {
+    this.observed.add(target)
+  }
+
+  unobserve(target: Element) {
+    this.observed.delete(target)
+  }
+
+  disconnect() {
+    this.observed.clear()
+  }
+
+  trigger(entry: FakeEntry) {
+    if (!this.observed.has(entry.target)) return
+    const record: IntersectionObserverEntry = {
+      boundingClientRect: entry.target.getBoundingClientRect(),
+      intersectionRatio: entry.isIntersecting ? 1 : 0,
+      intersectionRect: entry.target.getBoundingClientRect(),
+      isIntersecting: entry.isIntersecting,
+      rootBounds: null,
+      target: entry.target,
+      time: Date.now(),
+    }
+    this.callback([record], this as unknown as IntersectionObserver)
+  }
+}
+
+describe('ActionEngine', () => {
+  let originalObserver: typeof IntersectionObserver
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    originalObserver = window.IntersectionObserver
+    window.IntersectionObserver = FakeIntersectionObserver as unknown as typeof IntersectionObserver
+  })
+
+  afterEach(() => {
+    window.IntersectionObserver = originalObserver
+    delete window.__lastObserver
+  })
+
+  it('handles hover, click and inView triggers', () => {
+    const source = document.createElement('div')
+    source.setAttribute('data-node-id', 'source')
+    source.setAttribute('data-int', '[]')
+    const target = document.createElement('div')
+    target.setAttribute('data-node-id', 'target')
+    document.body.append(source, target)
+
+    const rules: ActionRule[] = [
+      {
+        sourceId: 'source',
+        triggers: [{ kind: 'click' }],
+        effects: [{ kind: 'class', target: 'target', add: ['clicked'] }],
+      },
+      {
+        sourceId: 'source',
+        triggers: [{ kind: 'hover', phase: 'enter' }],
+        effects: [{ kind: 'class', target: 'target', add: ['hovered'] }],
+      },
+      {
+        sourceId: 'source',
+        triggers: [{ kind: 'hover', phase: 'leave' }],
+        effects: [{ kind: 'class', target: 'target', remove: ['hovered'] }],
+      },
+      {
+        sourceId: 'source',
+        triggers: [{ kind: 'inView', once: true }],
+        effects: [{ kind: 'class', target: 'target', add: ['visible'] }],
+      },
+    ]
+
+    const engine = ActionEngine.bind(document, [{ element: source, rules }])
+    expect(engine).toBeInstanceOf(ActionEngine)
+
+    source.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    expect(target.classList.contains('hovered')).toBe(true)
+
+    source.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }))
+    expect(target.classList.contains('hovered')).toBe(false)
+
+    source.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(target.classList.contains('clicked')).toBe(true)
+
+    const io = window.__lastObserver!
+    io.trigger({ target: source, isIntersecting: true })
+    expect(target.classList.contains('visible')).toBe(true)
+
+    // second trigger ignored due to once:true
+    target.classList.remove('visible')
+    io.trigger({ target: source, isIntersecting: true })
+    expect(target.classList.contains('visible')).toBe(false)
+
+    engine.destroy()
+  })
+
+  it('respects concurrency strategies', async () => {
+    const clickOnce = document.createElement('div')
+    clickOnce.setAttribute('data-node-id', 'ignore')
+    clickOnce.setAttribute('data-int', '[]')
+    const clickRestart = document.createElement('div')
+    clickRestart.setAttribute('data-node-id', 'restart')
+    clickRestart.setAttribute('data-int', '[]')
+    document.body.append(clickOnce, clickRestart)
+
+    let ignoreCount = 0
+    let restartCount = 0
+    const ignoreListener = () => ignoreCount++
+    const restartListener = () => restartCount++
+    window.addEventListener('ignore-event', ignoreListener)
+    window.addEventListener('restart-event', restartListener)
+
+    const pairs = [
+      {
+        element: clickOnce,
+        rules: [
+          {
+            sourceId: 'ignore',
+            concurrency: 'ignore',
+            transition: { durationMs: 40 },
+            triggers: [{ kind: 'click' }],
+            effects: [{ kind: 'emit', name: 'ignore-event' }],
+          },
+        ],
+      },
+      {
+        element: clickRestart,
+        rules: [
+          {
+            sourceId: 'restart',
+            concurrency: 'restart',
+            transition: { durationMs: 40 },
+            triggers: [{ kind: 'click' }],
+            effects: [{ kind: 'emit', name: 'restart-event' }],
+          },
+        ],
+      },
+    ]
+
+    const engine = ActionEngine.bind(document, pairs)
+
+    clickOnce.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    clickOnce.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    clickRestart.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    clickRestart.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(ignoreCount).toBe(1)
+    expect(restartCount).toBe(2)
+
+    engine.destroy()
+    window.removeEventListener('ignore-event', ignoreListener)
+    window.removeEventListener('restart-event', restartListener)
+  })
+
+  it('collects rules from data attributes', () => {
+    const el = document.createElement('div')
+    el.setAttribute('data-node-id', 'x')
+    el.setAttribute('data-int', '{"tr":[{"k":"c"}],"fx":[{"k":"c","add":"active"}]}')
+    document.body.appendChild(el)
+
+    const pairs = collectRulesFromDataAttrs(document)
+    expect(pairs.length).toBe(1)
+    expect(pairs[0].rules[0].effects[0]).toMatchObject({ kind: 'class', add: ['active'] })
+  })
+})

--- a/apps/builder/lib/actions/engine.ts
+++ b/apps/builder/lib/actions/engine.ts
@@ -1,0 +1,357 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { decodeActionRules } from './serialize'
+import type { ActionEffect, ActionRule, ActionTrigger } from './types'
+
+type TriggerDispatch = 'click' | 'hover:enter' | 'hover:leave' | 'inView'
+
+type RuleRuntime = {
+  element: HTMLElement
+  rule: ActionRule
+  state: { running: boolean; controller?: AbortController }
+  onceFired: Set<number>
+}
+
+type ObserverEntry = { runtime: RuleRuntime; triggerIndex: number }
+
+type ObserverGroup = {
+  observer: IntersectionObserver
+  targets: Map<Element, ObserverEntry[]>
+}
+
+type ListenerRecord = {
+  target: Document | HTMLElement
+  type: string
+  listener: EventListenerOrEventListenerObject
+  options?: boolean | AddEventListenerOptions
+}
+
+const DEFAULT_DURATION = 150
+const DEFAULT_DELAY = 0
+const DEFAULT_EASING = 'ease-out'
+
+const asArray = <T,>(value: T | T[] | undefined): T[] => {
+  if (value == null) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+const detectReducedMotion = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  } catch {
+    return false
+  }
+}
+
+const closestInteractiveNode = (el: Element | null): HTMLElement | null => {
+  if (!el) return null
+  return (el.closest('[data-int]') as HTMLElement | null) ?? null
+}
+
+const matchesTrigger = (trigger: ActionTrigger, dispatch: TriggerDispatch) => {
+  if (trigger.kind === 'click') return dispatch === 'click'
+  if (trigger.kind === 'hover') {
+    const phase = trigger.phase ?? 'enter'
+    return (phase === 'enter' && dispatch === 'hover:enter') || (phase === 'leave' && dispatch === 'hover:leave')
+  }
+  if (trigger.kind === 'inView') return dispatch === 'inView'
+  return false
+}
+
+const waitFor = (ms: number, signal: AbortSignal) => {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise<void>((resolve, reject) => {
+    const id = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(id)
+      signal.removeEventListener('abort', onAbort)
+      reject(new Error('aborted'))
+    }
+    signal.addEventListener('abort', onAbort)
+  })
+}
+
+const dispatchCustomEvent = (name: string, detail: any) => {
+  if (typeof window === 'undefined') return
+  const ev = new CustomEvent(name, { detail }) as Event
+  window.dispatchEvent(ev)
+}
+
+const scrollIntoView = (selector: string, behavior?: ScrollBehavior) => {
+  if (typeof document === 'undefined') return
+  const target = document.querySelector(selector) as HTMLElement | null
+  target?.scrollIntoView({ behavior: behavior ?? 'smooth' })
+}
+
+const navigateTo = (href: string, target?: '_self' | '_blank') => {
+  if (typeof window === 'undefined') return
+  if (target === '_blank') {
+    window.open(href, '_blank', 'noopener,noreferrer')
+  } else {
+    window.location.href = href
+  }
+}
+
+export const collectRulesFromDataAttrs = (root: ParentNode) => {
+  const pairs: Array<{ element: HTMLElement; rules: ActionRule[] }> = []
+  const nodes = root.querySelectorAll<HTMLElement>('[data-int]')
+  nodes.forEach((el) => {
+    const attr = el.getAttribute('data-int')
+    if (!attr) return
+    const sourceId = el.getAttribute('data-node-id') ?? ''
+    const rules = decodeActionRules(attr, sourceId)
+    if (!rules.length) return
+    pairs.push({ element: el, rules })
+  })
+  return pairs
+}
+
+export interface ActionEngineOptions {
+  reducedMotion?: boolean
+}
+
+export class ActionEngine {
+  private root!: Document | HTMLElement
+  private scope!: ParentNode
+  private reducedMotion: boolean
+  private listeners: ListenerRecord[] = []
+  private elementRules = new Map<HTMLElement, RuleRuntime[]>()
+  private inViewObservers = new Map<string, ObserverGroup>()
+
+  constructor(opts?: ActionEngineOptions) {
+    this.reducedMotion = opts?.reducedMotion ?? detectReducedMotion()
+  }
+
+  static bind(
+    root: Document | HTMLElement,
+    pairs: Array<{ element: HTMLElement; rules: ActionRule[] }>,
+    opts?: ActionEngineOptions,
+  ) {
+    const engine = new ActionEngine(opts)
+    engine.attach(root)
+    pairs.forEach((pair) => engine.register(pair.element, pair.rules))
+    return engine
+  }
+
+  static fromDOM(root: Document | HTMLElement, opts?: ActionEngineOptions) {
+    const parent: ParentNode = root instanceof Document ? root : (root as unknown as ParentNode)
+    const pairs = collectRulesFromDataAttrs(parent)
+    return ActionEngine.bind(root, pairs, opts)
+  }
+
+  destroy() {
+    for (const rec of this.listeners) rec.target.removeEventListener(rec.type, rec.listener, rec.options)
+    this.listeners = []
+    this.inViewObservers.forEach((group) => group.observer.disconnect())
+    this.inViewObservers.clear()
+    this.elementRules.clear()
+  }
+
+  private attach(root: Document | HTMLElement) {
+    this.root = root
+    this.scope = root instanceof Document ? root : (root as unknown as ParentNode)
+    this.addListener(root, 'click', (event) => {
+      const target = closestInteractiveNode(event.target as Element | null)
+      if (!target) return
+      this.dispatch(target, 'click', event)
+    }, true)
+    this.addListener(root, 'mouseover', (event: Event) => {
+      const e = event as MouseEvent
+      const target = closestInteractiveNode(e.target as Element | null)
+      if (!target) return
+      const rel = e.relatedTarget as Node | null
+      if (rel && target.contains(rel)) return
+      this.dispatch(target, 'hover:enter', event)
+    }, true)
+    this.addListener(root, 'mouseout', (event: Event) => {
+      const e = event as MouseEvent
+      const target = closestInteractiveNode(e.target as Element | null)
+      if (!target) return
+      const rel = e.relatedTarget as Node | null
+      if (rel && target.contains(rel)) return
+      this.dispatch(target, 'hover:leave', event)
+    }, true)
+  }
+
+  private addListener(
+    target: Document | HTMLElement,
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ) {
+    target.addEventListener(type, listener, options)
+    this.listeners.push({ target, type, listener, options })
+  }
+
+  private register(element: HTMLElement, rules: ActionRule[]) {
+    const list = this.elementRules.get(element) ?? []
+    const elementSourceId = element.getAttribute?.('data-node-id') ?? ''
+    rules.forEach((rule) => {
+      if (!rule.sourceId) rule.sourceId = elementSourceId
+      const runtime: RuleRuntime = {
+        element,
+        rule: { ...rule },
+        state: { running: false },
+        onceFired: new Set(),
+      }
+      list.push(runtime)
+      this.registerTriggers(runtime)
+    })
+    if (list.length) this.elementRules.set(element, list)
+  }
+
+  private registerTriggers(runtime: RuleRuntime) {
+    runtime.rule.triggers.forEach((trigger, index) => {
+      if (trigger.kind === 'inView') this.registerInView(runtime, index, trigger)
+    })
+  }
+
+  private observerKey(trigger: Extract<ActionTrigger, { kind: 'inView' }>) {
+    const th = trigger.threshold ?? 0
+    const rm = trigger.rootMargin ?? ''
+    return JSON.stringify([th, rm])
+  }
+
+  private registerInView(runtime: RuleRuntime, triggerIndex: number, trigger: Extract<ActionTrigger, { kind: 'inView' }>) {
+    const key = this.observerKey(trigger)
+    let group = this.inViewObservers.get(key)
+    if (!group) {
+      const options: IntersectionObserverInit = {
+        threshold: trigger.threshold ?? 0,
+        rootMargin: trigger.rootMargin,
+      }
+      const observer = new IntersectionObserver((entries) => this.handleInView(entries, key), options)
+      group = { observer, targets: new Map() }
+      this.inViewObservers.set(key, group)
+    }
+    const current = group.targets.get(runtime.element) ?? []
+    current.push({ runtime, triggerIndex })
+    group.targets.set(runtime.element, current)
+    group.observer.observe(runtime.element)
+  }
+
+  private handleInView(entries: IntersectionObserverEntry[], key: string) {
+    const group = this.inViewObservers.get(key)
+    if (!group) return
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return
+      const arr = group.targets.get(entry.target as Element)
+      if (!arr?.length) return
+      arr.slice().forEach(({ runtime, triggerIndex }) => {
+        const trigger = runtime.rule.triggers[triggerIndex]
+        if (trigger?.kind !== 'inView') return
+        if (trigger.once && runtime.onceFired.has(triggerIndex)) return
+        this.runRule(runtime, triggerIndex, entry)
+        if (trigger.once) this.removeInViewTarget(key, runtime.element, triggerIndex)
+      })
+    })
+  }
+
+  private removeInViewTarget(key: string, element: Element, triggerIndex: number) {
+    const group = this.inViewObservers.get(key)
+    if (!group) return
+    const arr = group.targets.get(element)
+    if (!arr) return
+    const next = arr.filter((item) => item.triggerIndex !== triggerIndex)
+    if (next.length) group.targets.set(element, next)
+    else {
+      group.targets.delete(element)
+      group.observer.unobserve(element)
+    }
+  }
+
+  private dispatch(element: HTMLElement, dispatch: TriggerDispatch, detail: any) {
+    const runtimes = this.elementRules.get(element)
+    if (!runtimes) return
+    runtimes.forEach((runtime) => {
+      runtime.rule.triggers.forEach((trigger, index) => {
+        if (!matchesTrigger(trigger, dispatch)) return
+        if (trigger.once && runtime.onceFired.has(index)) return
+        this.runRule(runtime, index, detail)
+        if (trigger.once) runtime.onceFired.add(index)
+      })
+    })
+  }
+
+  private resolveTargets(target: string | string[] | undefined, source: HTMLElement) {
+    const ids = asArray(target)
+    if (!ids.length) return [source]
+    const hits: HTMLElement[] = []
+    ids.forEach((id) => {
+      const sel = `[data-node-id="${id}"]`
+      const found = this.scope.querySelector(sel) as HTMLElement | null
+      if (found) hits.push(found)
+    })
+    return hits.length ? hits : [source]
+  }
+
+  private applyEffect(effect: ActionEffect, runtime: RuleRuntime, signal: AbortSignal) {
+    switch (effect.kind) {
+      case 'class': {
+        const targets = this.resolveTargets(effect.target, runtime.element)
+        targets.forEach((el) => {
+          effect.remove?.forEach((cls) => el.classList.remove(cls))
+          effect.toggle?.forEach((cls) => el.classList.toggle(cls))
+          effect.add?.forEach((cls) => el.classList.add(cls))
+        })
+        break
+      }
+      case 'emit':
+        dispatchCustomEvent(effect.name, effect.detail)
+        break
+      case 'scroll':
+        scrollIntoView(effect.selector, effect.behavior)
+        break
+      case 'navigate':
+        navigateTo(effect.href, effect.target)
+        break
+      default:
+        break
+    }
+  }
+
+  private resolveTransition(rule: ActionRule) {
+    const base = rule.transition ?? {}
+    const disable = rule.disableMotionWhenReduced !== false
+    const factor = this.reducedMotion && disable ? 0 : 1
+    const delay = Math.max(0, Math.round((base.delayMs ?? DEFAULT_DELAY) * factor))
+    const duration = Math.max(0, Math.round((base.durationMs ?? DEFAULT_DURATION) * factor))
+    return { delay, duration, easing: base.easing ?? DEFAULT_EASING }
+  }
+
+  private runRule(runtime: RuleRuntime, triggerIndex: number, detail: any) {
+    const state = runtime.state
+    const rule = runtime.rule
+    const concurrency = rule.concurrency ?? 'restart'
+    if (state.running) {
+      if (concurrency === 'ignore') return
+      state.controller?.abort()
+    }
+    const controller = new AbortController()
+    state.running = true
+    state.controller = controller
+    runtime.onceFired.add(triggerIndex)
+    const transition = this.resolveTransition(rule)
+    const execute = async () => {
+      try {
+        if (transition.delay > 0) await waitFor(transition.delay, controller.signal)
+        for (const effect of rule.effects) {
+          this.applyEffect(effect, runtime, controller.signal)
+          if (controller.signal.aborted) return
+        }
+        if (transition.duration > 0) await waitFor(transition.duration, controller.signal)
+      } catch {
+        /* ignore */
+      } finally {
+        if (state.controller === controller) {
+          state.running = false
+          state.controller = undefined
+        }
+      }
+    }
+    void execute()
+  }
+}

--- a/apps/builder/lib/actions/index.ts
+++ b/apps/builder/lib/actions/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './serialize'
+export * from './engine'

--- a/apps/builder/lib/actions/serialize.spec.ts
+++ b/apps/builder/lib/actions/serialize.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { encodeActionRules, decodeActionRules, serializeRule } from './serialize'
+import type { ActionRule } from './types'
+
+describe('actions serialize', () => {
+  it('produces deterministic strings for equivalent rules', () => {
+    const base: ActionRule = {
+      sourceId: 'node-1',
+      triggers: [{ kind: 'click' }, { kind: 'hover', phase: 'enter' }],
+      effects: [{ kind: 'class', add: ['bg-blue-500', 'text-sm', 'bg-blue-500'] }],
+      transition: { durationMs: 150, delayMs: 0, easing: 'ease-out' },
+    }
+    const variant: ActionRule = {
+      sourceId: 'node-1',
+      triggers: [{ kind: 'hover', phase: 'enter' }, { kind: 'click' }],
+      effects: [{ kind: 'class', add: ['text-sm', 'bg-blue-500'] }],
+      transition: { durationMs: 150, delayMs: 0, easing: 'ease-out' },
+    }
+
+    const a = serializeRule(base)
+    const b = serializeRule(variant)
+    expect(a).toBe(b)
+  })
+
+  it('omits default transition values and rounds numbers', () => {
+    const rule: ActionRule = {
+      sourceId: 'node-2',
+      triggers: [{ kind: 'inView', threshold: 0.3333333 }],
+      effects: [
+        { kind: 'class', add: ['opacity-0'], toggle: ['opacity-100', 'opacity-100'] },
+      ],
+      transition: { durationMs: 275.678, delayMs: 0, easing: 'ease-in-out' },
+      concurrency: 'ignore',
+    }
+
+    const serialized = serializeRule(rule)
+    expect(serialized).toContain('0.3333')
+    expect(serialized.includes('150')).toBe(false)
+    expect(serialized).toContain('"d":275.678')
+    const decoded = decodeActionRules(serialized, 'node-2')
+    expect(decoded[0].effects[0]).toMatchObject({ toggle: ['opacity-100'] })
+    expect(decoded[0].transition).toMatchObject({ durationMs: 275.678, easing: 'ease-in-out' })
+    expect(decoded[0].concurrency).toBe('ignore')
+  })
+
+  it('encodes multiple rules deterministically', () => {
+    const rules: ActionRule[] = [
+      {
+        sourceId: 'a',
+        triggers: [{ kind: 'click' }],
+        effects: [{ kind: 'emit', name: 'test' }],
+      },
+      {
+        sourceId: 'b',
+        triggers: [{ kind: 'hover', phase: 'leave' }],
+        effects: [{ kind: 'class', remove: ['hidden', 'hidden'] }],
+      },
+    ]
+    const encoded = encodeActionRules(rules)
+    const again = encodeActionRules([...rules].reverse())
+    expect(encoded).toBe(again)
+  })
+})

--- a/apps/builder/lib/actions/serialize.ts
+++ b/apps/builder/lib/actions/serialize.ts
@@ -1,0 +1,206 @@
+import { stableStringify } from '../export/stableStringify'
+import type {
+  ActionEffect,
+  ActionRule,
+  ActionTransition,
+  PackedEffect,
+  PackedRule,
+  PackedTransition,
+  PackedTrigger,
+  ActionTrigger,
+} from './types'
+
+const DEFAULT_DURATION = 150
+const DEFAULT_DELAY = 0
+const DEFAULT_EASING = 'ease-out'
+
+const round = (v: number) => {
+  if (!Number.isFinite(v)) return undefined
+  const rounded = Number(v.toFixed(4))
+  return Object.is(rounded, -0) ? 0 : rounded
+}
+
+const normalizeStringArray = (value?: string | string[]) => {
+  if (value == null) return undefined
+  const list = Array.isArray(value) ? value : String(value).split(/\s+/)
+  const filtered = list.map((c) => c.trim()).filter(Boolean)
+  if (!filtered.length) return undefined
+  const uniq = Array.from(new Set(filtered))
+  uniq.sort()
+  return uniq
+}
+
+const normalizeClassList = (value?: string | string[]) => {
+  const uniq = normalizeStringArray(value)
+  if (!uniq?.length) return undefined
+  return uniq.join(' ')
+}
+
+const normalizeTargets = (value?: string | string[]) => {
+  const uniq = normalizeStringArray(value)
+  if (!uniq?.length) return undefined
+  return uniq.length === 1 ? uniq[0] : uniq
+}
+
+const denormalizeTargets = (value: string | string[] | undefined): string[] | undefined => {
+  if (!value) return undefined
+  const arr = Array.isArray(value) ? value : [value]
+  return arr.map((v) => String(v))
+}
+
+const packTrigger = (trigger: ActionTrigger): PackedTrigger => {
+  switch (trigger.kind) {
+    case 'click':
+      return { k: 'c', o: trigger.once ? 1 : undefined }
+    case 'hover':
+      return {
+        k: trigger.phase === 'leave' ? 'hl' : 'he',
+        o: trigger.once ? 1 : undefined,
+      }
+    case 'inView':
+      return {
+        k: 'v',
+        th: trigger.threshold != null ? round(trigger.threshold) : undefined,
+        rm: trigger.rootMargin,
+        o: trigger.once ? 1 : undefined,
+      }
+    default:
+      return { k: 'c' }
+  }
+}
+
+const unpackTrigger = (trigger: PackedTrigger): ActionTrigger => {
+  if (trigger.k === 'c') return { kind: 'click', once: trigger.o === 1 }
+  if (trigger.k === 'he') return { kind: 'hover', phase: 'enter', once: trigger.o === 1 }
+  if (trigger.k === 'hl') return { kind: 'hover', phase: 'leave', once: trigger.o === 1 }
+  return {
+    kind: 'inView',
+    threshold: trigger.th,
+    rootMargin: trigger.rm,
+    once: trigger.o === 1,
+  }
+}
+
+const packEffect = (effect: ActionEffect): PackedEffect => {
+  switch (effect.kind) {
+    case 'class': {
+      const target = normalizeTargets(effect.target)
+      const add = normalizeClassList(effect.add)
+      const rm = normalizeClassList(effect.remove)
+      const tg = normalizeClassList(effect.toggle)
+      const packed: PackedEffect = { k: 'c' }
+      if (target) packed.t = target
+      if (add) packed.add = add
+      if (rm) packed.rm = rm
+      if (tg) packed.tg = tg
+      return packed
+    }
+    case 'emit':
+      return { k: 'e', n: effect.name, d: effect.detail }
+    case 'scroll':
+      return { k: 's', sel: effect.selector, bh: effect.behavior }
+    case 'navigate':
+      return { k: 'n', href: effect.href, tgt: effect.target }
+    default:
+      return { k: 'c' }
+  }
+}
+
+const unpackEffect = (effect: PackedEffect): ActionEffect => {
+  switch (effect.k) {
+    case 'e':
+      return { kind: 'emit', name: effect.n, detail: effect.d }
+    case 's':
+      return { kind: 'scroll', selector: effect.sel, behavior: effect.bh }
+    case 'n':
+      return { kind: 'navigate', href: effect.href, target: effect.tgt }
+    default: {
+      const add = effect.add ? effect.add.split(/\s+/).filter(Boolean) : undefined
+      const rm = effect.rm ? effect.rm.split(/\s+/).filter(Boolean) : undefined
+      const tg = effect.tg ? effect.tg.split(/\s+/).filter(Boolean) : undefined
+      return {
+        kind: 'class',
+        target: denormalizeTargets(effect.t),
+        add,
+        remove: rm,
+        toggle: tg,
+      }
+    }
+  }
+}
+
+const packTransition = (transition?: ActionTransition): PackedTransition | undefined => {
+  if (!transition) return undefined
+  const out: PackedTransition = {}
+  const d = transition.durationMs
+  const dl = transition.delayMs
+  const easing = transition.easing
+  if (d != null) {
+    const v = round(d)
+    if (v != null && v !== DEFAULT_DURATION) out.d = v
+  }
+  if (dl != null) {
+    const v = round(dl)
+    if (v != null && v !== DEFAULT_DELAY) out.dl = v
+  }
+  if (easing && easing !== DEFAULT_EASING) out.e = easing
+  return Object.keys(out).length ? out : undefined
+}
+
+const unpackTransition = (transition?: PackedTransition): ActionTransition | undefined => {
+  if (!transition) return undefined
+  return {
+    durationMs: transition.d ?? DEFAULT_DURATION,
+    delayMs: transition.dl ?? DEFAULT_DELAY,
+    easing: transition.e ?? DEFAULT_EASING,
+  }
+}
+
+const packRule = (rule: ActionRule): PackedRule => {
+  const triggers = rule.triggers.map(packTrigger)
+  triggers.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  const effects = rule.effects.map(packEffect)
+  effects.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  const packed: PackedRule = {
+    id: rule.id,
+    tr: triggers,
+    fx: effects,
+  }
+  const trn = packTransition(rule.transition)
+  if (trn) packed.trn = trn
+  if (rule.concurrency === 'ignore') packed.cc = 'i'
+  if (rule.disableMotionWhenReduced) packed.rm = 1
+  return packed
+}
+
+const unpackRule = (rule: PackedRule, sourceId: string): ActionRule => {
+  return {
+    id: rule.id,
+    sourceId,
+    triggers: (rule.tr ?? []).map(unpackTrigger),
+    effects: (rule.fx ?? []).map(unpackEffect),
+    transition: unpackTransition(rule.trn),
+    concurrency: rule.cc === 'i' ? 'ignore' : 'restart',
+    disableMotionWhenReduced: rule.rm === 1,
+  }
+}
+
+export const encodeActionRules = (rules: ActionRule[]): string => {
+  const packed = rules.map(packRule)
+  packed.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  return stableStringify(packed.length === 1 ? packed[0] : packed)
+}
+
+export const decodeActionRules = (text: string, sourceId: string): ActionRule[] => {
+  if (!text) return []
+  let parsed: any
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return []
+  }
+  const arr: PackedRule[] = Array.isArray(parsed) ? parsed : [parsed]
+  return arr.map((rule) => unpackRule(rule, sourceId))
+}
+
+export const serializeRule = (rule: ActionRule): string => encodeActionRules([rule])

--- a/apps/builder/lib/actions/types.ts
+++ b/apps/builder/lib/actions/types.ts
@@ -1,0 +1,78 @@
+export type TriggerPhase = 'enter' | 'leave'
+
+export type ActionTrigger =
+  | { kind: 'click'; once?: boolean }
+  | { kind: 'hover'; phase?: TriggerPhase; once?: boolean }
+  | { kind: 'inView'; threshold?: number; rootMargin?: string; once?: boolean }
+
+export type ClassEffect = {
+  kind: 'class'
+  /** default: self element */
+  target?: string | string[]
+  add?: string[]
+  remove?: string[]
+  toggle?: string[]
+}
+
+export type EmitEffect = {
+  kind: 'emit'
+  name: string
+  detail?: any
+}
+
+export type ScrollEffect = {
+  kind: 'scroll'
+  selector: string
+  behavior?: ScrollBehavior
+}
+
+export type NavigateEffect = {
+  kind: 'navigate'
+  href: string
+  target?: '_self' | '_blank'
+}
+
+export type ActionEffect = ClassEffect | EmitEffect | ScrollEffect | NavigateEffect
+
+export type ActionConcurrency = 'restart' | 'ignore'
+
+export interface ActionTransition {
+  durationMs?: number
+  delayMs?: number
+  easing?: string
+}
+
+export interface ActionRule {
+  id?: string
+  sourceId: string
+  triggers: ActionTrigger[]
+  effects: ActionEffect[]
+  transition?: ActionTransition
+  concurrency?: ActionConcurrency
+  /** If true, skip delays/duration when prefers-reduced-motion */
+  disableMotionWhenReduced?: boolean
+}
+
+export type PackedTrigger = {
+  k: 'c' | 'he' | 'hl' | 'v'
+  th?: number
+  rm?: string
+  o?: 1
+}
+
+export type PackedEffect =
+  | { k: 'c'; t?: string | string[]; add?: string; rm?: string; tg?: string }
+  | { k: 'e'; n: string; d?: any }
+  | { k: 's'; sel: string; bh?: ScrollBehavior }
+  | { k: 'n'; href: string; tgt?: '_self' | '_blank' }
+
+export type PackedTransition = { d?: number; dl?: number; e?: string }
+
+export type PackedRule = {
+  id?: string
+  tr: PackedTrigger[]
+  fx: PackedEffect[]
+  trn?: PackedTransition
+  cc?: 'r' | 'i'
+  rm?: 1
+}

--- a/apps/builder/lib/export/generate.ts
+++ b/apps/builder/lib/export/generate.ts
@@ -2,32 +2,37 @@
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
+import { normalizeNodes, serializeNodes, type SerializableNode } from './serializeNode'
+import { stableStringify } from './stableStringify'
 
-function stableStringify(obj: any): string {
-  const seen = new WeakSet()
-  const stringify = (x: any): any => {
-    if (x && typeof x === 'object') {
-      if (seen.has(x)) return null
-      seen.add(x)
-      if (Array.isArray(x)) return x.map((v) => stringify(v))
-      const keys = Object.keys(x).sort()
-      const out: any = {}
-      for (const k of keys) out[k] = stringify(x[k])
-      return out
-    }
-    if (typeof x === 'number') return Number.isFinite(x) ? Number(x.toFixed(6)) : null
-    return x
-  }
-  return JSON.stringify(stringify(obj))
+const countNodes = (nodes: SerializableNode[]): number =>
+  nodes.reduce((total, node) => total + 1 + countNodes(node.children ?? []), 0)
+
+const buildTsx = (nodes: SerializableNode[]) => {
+  const lines: string[] = [
+    "import React from 'react'",
+    '',
+    'export default function GeneratedPage(){',
+    '  return (',
+    '    <>',
+  ]
+  const body = serializeNodes(nodes, 6)
+  if (body) lines.push(body)
+  lines.push('    </>', '  )', '}', '')
+  return lines.join('\n')
 }
 
 export async function generateExport(slug: string) {
   const file = path.join(process.cwd(), 'public', 'pages', `${slug}.json`)
   const raw = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : null
-  const tree = Array.isArray(raw?.tree) ? raw.tree : Array.isArray(raw) ? raw : []
-  const tsx = `// generated stub for ${slug}\nexport default ${JSON.stringify(tree, null, 2)}\n`
-  const tokens: string[] = []
-  const manifest = { id: slug, generatedAt: new Date().toISOString(), nodes: Array.isArray(tree) ? tree.length : 0 }
+  const tree = normalizeNodes(raw)
+  const tsx = buildTsx(tree)
+  const tokens: string[] = Array.isArray(raw?.tokens) ? [...raw.tokens] : []
+  const manifest = {
+    id: slug,
+    generatedAt: new Date().toISOString(),
+    nodes: countNodes(tree),
+  }
   const base = { tsx, manifest, tokens }
   const contentHash = crypto.createHash('sha256').update(stableStringify(base)).digest('hex')
   return { ...base, contentHash }

--- a/apps/builder/lib/export/serializeNode.ts
+++ b/apps/builder/lib/export/serializeNode.ts
@@ -1,0 +1,116 @@
+import { encodeActionRules } from '../actions/serialize'
+import type { ActionRule } from '../actions/types'
+
+export type SerializableNode = {
+  id: string
+  type: string
+  props?: Record<string, any>
+  children?: SerializableNode[]
+  textContent?: string
+  interactions?: ActionRule[]
+}
+
+const renderValue = (value: any): string | null => {
+  if (value == null) return null
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return `{${JSON.stringify(value)}}`
+  return `{${JSON.stringify(value)}}`
+}
+
+const cloneProps = (props?: Record<string, any>) => {
+  if (!props || typeof props !== 'object') return undefined
+  const entries = Object.entries(props)
+  if (!entries.length) return undefined
+  const out: Record<string, any> = {}
+  entries.forEach(([key, value]) => {
+    out[key] = value
+  })
+  return out
+}
+
+const renderProps = (node: SerializableNode): string[] => {
+  const attrs: string[] = []
+  attrs.push(`key=${JSON.stringify(node.id)}`)
+  attrs.push(`data-node-id=${JSON.stringify(node.id)}`)
+  const rules = node.interactions
+  if (rules?.length) attrs.push(`data-int=${JSON.stringify(encodeActionRules(rules))}`)
+  if (node.props) {
+    const keys = Object.keys(node.props)
+    keys.sort()
+    keys.forEach((key) => {
+      const rendered = renderValue((node.props as any)[key])
+      if (rendered != null) attrs.push(`${key}=${rendered}`)
+    })
+  }
+  return attrs
+}
+
+const indent = (level: number) => ' '.repeat(level)
+
+export function serializeNode(node: SerializableNode, level = 0): string {
+  const props = renderProps(node)
+  const pad = indent(level)
+  const open = `<${node.type}${props.length ? ' ' + props.join(' ') : ''}`
+  const children: string[] = []
+  const innerPad = indent(level + 2)
+  if (node.textContent != null) children.push(`${innerPad}{${JSON.stringify(node.textContent)}}`)
+  if (node.children?.length) {
+    node.children.forEach((child) => {
+      children.push(serializeNode(child, level + 2))
+    })
+  }
+  if (!children.length) return `${pad}${open} />`
+  const body = children.join('\n')
+  return `${pad}${open}>\n${body}\n${pad}</${node.type}>`
+}
+
+export function serializeNodes(nodes: SerializableNode[], level = 0): string {
+  return nodes.map((node) => serializeNode(node, level)).join('\n')
+}
+
+export function normalizeNode(input: any): SerializableNode {
+  const id = typeof input?.id === 'string' ? input.id : String(input?.id ?? 'node')
+  const type = typeof input?.type === 'string' ? input.type : 'div'
+  const props = cloneProps(input?.props)
+
+  const rawInteractions = Array.isArray(input?.interactions)
+    ? (input.interactions as ActionRule[])
+    : Array.isArray(props?.interactions)
+    ? (props.interactions as ActionRule[])
+    : Array.isArray(props?.$interactions)
+    ? (props.$interactions as ActionRule[])
+    : undefined
+  if (props) {
+    delete (props as any).interactions
+    delete (props as any).$interactions
+  }
+
+  const interactions = rawInteractions
+    ?.map((rule) => ({ ...rule, sourceId: rule.sourceId ?? id }))
+
+  const text =
+    typeof input?.textContent === 'string'
+      ? input.textContent
+      : typeof input?.text === 'string'
+      ? input.text
+      : undefined
+
+  const children = Array.isArray(input?.children)
+    ? (input.children as any[]).map((child) => normalizeNode(child))
+    : undefined
+
+  return {
+    id,
+    type,
+    props,
+    textContent: text,
+    children,
+    interactions,
+  }
+}
+
+export function normalizeNodes(input: any): SerializableNode[] {
+  if (Array.isArray(input)) return input.map((item) => normalizeNode(item))
+  if (Array.isArray(input?.tree)) return input.tree.map((item: any) => normalizeNode(item))
+  return []
+}

--- a/apps/preview/app/layout.tsx
+++ b/apps/preview/app/layout.tsx
@@ -1,7 +1,12 @@
+import ActionBoot from '../components/ActionBoot'
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body style={{ padding: 16, fontFamily: 'ui-sans-serif' }}>{children}</body>
+      <body style={{ padding: 16, fontFamily: 'ui-sans-serif' }}>
+        <ActionBoot />
+        {children}
+      </body>
     </html>
   )
 }

--- a/apps/preview/components/ActionBoot.tsx
+++ b/apps/preview/components/ActionBoot.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+import { ActionEngine } from '../../builder/lib/actions'
+
+export function ActionBoot() {
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const engine = ActionEngine.fromDOM(document)
+    return () => engine.destroy()
+  }, [])
+  return null
+}
+
+export default ActionBoot


### PR DESCRIPTION
## Summary
- implement a shared ActionEngine that parses `data-int` attributes, supports click/hover/inView triggers, and honors concurrency and reduced-motion hints
- serialize action rules deterministically and embed them on exported nodes while generating a JSX page shell
- bootstrap the preview runtime with an ActionBoot component and cover the new serialization/engine behavior with unit tests

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d3c38e2868832cb7bb943632c0c912