### PR TITLE
feat(builder): add InteractionsTab and preset apply to selected nodes

### DIFF
--- a/apps/builder/app/lineage.register.tsx
+++ b/apps/builder/app/lineage.register.tsx
@@ -177,6 +177,21 @@ if (typeof window !== 'undefined' && (window as any).registerRightPaneTab) {
   ;(window as any).registerRightPaneTab?.({ key: 'presets', label: 'Presets', render: () => <PresetsPanel /> })
 }
 
+// --- append-only: Interactions tab ---
+import DynInteractions from 'next/dynamic'
+const InteractionsTab = DynInteractions(
+  () => import('@/components/rightpane/InteractionsTab'),
+  { ssr: false },
+)
+
+if (typeof window !== 'undefined' && (window as any).registerRightPaneTab) {
+  ;(window as any).registerRightPaneTab?.({
+    key: 'interactions',
+    label: 'Interactions',
+    render: () => <InteractionsTab />,
+  })
+}
+
 // --- append-only: mark alias imports as “used” to satisfy some ESLint configs ---
 // 一部の設定では DynRecoPlus/DynSnippets/DynDsPlus/DynDs を未使用とみなすことがあるため、
 // 無害な参照を置いて警告を抑制する（実行副作用なし）。
@@ -185,4 +200,5 @@ if (typeof window !== 'undefined' && (window as any).registerRightPaneTab) {
   void DynSnippets
   void DynDsPlus
   void DynDs
+  void DynInteractions
 })()

