### PR TITLE
Log insert bridge fallback event

### DIFF
--- a/apps/builder/lib/bridge/insert.ts
+++ b/apps/builder/lib/bridge/insert.ts
@@ -1,0 +1,25 @@
+import type { ComponentNode } from '@chizu/types'
+
+type InsertAPI = (parentId: string | null, index: number, node: ComponentNode) => void | Promise<void>
+
+let insertAPI: InsertAPI | null = null
+let fallbackLogged = false
+
+export function registerInsertAPI(api: InsertAPI | null) {
+  insertAPI = api
+}
+
+export function callInsertAPI(parentId: string | null, index: number, node: ComponentNode) {
+  if (insertAPI) {
+    void insertAPI(parentId, index, node)
+    return
+  }
+  if (typeof window === 'undefined') return
+  if (!fallbackLogged) {
+    fallbackLogged = true
+    console.info('[builder.insertNode:fallback]', { parentId, index, node })
+  }
+  try {
+    window.dispatchEvent(new CustomEvent('builder.insertNode', { detail: { parentId, index, node } }))
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add insert bridge helper that records a console.info message before the fallback CustomEvent dispatch

## Testing
- pnpm --filter builder exec tsc --noEmit *(fails: existing type errors in app/dev/pages/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d5462f20e0832c86f4fb9c2c9da1e8