### PR TITLE
Update canvas drop separator patching

### DIFF
--- a/web/components/CanvasRenderer.tsx
+++ b/web/components/CanvasRenderer.tsx
@@ -32,9 +32,13 @@ function useDropSeparatorHitbox(tree: ComponentNode[], container: React.RefObjec
     if (!root) return;
 
     const apply = (target: ParentNode) => {
-      target.querySelectorAll<HTMLElement>("[data-drop-sep=\"true\"]").forEach((el) => {
+      target.querySelectorAll<HTMLElement>("[data-drop-sep]").forEach((el) => {
         if (el.dataset.dropSepPatched === "true") return;
         el.classList.add(...DROP_SEP_CLASS);
+        const index = el.getAttribute("data-drop-index");
+        if (index !== null) {
+          el.dataset.dropIndex = index;
+        }
         el.dataset.dropSepPatched = "true";
       });
     };

--- a/web/hooks/useTheme.ts
+++ b/web/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { createContext, createElement, useContext, useMemo, type ReactNode } from 'react'
 
 export type ThemeToken = {
   color: string
@@ -28,11 +28,7 @@ export const DomainThemeProvider = ({
 }) => {
   const parent = useContext(DomainThemeContext)
   const merged = useMemo(() => ({ ...parent, ...value }), [parent, value])
-  return (
-    <DomainThemeContext.Provider value={merged}>
-      {children}
-    </DomainThemeContext.Provider>
-  )
+  return createElement(DomainThemeContext.Provider, { value: merged, children })
 }
 
 export const LayoutThemeProvider = ({
@@ -44,11 +40,7 @@ export const LayoutThemeProvider = ({
 }) => {
   const parent = useContext(LayoutThemeContext)
   const merged = useMemo(() => ({ ...parent, ...value }), [parent, value])
-  return (
-    <LayoutThemeContext.Provider value={merged}>
-      {children}
-    </LayoutThemeContext.Provider>
-  )
+  return createElement(LayoutThemeContext.Provider, { value: merged, children })
 }
 
 export function useTheme(overrides?: Partial<ThemeToken>): ThemeToken {


### PR DESCRIPTION
## Summary
- align the canvas drop separator patcher with the new slot container attributes
- expose drop index data attributes for patched separators
- render theme providers without JSX so the module type-checks as .ts

## Testing
- pnpm -C web typecheck *(fails: existing TypeScript errors across the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d54ce3bf38832c8694169d057f3b00