### PR TITLE
fix: use presets registry alias in AutoPropsEditor

### DIFF
--- a/src/AutoPropsEditor.tsx
+++ b/src/AutoPropsEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { useDataSources } from './dataSources'
 import { PropBinding, useEditorState, useEditorActions } from './store'
-import { library as componentMeta } from '../lib/registry'
+import { library as componentMeta } from '@/lib/presets/registry'
 import { t, generateKey, registerKey, getLanguage } from './lib/i18n'
 import AssetPicker, { AssetMeta } from './components/assets/AssetPicker'
 import { groupProps, type PropMeta } from './lib/groupProps'


### PR DESCRIPTION
## Summary
- update the AutoPropsEditor component to import the registry metadata via the builder alias

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbae1e2720832c8dec686fc7481d91