### PR TITLE
Align drop separator attributes

### DIFF
--- a/apps/builder/lib/dnd/paletteToCanvas.ts
+++ b/apps/builder/lib/dnd/paletteToCanvas.ts
@@ -21,13 +21,13 @@ export function deriveDropTarget(clientX: number, clientY: number) {
   const at = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
 
   // 1) precise: separator between children
-  const sep = at?.closest?.('[data-drop-sep="true"]') as HTMLElement | null;
+  const sep = at?.closest?.('[data-drop-sep]') as HTMLElement | null;
   if (sep) {
     const slot = sep.closest('[data-slot]') as HTMLElement | null;
     const slotId = slot?.getAttribute('data-slot') || 'page.root';
     const containerNodeId =
       slot?.getAttribute('data-node-id') || currentPageId();
-    const index = Number(sep.getAttribute('data-child-index')) || 0;
+    const index = Number(sep.getAttribute('data-drop-index')) || 0;
     return { slotId, containerNodeId, index };
   }
 


### PR DESCRIPTION
## Summary
- broaden separator selector to match any data-drop-sep attribute
- read drop index from the aligned data-drop-index attribute

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d54d31c674832c9a737779f46460cd