### PR TITLE
Add slot containers with drop markers

### DIFF
--- a/packages/chizu-registry/dist/chizu-registry/src/index.js
+++ b/packages/chizu-registry/dist/chizu-registry/src/index.js
@@ -1,4 +1,13 @@
 import React from 'react';
+const SlotContainer = ({ slotId, nodeId, as, children }) => {
+    const list = React.Children.toArray(children ?? []);
+    const pieces = [React.createElement('div', { key: 'sep-0', 'data-drop-sep': '', 'data-drop-index': 0 })];
+    list.forEach((child, idx) => {
+        pieces.push(child);
+        pieces.push(React.createElement('div', { key: `sep-${idx + 1}`, 'data-drop-sep': '', 'data-drop-index': idx + 1 }));
+    });
+    return React.createElement(as, { 'data-slot': slotId, 'data-node-id': nodeId ?? slotId }, pieces);
+};
 function renderSlot(content) {
     if (Array.isArray(content)) {
         return content.map((n, i) => React.createElement('div', { key: i }, n));
@@ -55,21 +64,21 @@ export const entries = {
         displayName: 'Frame Basic',
         propsSchema: { type: 'object', properties: {} },
         slotSchema: [{ name: 'header' }, { name: 'sidebar' }, { name: 'content', required: true }, { name: 'footer' }],
-        render: (_p, slots, _runtime) => (React.createElement(React.Fragment, null, React.createElement('header', null, renderSlot(slots.header)), React.createElement('aside', null, renderSlot(slots.sidebar)), React.createElement('main', null, renderSlot(slots.content)), React.createElement('footer', null, renderSlot(slots.footer))))
+        render: (_p, slots, _runtime) => (React.createElement(React.Fragment, null, React.createElement(SlotContainer, { slotId: 'slot.header', as: 'header' }, renderSlot(slots.header)), React.createElement(SlotContainer, { slotId: 'slot.sidebar', as: 'aside' }, renderSlot(slots.sidebar)), React.createElement(SlotContainer, { slotId: 'slot.content', as: 'main' }, renderSlot(slots.content)), React.createElement(SlotContainer, { slotId: 'slot.footer', as: 'footer' }, renderSlot(slots.footer))))
     },
     Frame_Toponly: {
         id: 'Frame_Toponly',
         displayName: 'Frame TopOnly',
         propsSchema: { type: 'object', properties: {} },
         slotSchema: [{ name: 'header' }, { name: 'content', required: true }],
-        render: (_p, slots, _runtime) => (React.createElement(React.Fragment, null, React.createElement('header', null, renderSlot(slots.header)), React.createElement('main', null, renderSlot(slots.content))))
+        render: (_p, slots, _runtime) => (React.createElement(React.Fragment, null, React.createElement(SlotContainer, { slotId: 'slot.header', as: 'header' }, renderSlot(slots.header)), React.createElement(SlotContainer, { slotId: 'slot.content', as: 'main' }, renderSlot(slots.content))))
     },
     Frame_Wide: {
         id: 'Frame_Wide',
         displayName: 'Frame Wide',
         propsSchema: { type: 'object', properties: {} },
         slotSchema: [{ name: 'content', required: true }, { name: 'footer' }],
-        render: (_p, slots, _runtime) => (React.createElement(React.Fragment, null, React.createElement('main', null, renderSlot(slots.content)), React.createElement('footer', null, renderSlot(slots.footer))))
+        render: (_p, slots, _runtime) => (React.createElement(React.Fragment, null, React.createElement(SlotContainer, { slotId: 'slot.content', as: 'main' }, renderSlot(slots.content)), React.createElement(SlotContainer, { slotId: 'slot.footer', as: 'footer' }, renderSlot(slots.footer))))
     }
 };
 export const R = new Proxy(entries, { get: (t, p) => t[p]?.render ?? (() => React.createElement('div', null, `Unknown:${p}`)) });

--- a/packages/chizu-registry/dist/index.cjs
+++ b/packages/chizu-registry/dist/index.cjs
@@ -1729,6 +1729,15 @@ __export(index_exports, {
   mergeHoverStyle: () => mergeHoverStyle
 });
 module.exports = __toCommonJS(index_exports);
+function SlotContainer({ slotId, nodeId, as, children }) {
+  const list = import_react13.default.Children.toArray(children ?? []);
+  const pieces = [import_react13.default.createElement("div", { key: "sep-0", "data-drop-sep": "", "data-drop-index": 0 })];
+  list.forEach((child, idx) => {
+    pieces.push(child);
+    pieces.push(import_react13.default.createElement("div", { key: `sep-${idx + 1}`, "data-drop-sep": "", "data-drop-index": idx + 1 }));
+  });
+  return import_react13.default.createElement(as, { "data-slot": slotId, "data-node-id": nodeId ?? slotId }, pieces);
+}
 function renderSlot(content) {
   if (Array.isArray(content)) {
     return content.map((n, i) => import_react13.default.createElement("div", { key: i }, n));
@@ -1819,10 +1828,10 @@ var init_index = __esm({
         render: (_p, slots, _runtime) => import_react13.default.createElement(
           import_react13.default.Fragment,
           null,
-          import_react13.default.createElement("header", null, renderSlot(slots.header)),
-          import_react13.default.createElement("aside", null, renderSlot(slots.sidebar)),
-          import_react13.default.createElement("main", null, renderSlot(slots.content)),
-          import_react13.default.createElement("footer", null, renderSlot(slots.footer))
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.header", as: "header" }, renderSlot(slots.header)),
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.sidebar", as: "aside" }, renderSlot(slots.sidebar)),
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.content", as: "main" }, renderSlot(slots.content)),
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.footer", as: "footer" }, renderSlot(slots.footer))
         )
       },
       Frame_Toponly: {
@@ -1833,8 +1842,8 @@ var init_index = __esm({
         render: (_p, slots, _runtime) => import_react13.default.createElement(
           import_react13.default.Fragment,
           null,
-          import_react13.default.createElement("header", null, renderSlot(slots.header)),
-          import_react13.default.createElement("main", null, renderSlot(slots.content))
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.header", as: "header" }, renderSlot(slots.header)),
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.content", as: "main" }, renderSlot(slots.content))
         )
       },
       Frame_Wide: {
@@ -1845,8 +1854,8 @@ var init_index = __esm({
         render: (_p, slots, _runtime) => import_react13.default.createElement(
           import_react13.default.Fragment,
           null,
-          import_react13.default.createElement("main", null, renderSlot(slots.content)),
-          import_react13.default.createElement("footer", null, renderSlot(slots.footer))
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.content", as: "main" }, renderSlot(slots.content)),
+          import_react13.default.createElement(SlotContainer, { slotId: "slot.footer", as: "footer" }, renderSlot(slots.footer))
         )
       }
     };

--- a/packages/chizu-registry/dist/index.js
+++ b/packages/chizu-registry/dist/index.js
@@ -346,6 +346,15 @@ __export(index_exports, {
   mergeHoverStyle: () => mergeHoverStyle
 });
 import React7 from "react";
+const SlotContainer = ({ slotId, nodeId, as, children }) => {
+  const list = React7.Children.toArray(children ?? []);
+  const pieces = [React7.createElement("div", { key: "sep-0", "data-drop-sep": "", "data-drop-index": 0 })];
+  list.forEach((child, idx) => {
+    pieces.push(child);
+    pieces.push(React7.createElement("div", { key: `sep-${idx + 1}`, "data-drop-sep": "", "data-drop-index": idx + 1 }));
+  });
+  return React7.createElement(as, { "data-slot": slotId, "data-node-id": nodeId ?? slotId }, pieces);
+};
 function renderSlot(content) {
   if (Array.isArray(content)) {
     return content.map((n, i) => React7.createElement("div", { key: i }, n));
@@ -435,10 +444,10 @@ var init_index = __esm({
         render: (_p, slots, _runtime) => React7.createElement(
           React7.Fragment,
           null,
-          React7.createElement("header", null, renderSlot(slots.header)),
-          React7.createElement("aside", null, renderSlot(slots.sidebar)),
-          React7.createElement("main", null, renderSlot(slots.content)),
-          React7.createElement("footer", null, renderSlot(slots.footer))
+          React7.createElement(SlotContainer, { slotId: "slot.header", as: "header" }, renderSlot(slots.header)),
+          React7.createElement(SlotContainer, { slotId: "slot.sidebar", as: "aside" }, renderSlot(slots.sidebar)),
+          React7.createElement(SlotContainer, { slotId: "slot.content", as: "main" }, renderSlot(slots.content)),
+          React7.createElement(SlotContainer, { slotId: "slot.footer", as: "footer" }, renderSlot(slots.footer))
         )
       },
       Frame_Toponly: {
@@ -449,8 +458,8 @@ var init_index = __esm({
         render: (_p, slots, _runtime) => React7.createElement(
           React7.Fragment,
           null,
-          React7.createElement("header", null, renderSlot(slots.header)),
-          React7.createElement("main", null, renderSlot(slots.content))
+          React7.createElement(SlotContainer, { slotId: "slot.header", as: "header" }, renderSlot(slots.header)),
+          React7.createElement(SlotContainer, { slotId: "slot.content", as: "main" }, renderSlot(slots.content))
         )
       },
       Frame_Wide: {
@@ -461,8 +470,8 @@ var init_index = __esm({
         render: (_p, slots, _runtime) => React7.createElement(
           React7.Fragment,
           null,
-          React7.createElement("main", null, renderSlot(slots.content)),
-          React7.createElement("footer", null, renderSlot(slots.footer))
+          React7.createElement(SlotContainer, { slotId: "slot.content", as: "main" }, renderSlot(slots.content)),
+          React7.createElement(SlotContainer, { slotId: "slot.footer", as: "footer" }, renderSlot(slots.footer))
         )
       }
     };

--- a/packages/chizu-registry/src/index.ts
+++ b/packages/chizu-registry/src/index.ts
@@ -7,6 +7,36 @@ type SlotName = 'header' | 'sidebar' | 'content' | 'footer'
 type SlotValue = ReactNode[] | React.ReactElement | undefined
 type SlotBag = Partial<Record<SlotName, SlotValue>>
 
+type SlotTag = 'header' | 'aside' | 'main' | 'footer'
+
+function SlotContainer({
+  slotId,
+  nodeId,
+  as,
+  children,
+}: {
+  slotId: string
+  nodeId?: string
+  as: SlotTag
+  children?: React.ReactNode
+}) {
+  const list = React.Children.toArray(children ?? [])
+  const pieces: React.ReactNode[] = []
+  pieces.push(React.createElement('div', { key: 'sep-0', 'data-drop-sep': '', 'data-drop-index': 0 }))
+  list.forEach((child, idx) => {
+    pieces.push(child)
+    pieces.push(React.createElement('div', { key: `sep-${idx + 1}`, 'data-drop-sep': '', 'data-drop-index': idx + 1 }))
+  })
+  return React.createElement(
+    as,
+    {
+      'data-slot': slotId,
+      'data-node-id': nodeId ?? slotId,
+    },
+    pieces
+  )
+}
+
 function renderSlot(content: SlotValue): React.ReactNode {
   if (Array.isArray(content)) {
     return (content as ReactNode[]).map((n: ReactNode, i: number) => React.createElement('div', { key: i }, n))
@@ -68,10 +98,10 @@ export const entries: any = {
     slotSchema: [{ name: 'header' }, { name: 'sidebar' }, { name: 'content', required: true }, { name: 'footer' }],
     render: (_p: any, slots: SlotBag, _runtime?: any) => (
       React.createElement(React.Fragment, null,
-        React.createElement('header', null, renderSlot(slots.header)),
-        React.createElement('aside',  null, renderSlot(slots.sidebar)),
-        React.createElement('main',   null, renderSlot(slots.content)),
-        React.createElement('footer', null, renderSlot(slots.footer))
+        React.createElement(SlotContainer, { slotId: 'slot.header', as: 'header' }, renderSlot(slots.header)),
+        React.createElement(SlotContainer, { slotId: 'slot.sidebar', as: 'aside' }, renderSlot(slots.sidebar)),
+        React.createElement(SlotContainer, { slotId: 'slot.content', as: 'main' }, renderSlot(slots.content)),
+        React.createElement(SlotContainer, { slotId: 'slot.footer', as: 'footer' }, renderSlot(slots.footer))
       )
     )
   },
@@ -82,8 +112,8 @@ export const entries: any = {
     slotSchema: [{ name: 'header' }, { name: 'content', required: true }],
     render: (_p: any, slots: SlotBag, _runtime?: any) => (
       React.createElement(React.Fragment, null,
-        React.createElement('header', null, renderSlot(slots.header)),
-        React.createElement('main',   null, renderSlot(slots.content))
+        React.createElement(SlotContainer, { slotId: 'slot.header', as: 'header' }, renderSlot(slots.header)),
+        React.createElement(SlotContainer, { slotId: 'slot.content', as: 'main' }, renderSlot(slots.content))
       )
     )
   },
@@ -94,8 +124,8 @@ export const entries: any = {
     slotSchema: [{ name: 'content', required: true }, { name: 'footer' }],
     render: (_p: any, slots: SlotBag, _runtime?: any) => (
       React.createElement(React.Fragment, null,
-        React.createElement('main',   null, renderSlot(slots.content)),
-        React.createElement('footer', null, renderSlot(slots.footer))
+        React.createElement(SlotContainer, { slotId: 'slot.content', as: 'main' }, renderSlot(slots.content)),
+        React.createElement(SlotContainer, { slotId: 'slot.footer', as: 'footer' }, renderSlot(slots.footer))
       )
     )
   }


### PR DESCRIPTION
## Summary
- introduce SlotContainer helper that wraps frame slots with data-slot/data-node-id attributes and drop separators
- update Frame_* renderers to use SlotContainer so header/sidebar/content/footer emit drop markers
- sync generated dist files with SlotContainer logic for runtime consumers

## Testing
- pnpm -C packages/chizu-registry typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5463a9284832c8520b080fdfd6193