### PR TITLE
Add palette tab registration behind feature flag

### DIFF
--- a/apps/builder/app/lineage.register.tsx
+++ b/apps/builder/app/lineage.register.tsx
@@ -2,6 +2,7 @@
 'use client'
 import React from 'react'
 import dynamic from 'next/dynamic'
+import { ENABLE_PALETTE_V1 } from '@/lib/flags'
 
 const LineagePanel = dynamic(
   () => import('@/components/rightpane/LineagePanel').then(m => m.LineagePanel),
@@ -190,6 +191,11 @@ if (typeof window !== 'undefined' && (window as any).registerRightPaneTab) {
     label: 'Interactions',
     render: () => <InteractionsTab />,
   })
+}
+
+// --- append-only: Palette left-pane tab (feature-flagged) ---
+if (ENABLE_PALETTE_V1) {
+  void import('@/components/leftpane/PaletteTab')
 }
 
 // --- append-only: mark alias imports as “used” to satisfy some ESLint configs ---

--- a/apps/builder/components/leftpane/PaletteTab.tsx
+++ b/apps/builder/components/leftpane/PaletteTab.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React from 'react'
+import dynamic from 'next/dynamic'
+
+const ComponentPalette = dynamic(() => import('../../../../src/ComponentPalette'), {
+  ssr: false,
+})
+
+const TAB_KEY = 'palette'
+
+function PalettePanel() {
+  return (
+    <div
+      data-leftpane-panel="palette"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        height: '100%',
+        padding: 8,
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{ fontSize: 12, fontWeight: 600, letterSpacing: 0.4, textTransform: 'uppercase' }}>
+        Palette
+      </div>
+      <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+        <ComponentPalette />
+      </div>
+    </div>
+  )
+}
+
+function registerPaletteTab(attempt = 0) {
+  if (typeof window === 'undefined') return
+  const w = window as typeof window & {
+    registerLeftPaneTab?:
+      | ((tab: { key: string; label: string; render: () => JSX.Element }) => void)
+      | ((key: string, label: string, render: () => JSX.Element) => void)
+    __leftPanePaletteRegistered?: boolean
+  }
+
+  if (w.__leftPanePaletteRegistered) return
+  const register = w.registerLeftPaneTab
+
+  if (typeof register !== 'function') {
+    if (attempt < 5) {
+      setTimeout(() => registerPaletteTab(attempt + 1), 200 * (attempt + 1))
+    }
+    return
+  }
+
+  const render = () => <PalettePanel />
+
+  try {
+    ;(register as (tab: { key: string; label: string; render: () => JSX.Element }) => void)({
+      key: TAB_KEY,
+      label: 'Palette',
+      render,
+    })
+    w.__leftPanePaletteRegistered = true
+    return
+  } catch {}
+
+  try {
+    ;(register as (key: string, label: string, render: () => JSX.Element) => void)(
+      TAB_KEY,
+      'Palette',
+      render,
+    )
+    w.__leftPanePaletteRegistered = true
+  } catch {}
+}
+
+if (typeof window !== 'undefined') {
+  registerPaletteTab()
+}
+
+export function RegisterPaletteTabOnce() {
+  React.useEffect(() => {
+    registerPaletteTab()
+  }, [])
+  return null
+}
+
+export default RegisterPaletteTabOnce

--- a/apps/builder/lib/flags.ts
+++ b/apps/builder/lib/flags.ts
@@ -1,0 +1,1 @@
+export const ENABLE_PALETTE_V1 = true as const


### PR DESCRIPTION
## Summary
- add a reusable ENABLE_PALETTE_V1 flag to guard the left-pane palette rollout
- register the palette tab against the host left-pane API when the flag is enabled
- render the existing ComponentPalette inside the new left-pane tab panel via client-only dynamic import

## Testing
- pnpm test:unit *(fails: existing duplicate export error in apps/builder/lib/actions/engine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d54634d108832cb0975821013c56f2