### PR TITLE
Add insert entrypoint and history bridge

### DIFF
--- a/apps/builder/app/lineage.register.tsx
+++ b/apps/builder/app/lineage.register.tsx
@@ -202,3 +202,13 @@ if (typeof window !== 'undefined' && (window as any).registerRightPaneTab) {
   void DynDs
   void DynInteractions
 })()
+
+// append-only: register canonical insert and history bridges
+import { registerInsertAPI } from '@/lib/bridge/insert'
+import { insertNode as canonicalInsert } from '@/stores/insert'
+registerInsertAPI(canonicalInsert as any)
+
+// optional: if you have a real history API, register it here
+// import { pushInsert as realPushInsert } from '<path-to-history-api>'
+// import { registerHistoryInsert } from '@/lib/history/bridge'
+// registerHistoryInsert(realPushInsert)

--- a/apps/builder/lib/history/bridge.ts
+++ b/apps/builder/lib/history/bridge.ts
@@ -1,0 +1,25 @@
+// append-only history bridge; wire real history when available
+export type HistoryInsert = (args: { parentId: string; index: number; nodeId: string }) => void;
+
+declare global {
+  interface Window {
+    builder?: { pushInsertHistory?: HistoryInsert };
+  }
+}
+
+export function registerHistoryInsert(fn: HistoryInsert) {
+  (window as any).builder = (window as any).builder || {};
+  (window as any).builder.pushInsertHistory = fn;
+}
+
+// default listener: convert the CustomEvent to the bridge call (no-op if not registered)
+(function wireHistoryListener() {
+  const h = (e: Event) => {
+    const detail = (e as CustomEvent).detail || {};
+    const fn = (window as any).builder?.pushInsertHistory;
+    if (typeof fn === 'function' && detail?.type === 'insert' && detail?.nodeId) {
+      fn({ parentId: detail.parentId, index: detail.index, nodeId: String(detail.nodeId) });
+    }
+  };
+  window.addEventListener('builder.history', h as any);
+})();

--- a/apps/builder/stores/insert.ts
+++ b/apps/builder/stores/insert.ts
@@ -1,0 +1,19 @@
+// append-only canonical insert entrypoint (can be swapped to real API later)
+export type InsertPayload = { parentId: string; index: number; node: any };
+
+export function insertNode(parentId: string, index: number, node: any) {
+  const detail: InsertPayload = { parentId, index, node };
+
+  // 1) delegate to any existing consumer
+  window.dispatchEvent(new CustomEvent('builder.insertNode', { detail }));
+
+  // 2) fire a history hint; real history layer can hook this
+  window.dispatchEvent(
+    new CustomEvent('builder.history', {
+      detail: { type: 'insert', ...detail, nodeId: node?.id },
+    }),
+  );
+
+  // return nodeId for convenience
+  return node?.id;
+}


### PR DESCRIPTION
## Summary
- add a canonical insert store that emits the existing insert and history events
- introduce a history bridge helper that forwards insert history events when registered
- register the new canonical insert entrypoint within the lineage registration wiring

## Testing
- pnpm --filter builder typecheck *(fails: No "typecheck" script defined for builder)*

------
https://chatgpt.com/codex/tasks/task_e_68d54a570998832c9eb1ecc01dd43fcf