### PR TITLE
Add presets registry metadata loader

### DIFF
--- a/web/lib/presets/registry.ts
+++ b/web/lib/presets/registry.ts
@@ -1,0 +1,21 @@
+import meta from '../../../component-meta.json'
+
+type PropMeta = {
+  name: string
+  type: string
+  required?: boolean
+  description?: string
+  default?: unknown
+  group?: string
+}
+
+type ComponentPresetMeta = {
+  displayName: string
+  description?: string
+  props: PropMeta[]
+}
+
+export const library: ComponentPresetMeta[] = (meta as ComponentPresetMeta[]).map((entry) => ({
+  ...entry,
+  props: Array.isArray(entry.props) ? entry.props : [],
+}))


### PR DESCRIPTION
## Summary
- add web/lib/presets/registry.ts to expose component preset metadata from component-meta.json for AutoPropsEditor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb0227304832ca6f60048a0bbef00