### PR TITLE
Add insert API symbols to baseline

### DIFF
--- a/scripts/dev/baseline.json
+++ b/scripts/dev/baseline.json
@@ -1,0 +1,7 @@
+[
+  "callInsertAPI",
+  "createNodeFromDef",
+  "getComponentDef",
+  "insertNode",
+  "registerInsertAPI"
+]


### PR DESCRIPTION
## Summary
- add a baseline manifest under scripts/dev to protect insert API symbols

## Testing
- pnpm scan:builder

------
https://chatgpt.com/codex/tasks/task_e_68d546639738832c831ce79b949dacfc