### PR TITLE
feat(builder): add palette drop helpers

### DIFF
--- a/apps/builder/components/canvas/CanvasRoot.tsx
+++ b/apps/builder/components/canvas/CanvasRoot.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import React, { useEffect } from 'react'
+
+import { handleCanvasDrop } from '@/lib/dnd/paletteToCanvas'
+import { callInsertAPI } from '@/lib/bridge/insert'
+import { getComponentDef } from '@/lib/registry/compat'
+import { createNodeFromDef } from '@/lib/nodes/factory.compat'
+
+export function CanvasRoot({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const onDrop = (e: DragEvent) => {
+      e.preventDefault()
+      handleCanvasDrop(e, {
+        getDef: getComponentDef,
+        createNode: createNodeFromDef,
+        callInsert: callInsertAPI,
+      })
+    }
+    const onDragOver = (e: DragEvent) => e.preventDefault()
+    document.addEventListener('drop', onDrop)
+    document.addEventListener('dragover', onDragOver)
+    return () => {
+      document.removeEventListener('drop', onDrop)
+      document.removeEventListener('dragover', onDragOver)
+    }
+  }, [])
+
+  return (
+    <div className="relative w-full h-full" data-actions-enabled="true">
+      {children}
+    </div>
+  )
+}
+
+export default CanvasRoot

--- a/apps/builder/lib/dnd/paletteToCanvas.ts
+++ b/apps/builder/lib/dnd/paletteToCanvas.ts
@@ -1,0 +1,64 @@
+// apps/builder/lib/dnd/paletteToCanvas.ts
+// append-only DnD helpers for palette -> canvas insertion
+
+export const DT_KEY = 'application/x-uib-palette-id';
+
+export function startPaletteDrag(ev: React.DragEvent, compId: string) {
+  ev.dataTransfer?.setData(DT_KEY, compId);
+  if (ev.dataTransfer) ev.dataTransfer.effectAllowed = 'copy';
+}
+
+// Replace this stub if you have a selector; keeps it append-only.
+function currentPageId(): string {
+  return (
+    document.querySelector('[data-page-id]')?.getAttribute('data-page-id') ||
+    'page-root'
+  );
+}
+
+/** Prefer separator to compute exact index; fallback: append to slot */
+export function deriveDropTarget(clientX: number, clientY: number) {
+  const at = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+
+  // 1) precise: separator between children
+  const sep = at?.closest?.('[data-drop-sep="true"]') as HTMLElement | null;
+  if (sep) {
+    const slot = sep.closest('[data-slot]') as HTMLElement | null;
+    const slotId = slot?.getAttribute('data-slot') || 'page.root';
+    const containerNodeId =
+      slot?.getAttribute('data-node-id') || currentPageId();
+    const index = Number(sep.getAttribute('data-child-index')) || 0;
+    return { slotId, containerNodeId, index };
+  }
+
+  // 2) fallback: whole-slot => append
+  const slot = at?.closest?.('[data-slot]') as HTMLElement | null;
+  if (!slot) {
+    return { slotId: 'page.root', containerNodeId: currentPageId(), index: Infinity };
+  }
+  const slotId = slot.getAttribute('data-slot')!;
+  const containerNodeId = slot.getAttribute('data-node-id') || currentPageId();
+  return { slotId, containerNodeId, index: Infinity };
+}
+
+/** High-level drop handler that resolves def -> node -> bridge call */
+export function handleCanvasDrop(
+  ev: DragEvent,
+  deps: {
+    getDef: (id: string) => any;
+    createNode: (def: any, opts: any) => any;
+    callInsert: (parentId: string, index: number, node: any) => void;
+  }
+) {
+  const compId = ev.dataTransfer?.getData(DT_KEY);
+  if (!compId) return;
+  const def = deps.getDef(compId);
+  if (!def) return;
+
+  const { slotId, containerNodeId, index } = deriveDropTarget(ev.clientX, ev.clientY);
+
+  if (def.dropTargets && !def.dropTargets.includes(slotId)) return;
+
+  const node = deps.createNode(def, { slotKey: slotId });
+  deps.callInsert(containerNodeId, index, node);
+}

--- a/apps/builder/lib/nodes/factory.compat.ts
+++ b/apps/builder/lib/nodes/factory.compat.ts
@@ -1,0 +1,37 @@
+// apps/builder/lib/nodes/factory.compat.ts
+import type { ComponentNode, JSONSchema } from '@chizu/types'
+
+function generateNodeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    try {
+      return crypto.randomUUID()
+    } catch {}
+  }
+  return `node-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function extractDefaultProps(schema: JSONSchema | undefined): Record<string, any> {
+  if (!schema || typeof schema !== 'object') return {}
+  const props = schema.properties ?? {}
+  const defaults: Record<string, any> = {}
+  Object.entries(props).forEach(([key, spec]) => {
+    if (spec && typeof spec === 'object' && 'default' in spec && spec.default !== undefined) {
+      defaults[key] = spec.default
+    }
+  })
+  return defaults
+}
+
+export function createNodeFromDef(def: any, _opts?: { slotKey?: string }): ComponentNode {
+  const id = generateNodeId()
+  const type = typeof def?.id === 'string' ? def.id : typeof def?.componentId === 'string' ? def.componentId : 'div'
+  const defaults = extractDefaultProps(def?.propsSchema as JSONSchema | undefined)
+  const props = Object.keys(defaults).length ? defaults : undefined
+
+  return {
+    id,
+    type,
+    props,
+    children: [],
+  }
+}

--- a/apps/builder/lib/registry/compat.ts
+++ b/apps/builder/lib/registry/compat.ts
@@ -1,0 +1,9 @@
+// apps/builder/lib/registry/compat.ts
+import { entries } from '@chizu/registry'
+
+export type PaletteComponentDef = Record<string, any>
+
+export function getComponentDef(id: string): PaletteComponentDef | null {
+  const def = (entries as Record<string, any>)[id]
+  return def ?? null
+}


### PR DESCRIPTION
## Summary
- add palette to canvas drag-and-drop helpers that prefer separator targets when computing indices
- wire the CanvasRoot drop listener to reuse the shared palette drop handler
- add lightweight compat shims for component lookup and node creation used by the drop handler

## Testing
- pnpm --filter builder typecheck *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d549d32600832cbc92e8823d733774