### PR TITLE
Guard palette tab import for browser

### DIFF
--- a/apps/builder/app/lineage.register.tsx
+++ b/apps/builder/app/lineage.register.tsx
@@ -194,7 +194,7 @@ if (typeof window !== 'undefined' && (window as any).registerRightPaneTab) {
 }
 
 // --- append-only: Palette left-pane tab (feature-flagged) ---
-if (ENABLE_PALETTE_V1) {
+if (ENABLE_PALETTE_V1 && typeof window !== 'undefined') {
   void import('@/components/leftpane/PaletteTab')
 }
 


### PR DESCRIPTION
## Summary
- guard the palette tab dynamic import so it only runs when the window object is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54cfa1784832c989a9b41eda9122f