### PR TITLE
Align .gitignore entries for build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 node_modules
 public/component-meta.json
-.next
 web/.generated/
 
-.next/
-dist/
-coverage/
+/.next/
+/dist/
+/coverage/
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- deduplicate the `.next` ignore entries and scope it to the repository root
- ensure the dist and coverage directories are ignored from the repository root

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d54d43f10c832c9de894c4aa0b782c