### PR TITLE
feat: gate stable export normalization behind flag

### DIFF
--- a/apps/builder/lib/export/serializeNode.ts
+++ b/apps/builder/lib/export/serializeNode.ts
@@ -1,5 +1,6 @@
 import { encodeActionRules } from '../actions/serialize'
 import type { ActionRule } from '../actions/types'
+import { ENABLE_STABLE_EXPORT } from '../flags'
 
 export type SerializableNode = {
   id: string
@@ -69,6 +70,7 @@ export function serializeNodes(nodes: SerializableNode[], level = 0): string {
 }
 
 export function normalizeNode(input: any): SerializableNode {
+  if (!ENABLE_STABLE_EXPORT) return input as SerializableNode
   const id = typeof input?.id === 'string' ? input.id : String(input?.id ?? 'node')
   const type = typeof input?.type === 'string' ? input.type : 'div'
   const props = cloneProps(input?.props)

--- a/apps/builder/lib/flags.ts
+++ b/apps/builder/lib/flags.ts
@@ -1,0 +1,1 @@
+export const ENABLE_STABLE_EXPORT = true as const


### PR DESCRIPTION
## Summary
- add a builder flag to control whether stable export processing runs
- guard export node normalization so it can be disabled when the flag is false

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d546589408832c827d4a565010984e