--- a/apps/builder/components/rightpane/InteractionsTab.tsx
+++ b/apps/builder/components/rightpane/InteractionsTab.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import * as React from 'react'
+import type { InteractionPreset } from '@/types/interactions'
+import {
+  type ApplyMode,
+  type ActionRule,
+  type BehaviorTrigger,
+  type ActionTarget,
+} from '@/lib/actions/apply'
+import { useSelectionStore } from '@/stores/selection'
+
+type PresetWithActions = InteractionPreset & {
+  actions?: ActionRule['actions']
+  when?: BehaviorTrigger[]
+}
+
+const APPLY_MODES: ApplyMode[] = ['replace', 'append', 'remove']
+const TRIGGERS: BehaviorTrigger[] = ['click', 'doubleClick', 'mount', 'delay', 'inView']
+const TARGETS: ActionTarget[] = ['self', 'group', 'descendants']
+
+async function loadPresets(): Promise<PresetWithActions[]> {
+  const tryFetch = async (url: string) => {
+    try {
+      const res = await fetch(url, { cache: 'no-store' })
+      if (!res.ok) return null
+      const json = await res.json()
+      if (Array.isArray(json)) return json as PresetWithActions[]
+      if (Array.isArray(json?.presets)) return json.presets as PresetWithActions[]
+      return null
+    } catch {
+      return null
+    }
+  }
+  const candidates = [
+    '/api/dev/actions/presets?format=json',
+    '/dev/actions.json',
+    '/api/interaction-presets',
+  ]
+  for (const url of candidates) {
+    const found = await tryFetch(url)
+    if (found?.length) return found
+  }
+  if (typeof window !== 'undefined') {
+    const globalPresets = (window as any).__actionPresets
+    if (Array.isArray(globalPresets)) return globalPresets as PresetWithActions[]
+  }
+  return []
+}
+
+function ruleKey(rule: ActionRule, index: number) {
+  return rule.id || `${rule.presetId ?? 'rule'}-${index}`
+}
+
+function NodeSummary({ nodes }: { nodes: { id: string; name?: string }[] }) {
+  if (!nodes.length) return null
+  if (nodes.length === 1) {
+    const node = nodes[0]
+    return (
+      <div className="text-xs text-neutral-500">
+        Editing <span className="font-semibold text-neutral-200">{node.name || node.id}</span>
+      </div>
+    )
+  }
+  return (
+    <div className="text-xs text-neutral-500">
+      {nodes.length} nodes selected
+    </div>
+  )
+}
+
+function RuleRow({
+  rule,
+  index,
+  onUpdate,
+  onRemove,
+}: {
+  rule: ActionRule
+  index: number
+  onUpdate: (patch: Partial<ActionRule>) => void
+  onRemove: () => void
+}) {
+  return (
+    <div className="border border-neutral-800 rounded p-2 space-y-2 bg-neutral-900">
+      <div className="flex items-center gap-2">
+        <input
+          value={rule.name}
+          onChange={(e) => onUpdate({ name: e.target.value })}
+          placeholder="Rule name"
+          className="flex-1 bg-neutral-950 border border-neutral-700 rounded px-2 py-1 text-sm text-neutral-200"
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-xs text-rose-300 hover:text-rose-200"
+        >
+          Remove
+        </button>
+      </div>
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] uppercase tracking-wide text-neutral-500">Trigger</span>
+          <select
+            className="bg-neutral-950 border border-neutral-700 rounded px-2 py-1"
+            value={rule.trigger}
+            onChange={(e) => onUpdate({ trigger: e.target.value as BehaviorTrigger })}
+          >
+            {TRIGGERS.map((tr) => (
+              <option key={tr} value={tr}>
+                {tr}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] uppercase tracking-wide text-neutral-500">Target</span>
+          <select
+            className="bg-neutral-950 border border-neutral-700 rounded px-2 py-1"
+            value={rule.target}
+            onChange={(e) => onUpdate({ target: e.target.value as ActionTarget })}
+          >
+            {TARGETS.map((tgt) => (
+              <option key={tgt} value={tgt}>
+                {tgt}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {rule.presetName && (
+        <div className="text-[11px] text-neutral-500">
+          From preset: <span className="font-mono text-neutral-300">{rule.presetName}</span>
+        </div>
+      )}
+      <div className="text-[11px] text-neutral-500">
+        Actions: {rule.actions?.length ?? 0}
+      </div>
+    </div>
+  )
+}
+
+export default function InteractionsTab(): JSX.Element {
+  const nodes = useSelectionStore((s) => s.nodes)
+  const applyPreset = useSelectionStore((s) => s.applyPreset)
+  const addEmptyRule = useSelectionStore((s) => s.addEmptyRule)
+  const updateRule = useSelectionStore((s) => s.updateRule)
+  const removeRule = useSelectionStore((s) => s.removeRule)
+
+  const [presets, setPresets] = React.useState<PresetWithActions[]>([])
+  const [loadingPresets, setLoadingPresets] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [addingPreset, setAddingPreset] = React.useState(false)
+  const [selectedPreset, setSelectedPreset] = React.useState<string>('')
+  const [applyMode, setApplyMode] = React.useState<ApplyMode>('append')
+
+  React.useEffect(() => {
+    let mounted = true
+    setLoadingPresets(true)
+    ;(async () => {
+      const list = await loadPresets()
+      if (!mounted) return
+      if (!list.length) setError('No presets available. Create presets in /dev/actions.')
+      else setError(null)
+      setPresets(list)
+      setLoadingPresets(false)
+    })()
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  const handleApplyPreset = () => {
+    if (!selectedPreset) return
+    const preset = presets.find((p) => p.id === selectedPreset)
+    if (!preset) return
+    applyPreset(preset, applyMode)
+    setAddingPreset(false)
+    setSelectedPreset('')
+  }
+
+  if (!nodes.length) {
+    return <div className="p-3 text-sm text-neutral-500">Select a node to manage interactions.</div>
+  }
+
+  const primary = nodes[0]
+  const rules: ActionRule[] = primary.actionRules ?? []
+
+  return (
+    <div className="p-3 space-y-3 text-sm text-neutral-200">
+      <div className="flex items-center justify-between">
+        <div className="text-base font-semibold">Interactions</div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="px-2 py-1 text-xs bg-neutral-800 rounded hover:bg-neutral-700"
+            onClick={() => setAddingPreset((v) => !v)}
+          >
+            + Add
+          </button>
+          <button
+            type="button"
+            className="px-2 py-1 text-xs bg-neutral-800 rounded hover:bg-neutral-700"
+            onClick={() => addEmptyRule(primary.id)}
+          >
+            + Empty
+          </button>
+        </div>
+      </div>
+
+      <NodeSummary nodes={nodes} />
+
+      {addingPreset && (
+        <div className="border border-neutral-800 rounded p-2 bg-neutral-900 space-y-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-xs text-neutral-400">
+              Preset
+              <select
+                className="mt-1 w-full bg-neutral-950 border border-neutral-700 rounded px-2 py-1"
+                value={selectedPreset}
+                onChange={(e) => setSelectedPreset(e.target.value)}
+                disabled={loadingPresets}
+              >
+                <option value="">Select preset</option>
+                {presets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs text-neutral-400">
+              Mode
+              <select
+                className="mt-1 w-full bg-neutral-950 border border-neutral-700 rounded px-2 py-1"
+                value={applyMode}
+                onChange={(e) => setApplyMode(e.target.value as ApplyMode)}
+              >
+                {APPLY_MODES.map((mode) => (
+                  <option key={mode} value={mode}>
+                    {mode}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="px-2 py-1 text-xs bg-blue-600 rounded text-white disabled:opacity-60"
+              onClick={handleApplyPreset}
+              disabled={!selectedPreset}
+            >
+              Apply
+            </button>
+            <button
+              type="button"
+              className="px-2 py-1 text-xs bg-neutral-800 rounded"
+              onClick={() => setAddingPreset(false)}
+            >
+              Cancel
+            </button>
+          </div>
+          {error && <div className="text-[11px] text-amber-400">{error}</div>}
+        </div>
+      )}
+
+      <div className="space-y-2">
+          {rules.length ? (
+            rules.map((rule, index) => (
+              <RuleRow
+                key={ruleKey(rule, index)}
+                rule={rule}
+                index={index}
+                onUpdate={(patch) => updateRule(primary.id, rule.id, patch)}
+                onRemove={() => removeRule(primary.id, rule.id)}
+              />
+            ))
+          ) : (
+          <div className="text-xs text-neutral-500">No interaction rules configured.</div>
+        )}
+      </div>
+
+      <div className="text-[11px] text-neutral-500">
+        Presets are managed from <a className="underline" href="/dev/actions">/dev/actions</a>.
+      </div>
+    </div>
+  )
+}
+

--- a/apps/builder/lib/actions/apply.ts
+++ b/apps/builder/lib/actions/apply.ts
@@ -1,0 +1,181 @@
+// apps/builder/lib/actions/apply.ts
+import type { InteractionPreset } from '@/types/interactions'
+
+export type ApplyMode = 'replace' | 'append' | 'remove'
+
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [key: string]: Json }
+
+export type Logic =
+  | { '==': [Json, Json] }
+  | { '===': [Json, Json] }
+  | { '!=': [Json, Json] }
+  | { '!==': [Json, Json] }
+  | { '<': [Json, Json] }
+  | { '<=': [Json, Json] }
+  | { '>': [Json, Json] }
+  | { '>=': [Json, Json] }
+  | { and: Logic[] }
+  | { or: Logic[] }
+  | { '!': [Logic] }
+  | { '+': Json[] }
+  | { '-': Json[] }
+  | { '*': Json[] }
+  | { '/': Json[] }
+  | { '%': [Json, Json] }
+  | { var: string }
+  | Json
+
+export type ActionTarget = 'self' | 'group' | 'descendants'
+
+export type BehaviorTrigger =
+  | 'click'
+  | 'doubleClick'
+  | 'mount'
+  | 'delay'
+  | 'inView'
+
+export type TargetSelector =
+  | { type: 'nodeId'; value: string }
+  | { type: 'query'; value: string }
+
+export type ActionBase = {
+  if?: Logic
+  throttleMs?: number
+  debounceMs?: number
+}
+
+export type Action =
+  | (ActionBase & { kind: 'openUrl'; url: string; target?: '_blank' | '_self' })
+  | (ActionBase & { kind: 'navigate'; to: string })
+  | (ActionBase & { kind: 'emitEvent'; name: string; payload?: Json })
+  | (ActionBase & {
+      kind: 'setProp'
+      selector?: TargetSelector
+      prop: string
+      value: Json | string
+    })
+
+export type ActionRule = {
+  id: string
+  name: string
+  trigger: BehaviorTrigger
+  target: ActionTarget
+  actions: Action[]
+  presetId?: string
+  presetName?: string
+}
+
+export type NodeWithActions = {
+  id: string
+  name?: string
+  actionRules?: ActionRule[]
+  [key: string]: unknown
+}
+
+const uid = () => `ar_${Math.random().toString(36).slice(2, 10)}`
+
+function ensureTriggerList(preset: InteractionPreset): BehaviorTrigger[] {
+  const list = Array.isArray((preset as any)?.when)
+    ? ((preset as any).when as BehaviorTrigger[])
+    : []
+  if (list.length > 0) return list
+  return ['click']
+}
+
+function notifyHistory(detail: any) {
+  if (typeof window === 'undefined') return
+  try {
+    window.dispatchEvent(new CustomEvent('builder:history', { detail }))
+  } catch {
+    /* noop */
+  }
+}
+
+function notifyRuntime(detail: any) {
+  if (typeof window === 'undefined') return
+  try {
+    window.dispatchEvent(new CustomEvent('builder:actions:changed', { detail }))
+  } catch {
+    /* noop */
+  }
+  try {
+    const engine: any = (window as any).__builderActionEngine
+    if (engine && typeof engine.refresh === 'function') engine.refresh(detail)
+  } catch {
+    /* noop */
+  }
+}
+
+export function createEmptyRule(): ActionRule {
+  return {
+    id: uid(),
+    name: 'New action',
+    trigger: 'click',
+    target: 'self',
+    actions: [],
+  }
+}
+
+export function toRuntimeRules(
+  preset: InteractionPreset,
+  target: ActionTarget = 'self',
+): ActionRule[] {
+  const name = (preset as any)?.name ?? preset.id ?? 'Preset'
+  const actions = Array.isArray((preset as any)?.actions)
+    ? ((preset as any).actions as Action[])
+    : []
+  const triggers = ensureTriggerList(preset)
+  return triggers.map((trigger) => ({
+    id: uid(),
+    name,
+    trigger,
+    target,
+    actions,
+    presetId: preset.id,
+    presetName: name,
+  }))
+}
+
+function mergeRules(
+  current: ActionRule[] | undefined,
+  incoming: ActionRule[],
+  mode: ApplyMode,
+  presetId: string,
+): ActionRule[] {
+  const cur = Array.isArray(current) ? current : []
+  if (mode === 'replace') return [...incoming]
+  if (mode === 'append') return [...cur, ...incoming]
+  if (mode === 'remove') return cur.filter((rule) => rule.presetId !== presetId)
+  return cur
+}
+
+export function applyPresetToNodes<T extends NodeWithActions>(
+  preset: InteractionPreset,
+  nodes: T[],
+  mode: ApplyMode,
+): T[] {
+  if (!Array.isArray(nodes) || nodes.length === 0) return nodes
+  const runtimeRules = toRuntimeRules(preset)
+  const nextNodes = nodes.map((node) => {
+    const nextRules = mergeRules(node.actionRules, runtimeRules, mode, preset.id)
+    return { ...node, actionRules: nextRules }
+  })
+  const detail = {
+    type: 'actions.apply',
+    presetId: preset.id,
+    presetName: (preset as any)?.name,
+    mode,
+    nodeIds: nodes.map((n) => n.id),
+    ruleCount: runtimeRules.length,
+  }
+  notifyRuntime(detail)
+  notifyHistory(detail)
+  return nextNodes
+}
+

--- a/apps/builder/stores/selection.ts
+++ b/apps/builder/stores/selection.ts
@@ -1,0 +1,79 @@
+'use client'
+
+import { create } from 'zustand'
+import type { InteractionPreset } from '@/types/interactions'
+import {
+  applyPresetToNodes,
+  createEmptyRule,
+  type ActionRule,
+  type ApplyMode,
+  type NodeWithActions,
+} from '@/lib/actions/apply'
+
+export type SelectionNode = NodeWithActions
+
+type SelectionState = {
+  nodes: SelectionNode[]
+  setNodes: (nodes: SelectionNode[]) => void
+  clear: () => void
+  applyPreset: (preset: InteractionPreset, mode: ApplyMode) => void
+  addEmptyRule: (nodeId: string) => void
+  updateRule: (nodeId: string, ruleId: string, patch: Partial<ActionRule>) => void
+  removeRule: (nodeId: string, ruleId: string) => void
+  setRules: (nodeId: string, rules: ActionRule[]) => void
+}
+
+function replaceNode(nodes: SelectionNode[], nodeId: string, updater: (node: SelectionNode) => SelectionNode): SelectionNode[] {
+  return nodes.map((node) => (node.id === nodeId ? updater(node) : node))
+}
+
+export const useSelectionStore = create<SelectionState>((set, get) => ({
+  nodes: [],
+  setNodes(nodes) {
+    set({ nodes })
+  },
+  clear() {
+    set({ nodes: [] })
+  },
+  applyPreset(preset, mode) {
+    const nodes = get().nodes
+    if (!nodes.length) return
+    const next = applyPresetToNodes(preset, nodes, mode)
+    set({ nodes: next })
+  },
+  addEmptyRule(nodeId) {
+    set((state) => ({
+      nodes: replaceNode(state.nodes, nodeId, (node) => ({
+        ...node,
+        actionRules: [...(node.actionRules ?? []), createEmptyRule()],
+      })),
+    }))
+  },
+  updateRule(nodeId, ruleId, patch) {
+    set((state) => ({
+      nodes: replaceNode(state.nodes, nodeId, (node) => ({
+        ...node,
+        actionRules: (node.actionRules ?? []).map((rule) =>
+          rule.id === ruleId ? { ...rule, ...patch } : rule,
+        ),
+      })),
+    }))
+  },
+  removeRule(nodeId, ruleId) {
+    set((state) => ({
+      nodes: replaceNode(state.nodes, nodeId, (node) => ({
+        ...node,
+        actionRules: (node.actionRules ?? []).filter((rule) => rule.id !== ruleId),
+      })),
+    }))
+  },
+  setRules(nodeId, rules) {
+    set((state) => ({
+      nodes: replaceNode(state.nodes, nodeId, (node) => ({
+        ...node,
+        actionRules: [...rules],
+      })),
+    }))
+  },
+}))
+


### PR DESCRIPTION
## Summary
- add helpers to convert interaction presets into runtime action rules and notify the builder runtime when applying them
- introduce a selection store for editing node action rules and applying presets across the current selection
- expose a new Interactions tab in the right pane with controls for managing rules and linking to the preset designer

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d3c3866578832cbfb88e853574a311