### PR TITLE
Adjust drop separator hitbox selection

### DIFF
--- a/web/components/CanvasRenderer.tsx
+++ b/web/components/CanvasRenderer.tsx
@@ -32,7 +32,7 @@ function useDropSeparatorHitbox(tree: ComponentNode[], container: React.RefObjec
     if (!root) return;
 
     const apply = (target: ParentNode) => {
-      target.querySelectorAll<HTMLElement>("[data-drop-sep=\"true\"]").forEach((el) => {
+      target.querySelectorAll<HTMLElement>("[data-drop-sep]").forEach((el) => {
         if (el.dataset.dropSepPatched === "true") return;
         el.classList.add(...DROP_SEP_CLASS);
         el.dataset.dropSepPatched = "true";


### PR DESCRIPTION
## Summary
- broaden the drop separator selector so hitbox patching applies when the attribute is present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d54d381658832cbe05a6bb33b32afc